### PR TITLE
fix: two segfaults reachable from ordinary Python

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -2,6 +2,7 @@
 
 #include "compare.h"
 #include "mixin.h"
+#include "owned.h"
 #include "types.h"
 
 /* The tri-state PyObject_RichCompareBool speaks, named. */
@@ -52,6 +53,9 @@ static PyObject * equality_result(PyObject * const self, PyObject * const other,
  * compare in. Both classes have to have asked for ordering, because a class
  * that did not is not orderable, and being compared against one that did does
  * not change that.
+ *
+ * The values are owned rather than borrowed: the equality probe runs arbitrary
+ * Python, which can rebind either slot before the unequal branch reads them.
  */
 static PyObject * ordering_result(PyObject * const self, PyObject * const other, int const op) {
 	StructType const * const self_type = struct_type_of(self);
@@ -71,8 +75,8 @@ static PyObject * ordering_result(PyObject * const self, PyObject * const other,
 	}
 
 	for (Py_ssize_t i = 0; i < self_type->struct_field_count; ++i) {
-		PyObject * const mine = struct_slot_or_none(self_type, self, i);
-		PyObject * const theirs = struct_slot_or_none(other_type, other, i);
+		PY_OWNED(mine, Py_NewRef(struct_slot_or_none(self_type, self, i)));
+		PY_OWNED(theirs, Py_NewRef(struct_slot_or_none(other_type, other, i)));
 		int const equal = PyObject_RichCompareBool(mine, theirs, Py_EQ);
 
 		if (equal == COMPARISON_ERROR) {
@@ -111,6 +115,8 @@ static enum comparison names_equal(
 	);
 }
 
+/* Borrowed slots are sound here and not in ordering_result: the comparison is
+ * the last use of either pointer. */
 static enum comparison values_equal(
 	StructType const * const self_type,
 	PyObject * const self,

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,6 +1,7 @@
 #include <Python.h>
 
 #include "hash.h"
+#include "owned.h"
 #include "types.h"
 
 /* CPython reserves -1: a real hash of -1 is remapped to -2. */
@@ -12,10 +13,13 @@ enum : Py_hash_t {
  * A struct hashes as the tuple of its values, so `hash(p) == hash((1.0, 2.0))`
  * and structs interoperate with tuple keys. Building the tuple is the whole
  * cost; PyObject_Hash does the rest.
+ *
+ * A struct that holds itself re-enters here through tuplehash without pushing
+ * a Python frame, so the interpreter's own depth limit never sees the descent.
  */
 Py_hash_t Struct_hash(PyObject * const self) {
 	StructType const * const type = struct_type_of(self);
-	PyObject * const values = PyTuple_New(type->struct_field_count);
+	PY_OWNED(values, PyTuple_New(type->struct_field_count));
 
 	if (values == NULL) {
 		return HASH_ERR;
@@ -25,8 +29,13 @@ Py_hash_t Struct_hash(PyObject * const self) {
 		PyTuple_SET_ITEM(values, i, Py_NewRef(struct_slot_or_none(type, self, i)));
 	}
 
+	if (Py_EnterRecursiveCall(" while hashing a struct") != 0) {
+		return HASH_ERR;
+	}
+
 	Py_hash_t const hash = PyObject_Hash(values);
-	Py_DECREF(values);
+
+	Py_LeaveRecursiveCall();
 
 	return hash;
 }

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -11,7 +11,7 @@ import weakref
 import pytest
 from values import EVERY, HASHABLE, identify
 
-from salix import Struct
+from salix import Struct, set_field
 
 
 class Plain(Struct):
@@ -169,6 +169,21 @@ class TestOrder:
 
         with pytest.raises(TypeError):
             _ = Holder(object()) < Holder(object())
+
+    def test_a_field_that_rewrites_its_own_slot_mid_comparison(self):
+        class Fickle:
+            def __eq__(self, other):
+                set_field(holder, "x", 0)
+                return False
+
+            def __lt__(self, other):
+                return True
+
+            __hash__ = None
+
+        holder = Ordered(Fickle(), 1)
+
+        assert holder < Ordered(Fickle(), 2)
 
     def test_it_is_inherited(self):
         class Child(Ordered):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from salix import Struct
+from salix import Struct, set_field
 
 
 class Point(Struct):
@@ -70,6 +70,17 @@ def test_equal_structs_share_a_hash_bucket():
 def test_an_unhashable_field_makes_the_struct_unhashable():
     with pytest.raises(TypeError, match="unhashable"):
         hash(Nested([1]))
+
+
+def test_hash_of_a_struct_that_contains_itself():
+    class Node(Struct):
+        child: object = None
+
+    node = Node()
+    set_field(node, "child", node)
+
+    with pytest.raises(RecursionError):
+        hash(node)
 
 
 def test_repr_round_trips_through_eval():


### PR DESCRIPTION
Closes #6. Closes #30.

Two crashes on a stock GIL build, both reproduced at exit 139 before the fix and gone after it.

| | before | after |
| --- | --- | --- |
| `hash(n)` where `n.child is n` | `Segmentation fault` (139) | `RecursionError: Stack overflow (used 8144 kB) while hashing a struct` |
| `<` where a field's `__eq__` rewrites the slot | `Segmentation fault` (139) | `True` |

### #6 — `tp_hash` had no recursion guard

`Struct_hash` builds a tuple and hands it to `PyObject_Hash`; when a value *is* the struct, `tuplehash` comes straight back in. Nothing on that path pushes a Python frame, so the interpreter's depth limit never sees the descent and the C stack goes first. A frozen dataclass survives the same shape only because its `__hash__` is a Python function — the frame push is its guard.

`Py_EnterRecursiveCall` around `PyObject_Hash`, not around the tuple build, which is not where the recursion is.

### #30 — ordering reused borrowed slots across user code

`ordering_result` took two borrowed pointers, ran `PyObject_RichCompareBool` on them, and then read both again on the unequal branch. The probe runs arbitrary Python; that Python can drop the slot. `PY_OWNED` holds both for the length of an iteration — two increments per field, ordering path only.

<details>
<summary><b>The neighbouring paths, checked rather than assumed</b></summary>

`ordering_result` is the only one of four that reuses the pointers:

| function | borrowed slots | runs user code | reuses after | crashes |
| --- | --- | --- | --- | --- |
| `ordering_result` | yes | yes | **yes** | **yes** |
| `values_equal` | yes | yes | no | no |
| `Struct_hash` | yes | no — `Py_NewRef` into the tuple first | n/a | no |
| `field_repr` | yes | yes | no | no |

`values_equal` now carries a comment saying why its borrow is sound, because it is one refactor away from the bug next door.

</details>

<details>
<summary><b>Why the tests assert what they assert</b></summary>

Neither can assert a crash — a segfault takes pytest with it — so each asserts the guarded outcome:

- `test_hash_of_a_struct_that_contains_itself` builds the cycle with `set_field` and expects `RecursionError`. It asserts the type, not the message: 3.12+ reports `Stack overflow (used N kB)` where earlier versions say `maximum recursion depth exceeded`, and this passes on 3.10 through 3.15 plus 3.14t.
- `test_a_field_that_rewrites_its_own_slot_mid_comparison` is the #30 reproducer with an assertion on the answer.

A regression in either takes the test session down rather than failing a case. That is the cost of testing a use-after-free in-process, and it is loud.

`hash.c` also moves its tuple to `PY_OWNED`, which is what removes the second `Py_DECREF` the new early return would otherwise need.

`camas check` green at 25/25 — six interpreters, `clang-tidy`, `gcc -fanalyzer`, and the nix C tests.

</details>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in batches, simplest first; this is batch 2 of 12, and #26 indexes the rest.
