### PR TITLE
fix: stop the stub from accepting five calls the runtime rejects

### DIFF
--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -1,15 +1,15 @@
-from typing import Any
+from typing import Any, Final
 
 from typing_extensions import dataclass_transform
 
 class StructMeta(type):
-    __struct_fields__: tuple[str, ...]
-    __struct_defaults__: tuple[Any, ...]
+    __struct_fields__: Final[tuple[str, ...]]
+    __struct_defaults__: Final[tuple[Any, ...]]
 
 @dataclass_transform(frozen_default=True)
 class Struct(metaclass=StructMeta):
-    __struct_fields__: tuple[str, ...]
-    __struct_defaults__: tuple[Any, ...]
+    __struct_fields__: Final[tuple[str, ...]]
+    __struct_defaults__: Final[tuple[Any, ...]]
     def __init_subclass__(
         cls,
         *,
@@ -21,4 +21,4 @@ class Struct(metaclass=StructMeta):
         weakref: bool = False,
     ) -> None: ...
 
-def set_field(instance: Struct, name: str, value: object) -> None: ...
+def set_field(instance: Struct, name: str, value: object, /) -> None: ...

--- a/tests/typing/rejected.py
+++ b/tests/typing/rejected.py
@@ -87,3 +87,23 @@ def set_field_will_not_take_a_non_struct() -> None:
 
 def set_field_will_not_take_a_name_that_is_not_a_string() -> None:
     set_field(Point(1, "two"), 5, 9)  # type: ignore[arg-type]
+
+
+def set_field_will_not_take_keywords() -> None:
+    set_field(instance=Point(1, "two"), name="x", value=9)  # type: ignore[call-arg]
+
+
+def the_field_names_may_not_be_assigned_on_the_class() -> None:
+    Point.__struct_fields__ = ("z",)  # type: ignore[misc]
+
+
+def the_defaults_may_not_be_assigned_on_the_class() -> None:
+    Point.__struct_defaults__ = (9,)  # type: ignore[misc]
+
+
+def the_field_names_may_not_be_assigned_on_an_instance() -> None:
+    Point(1, "two").__struct_fields__ = ("z",)  # type: ignore[misc]
+
+
+def the_defaults_may_not_be_assigned_on_an_instance() -> None:
+    Point(1, "two").__struct_defaults__ = (9,)  # type: ignore[misc]


### PR DESCRIPTION
Closes #34.

`salix/__init__.pyi` told the checkers that five things were legal. The interpreter refuses all five.

| call | before | after | runtime |
| --- | --- | --- | --- |
| `set_field(instance=x, name="a", value=2)` | accepted | rejected | `TypeError: set_field() takes no keyword arguments` |
| `Point.__struct_fields__ = ("z",)` | accepted | rejected | `AttributeError: attribute '__struct_fields__' of 'salix.StructMeta' objects is not writable` |
| `Point.__struct_defaults__ = (9,)` | accepted | rejected | `AttributeError: ... is not writable` |
| `Point(1, "two").__struct_fields__ = ("z",)` | accepted | rejected | `TypeError: Point object does not support attribute assignment` |
| `Point(1, "two").__struct_defaults__ = (9,)` | accepted | rejected | `TypeError: ... does not support attribute assignment` |

Two edits: a `/` after `value`, and `Final` on the four dunder declarations. Five assertions in `tests/typing/rejected.py`.

### `Final`, not `@property`

The issue proposed `@property` and flagged that both declarations — metaclass and mixin — have to survive. They do not survive it. Measured:

<details>
<summary><b>What <code>@property</code> does to mypy, and why the runtime disagrees with it</b></summary>

With `@property` on both `StructMeta` and `Struct`, `--strict --warn-unused-ignores` on `tests/typing`:

```
tests/typing/accepted.py:62: error: Expression is of type
  "Callable[[Struct], tuple[str, ...]]", not "tuple[str, ...]"  [assert-type]
```

`accepted.py:62` is `assert_type(Point.__struct_fields__, tuple[str, ...])`, and it is right — that expression really is a tuple at runtime. mypy resolves class-level access through `Point.__mro__` and finds the mixin property. Python does not: `StructMeta.__struct_fields__` is a getset, getsets define `tp_descr_set` even with no setter, so it is a **data descriptor on the type of `Point`** and wins over anything in `Point`'s own MRO. pyright and ty both model this and reported nothing; mypy is the outlier.

So `@property` forces a choice between correct inference and read-only enforcement. `Final` needs no choice: mypy, pyright and ty all reject the assignment *and* keep the inference, because `Final` constrains rebinding without changing what the name is.

The issue dismissed `Final` as "bound once, in the class body … a lie about `Struct` subclasses, each of which gets its own value." That is true of the mechanism and irrelevant to the claim: the stub never gives a value, each class gets its own from the metaclass, and the only thing `Final` asserts to a caller is *you may not rebind this* — which is exactly and only what the getsets enforce. It is a weaker claim than the runtime makes, not a different one.

</details>

<details>
<summary><b>Verification</b></summary>

Each row of the table above was run against the built extension before the stub was touched, which is where the error text comes from.

`tests/typing/rejected.py` asserts by inversion — `--warn-unused-ignores` makes an ignore that stops being needed an error — so the five new lines fail if any checker ever starts accepting one of these. `camas check` is green at 25/25, and `type_check` covers mypy, pyright and ty.

</details>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in batches, simplest first; this is batch 1 of 12, and #26 indexes the rest.
