### PR TITLE
chore: give the distribution and the repository their metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# #22 pins the actions by commit SHA, which is the one pin nobody updates by
+# hand. One group, because a pull request per action is noise at this size.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+salix follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Nothing released yet; everything in `main` is the first release.
+
+[Unreleased]: https://github.com/JPHutchins/salix/commits/main/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+## The environment
+
+```sh
+nix develop
+```
+
+That is not a convenience. `clang-tidy`, `gcc -fanalyzer`, `nixfmt` and
+`jphfmt` all come from the dev shell, the shell deliberately carries no Python
+so that `uv` supplies every interpreter the matrix names, and CI installs Nix
+and enters the same shell. A checkout without it can build the extension and
+little else.
+
+## The loop
+
+```sh
+uv run camas check      # the default task
+uv run camas ci         # exactly what CI runs
+```
+
+`camas` is one definition of the task tree shared by this repository and its
+workflows, so `ci` locally is the same tree GitHub runs, not an approximation
+of it. `uv run camas --list` names the rest; the ones you are most likely to
+want alone are `test`, `type_check`, `analyze` and `format`.
+
+`check` is the inner loop: six CPython versions plus free-threaded 3.14, the
+linters, the analyzers and the three type checkers. `ci` adds `nix flake
+check`, which builds the wheels and takes minutes.
+
+Run `uv run camas format` before committing, or `check` will tell you to.
+
+## What the tests are
+
+- `tests/` is pytest, and every supported interpreter runs all of it.
+- `tests/typing/accepted.py` and `tests/typing/rejected.py` are assertions
+  about mypy, pyright and ty rather than about runtime behaviour. `rejected.py`
+  asserts by inversion: each `# type: ignore` is a claim that the checker
+  reports something there, and `--warn-unused-ignores` makes a suppression that
+  stops being needed an error.
+- `README.md` is collected by pytest as doctests, so its examples are run and
+  not proof-read.
+- `src/*.c` carry in-file C tests, built and run by `nix build .#c-tests`.
+
+A fix for a crash needs a test that asserts the guarded outcome — an
+exception, or the right answer — because a segfault takes the test runner with
+it and proves nothing.
+
+## Style
+
+Follow the code already in the file you are editing. The C is formatted by
+`jphfmt` and there is no Python formatter on purpose; `ruff` is configured to
+find defects, not to have opinions about layout.
+
+The C targets C23 and builds with `-Werror -Wall -Wextra -Wdouble-promotion`.
+
+## Commits and pull requests
+
+Conventional prefixes — `feat:`, `fix:`, `build:`, `refactor:`, `style:`,
+`chore:`. The body is where reasoning belongs: what was measured, what was
+tried and rejected, and why. That is context the source cannot carry.
+
+Every pull request is reviewed automatically once CI finishes. The review runs
+from the default branch and comments on the pull request.
+
+Work authored by an LLM agent must say so, in the commit trailer and in
+anything it posts:
+
+```
+Co-Authored-By: <model-id> <noreply@<provider>>
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security
+
+## Reporting
+
+Report a vulnerability privately through GitHub's
+[security advisories](https://github.com/JPHutchins/salix/security/advisories/new).
+Please do not open a public issue for one.
+
+## Scope
+
+salix is a C extension. A crash reachable from ordinary Python — a segfault, a
+use-after-free, a read past the end of a field table — is in scope whether or
+not it is exploitable, because the memory unsafety is the bug and the
+exploitability is a detail. Report it here rather than as an issue if you are
+unsure which it is.
+
+Out of scope: passing deliberately hostile arguments to `ctypes`, to
+`object.__setattr__`, or to anything else that reaches an instance's memory
+without going through the API. `salix/__init__.pyi` is the API.
+
+## Supported versions
+
+Nothing has been released yet. Once it has, fixes land on the latest minor
+version.

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -53,6 +53,13 @@ class Construct(NamedTuple):
     ctor: Callable[[], Callable[[int, int, int], object]]
 
 
+class Row(NamedTuple):
+    label: str
+    dep_ms: float
+    per_type_us: float
+    instantiate_ns: float
+
+
 def _struct(i: int) -> str:
     return f"class C{i}(Struct):\n    a: int\n    b: int\n    c: int\n"
 
@@ -126,8 +133,10 @@ def _record_type_ctor() -> Callable[[int, int, int], object]:
     return C  # type: ignore[no-any-return]
 
 
+# An unbuilt salix/ still holds py.typed and the stub, which makes it a
+# namespace package: find_spec answers, and the module it names is empty.
 def _installed(dep: str | None) -> bool:
-    return dep is None or find_spec(dep) is not None
+    return dep is None or ((spec := find_spec(dep)) is not None and spec.loader is not None)
 
 
 # A rival to measure against, not a requirement: record-type carries a
@@ -203,22 +212,22 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp)
         rows = {
-            c.key: (c.label, dep_ms(c, work), per_type_us(c, work),
-                    instantiate_ns(ctors[c.key]))
+            c.key: Row(c.label, dep_ms(c, work), per_type_us(c, work),
+                       instantiate_ns(ctors[c.key]))
             for c in CONSTRUCTS
         }
 
-    w = max(len(r[0]) for r in rows.values())
+    w = max(len(r.label) for r in rows.values())
     print(f"{'construct':<{w}} {'import ms':>10} {'us/type':>9} {'inst ns':>9}")
     print("-" * (w + 31))
-    for label, dep, us, ns in rows.values():
-        print(f"{label:<{w}} {dep:>10.3f} {us:>9.1f} {ns:>9.1f}")
+    for r in rows.values():
+        print(f"{r.label:<{w}} {r.dep_ms:>10.3f} {r.per_type_us:>9.1f} {r.instantiate_ns:>9.1f}")
 
     print("\nTotal startup to define N struct types = import_ms + N * us/type/1000")
-    def total(r: tuple[str, float, float, float], n: int) -> float:
-        return r[1] + n * r[2] / 1000
+    def total(r: Row, n: int) -> float:
+        return r.dep_ms + n * r.per_type_us / 1000
 
-    headline = [(rows[k][0].split()[0], rows[k]) for k in HEADLINE if k in rows]
+    headline = [(rows[k].label.split()[0], rows[k]) for k in HEADLINE if k in rows]
     for n in (1, 10, 100, 1000):
         print(f"  N={n:<5}  "
               + "   ".join(f"{name} {total(row, n):8.3f} ms" for name, row in headline))

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -25,6 +25,7 @@ import sys
 import tempfile
 import timeit
 from collections.abc import Callable
+from importlib.util import find_spec
 from pathlib import Path
 from typing import NamedTuple
 
@@ -49,6 +50,7 @@ class Construct(NamedTuple):
     dep: str | None   # the dependency library to import (None = no dependency)
     header: str
     body: Callable[[int], str]
+    ctor: Callable[[], Callable[[int, int, int], object]]
 
 
 def _struct(i: int) -> str:
@@ -72,18 +74,83 @@ def _record_type(i: int) -> str:
     return f"@record\ndef C{i}(a: int, b: int, c: int) -> None: ...\n"
 
 
+# The import belongs to the constructor and not to the module, so a construct
+# whose dependency is absent costs nothing to skip.
+def _struct_ctor() -> Callable[[int, int, int], object]:
+    from salix import Struct
+
+    class C(Struct):
+        a: int
+        b: int
+        c: int
+    return C
+
+
+def _msgspec_ctor() -> Callable[[int, int, int], object]:
+    import msgspec
+
+    class C(msgspec.Struct):
+        a: int
+        b: int
+        c: int
+    return C
+
+
+def _namedtuple_ctor() -> Callable[[int, int, int], object]:
+    class C(NamedTuple):
+        a: int
+        b: int
+        c: int
+    return C
+
+
+def _dc_frozen_ctor() -> Callable[[int, int, int], object]:
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True, slots=True)
+    class C:
+        a: int
+        b: int
+        c: int
+    return C
+
+
+def _record_type_ctor() -> Callable[[int, int, int], object]:
+    from records import record  # type: ignore[import-untyped]
+
+    # record reads the return annotation and refuses one that is not None,
+    # so this signature is the decorator's requirement, not an oversight.
+    @record  # type: ignore[untyped-decorator]
+    def C(a: int, b: int, c: int):  # type: ignore[no-untyped-def]
+        ...
+    return C  # type: ignore[no-any-return]
+
+
+def _installed(dep: str | None) -> bool:
+    return dep is None or find_spec(dep) is not None
+
+
+# A rival to measure against, not a requirement: record-type carries a
+# python_version>='3.11' marker and is simply absent below that.
 CONSTRUCTS = [
-    Construct("gen_salix", "salix (this project)", "salix",
-              "from salix import Struct", _struct),
-    Construct("gen_msgspec", "msgspec.Struct", "msgspec",
-              "import msgspec", _msgspec),
-    Construct("gen_namedtuple", "typing.NamedTuple", "typing",
-              "from typing import NamedTuple", _namedtuple),
-    Construct("gen_dcfrozen", "dataclass (frozen+slots)", "dataclasses",
-              "from dataclasses import dataclass", _dc_frozen),
-    Construct("gen_recordtype", "record-type (@record)", "records",
-              "from records import record", _record_type),
+    c
+    for c in (
+        Construct("gen_salix", "salix (this project)", "salix",
+                  "from salix import Struct", _struct, _struct_ctor),
+        Construct("gen_msgspec", "msgspec.Struct", "msgspec",
+                  "import msgspec", _msgspec, _msgspec_ctor),
+        Construct("gen_namedtuple", "typing.NamedTuple", "typing",
+                  "from typing import NamedTuple", _namedtuple, _namedtuple_ctor),
+        Construct("gen_dcfrozen", "dataclass (frozen+slots)", "dataclasses",
+                  "from dataclasses import dataclass", _dc_frozen, _dc_frozen_ctor),
+        Construct("gen_recordtype", "record-type (@record)", "records",
+                  "from records import record", _record_type, _record_type_ctor),
+    )
+    if _installed(c.dep)
 ]
+
+# Which rows the closing summary compares, when they survived the filter.
+HEADLINE = ("gen_salix", "gen_namedtuple", "gen_msgspec")
 
 _LINE = re.compile(r"import time:\s+(\d+)\s+\|\s+(\d+)\s+\|\s+(.*)")
 
@@ -120,51 +187,8 @@ def dep_ms(c: Construct, work: Path) -> float:
 
 def build_constructors() -> dict[str, Callable[[int, int, int], object]]:
     """Real in-process 3-field constructors (avoids exec/PEP-649 quirks)."""
-    out: dict[str, Callable[[int, int, int], object]] = {}
 
-    from salix import Struct
-
-    class RC(Struct):
-        a: int
-        b: int
-        c: int
-    out["gen_salix"] = RC
-
-    import msgspec
-
-    class MS(msgspec.Struct):
-        a: int
-        b: int
-        c: int
-    out["gen_msgspec"] = MS
-
-    from typing import NamedTuple
-
-    class NT(NamedTuple):
-        a: int
-        b: int
-        c: int
-    out["gen_namedtuple"] = NT
-
-    from dataclasses import dataclass
-
-    @dataclass(frozen=True, slots=True)
-    class DC:
-        a: int
-        b: int
-        c: int
-    out["gen_dcfrozen"] = DC
-
-    from records import record  # type: ignore[import-untyped]
-
-    # record reads the return annotation and refuses one that is not None,
-    # so this signature is the decorator's requirement, not an oversight.
-    @record  # type: ignore[untyped-decorator]
-    def RT(a: int, b: int, c: int):  # type: ignore[no-untyped-def]
-        ...
-    out["gen_recordtype"] = RT
-
-    return out
+    return {c.key: c.ctor() for c in CONSTRUCTS}
 
 
 def instantiate_ns(ctor: Callable[[int, int, int], object]) -> float:
@@ -176,29 +200,28 @@ def main() -> None:
     print(f"python {sys.version.split()[0]} | K={K} | median of {RUNS} fresh "
           f"interpreters (warm)\n")
     ctors = build_constructors()
-    rows = []
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp)
-        for c in CONSTRUCTS:
-            rows.append((c.label, dep_ms(c, work), per_type_us(c, work),
-                         instantiate_ns(ctors[c.key])))
+        rows = {
+            c.key: (c.label, dep_ms(c, work), per_type_us(c, work),
+                    instantiate_ns(ctors[c.key]))
+            for c in CONSTRUCTS
+        }
 
-    w = max(len(r[0]) for r in rows)
+    w = max(len(r[0]) for r in rows.values())
     print(f"{'construct':<{w}} {'import ms':>10} {'us/type':>9} {'inst ns':>9}")
     print("-" * (w + 31))
-    for label, dep, us, ns in rows:
+    for label, dep, us, ns in rows.values():
         print(f"{label:<{w}} {dep:>10.3f} {us:>9.1f} {ns:>9.1f}")
 
-    salix_row = rows[0]
-    nt = next(r for r in rows if r[0].startswith("typing.NamedTuple"))
-    ms = next(r for r in rows if r[0].startswith("msgspec"))
     print("\nTotal startup to define N struct types = import_ms + N * us/type/1000")
     def total(r: tuple[str, float, float, float], n: int) -> float:
         return r[1] + n * r[2] / 1000
 
+    headline = [(rows[k][0].split()[0], rows[k]) for k in HEADLINE if k in rows]
     for n in (1, 10, 100, 1000):
-        print(f"  N={n:<5}  salix {total(salix_row, n):8.3f} ms   "
-              f"NamedTuple {total(nt, n):8.3f} ms   msgspec {total(ms, n):8.3f} ms")
+        print(f"  N={n:<5}  "
+              + "   ".join(f"{name} {total(row, n):8.3f} ms" for name, row in headline))
 
 
 if __name__ == "__main__":

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -25,7 +25,6 @@ import sys
 import tempfile
 import timeit
 from collections.abc import Callable
-from importlib.util import find_spec
 from pathlib import Path
 from typing import NamedTuple
 
@@ -47,6 +46,7 @@ _ENV = {**os.environ, "PYTHONPATH": os.pathsep.join(
 class Construct(NamedTuple):
     key: str          # unique module name (must differ from any real library)
     label: str
+    short: str        # the closing summary's column, which has no room for label
     dep: str | None   # the dependency library to import (None = no dependency)
     header: str
     body: Callable[[int], str]
@@ -55,6 +55,7 @@ class Construct(NamedTuple):
 
 class Row(NamedTuple):
     label: str
+    short: str
     dep_ms: float
     per_type_us: float
     instantiate_ns: float
@@ -81,8 +82,9 @@ def _record_type(i: int) -> str:
     return f"@record\ndef C{i}(a: int, b: int, c: int) -> None: ...\n"
 
 
-# The import belongs to the constructor and not to the module, so a construct
-# whose dependency is absent costs nothing to skip.
+# A rival's import belongs to its constructor and not to the module, so a
+# construct that cannot be built costs nothing to skip. typing is not a rival:
+# it is stdlib, and Construct and Row already need it up there.
 def _struct_ctor() -> Callable[[int, int, int], object]:
     from salix import Struct
 
@@ -133,30 +135,20 @@ def _record_type_ctor() -> Callable[[int, int, int], object]:
     return C  # type: ignore[no-any-return]
 
 
-# An unbuilt salix/ still holds py.typed and the stub, which makes it a
-# namespace package: find_spec answers, and the module it names is empty.
-def _installed(dep: str | None) -> bool:
-    return dep is None or ((spec := find_spec(dep)) is not None and spec.loader is not None)
-
-
 # A rival to measure against, not a requirement: record-type carries a
 # python_version>='3.11' marker and is simply absent below that.
-CONSTRUCTS = [
-    c
-    for c in (
-        Construct("gen_salix", "salix (this project)", "salix",
-                  "from salix import Struct", _struct, _struct_ctor),
-        Construct("gen_msgspec", "msgspec.Struct", "msgspec",
-                  "import msgspec", _msgspec, _msgspec_ctor),
-        Construct("gen_namedtuple", "typing.NamedTuple", "typing",
-                  "from typing import NamedTuple", _namedtuple, _namedtuple_ctor),
-        Construct("gen_dcfrozen", "dataclass (frozen+slots)", "dataclasses",
-                  "from dataclasses import dataclass", _dc_frozen, _dc_frozen_ctor),
-        Construct("gen_recordtype", "record-type (@record)", "records",
-                  "from records import record", _record_type, _record_type_ctor),
-    )
-    if _installed(c.dep)
-]
+CONSTRUCTS = (
+    Construct("gen_salix", "salix (this project)", "salix", "salix",
+              "from salix import Struct", _struct, _struct_ctor),
+    Construct("gen_msgspec", "msgspec.Struct", "msgspec", "msgspec",
+              "import msgspec", _msgspec, _msgspec_ctor),
+    Construct("gen_namedtuple", "typing.NamedTuple", "NamedTuple", "typing",
+              "from typing import NamedTuple", _namedtuple, _namedtuple_ctor),
+    Construct("gen_dcfrozen", "dataclass (frozen+slots)", "dataclass", "dataclasses",
+              "from dataclasses import dataclass", _dc_frozen, _dc_frozen_ctor),
+    Construct("gen_recordtype", "record-type (@record)", "record-type", "records",
+              "from records import record", _record_type, _record_type_ctor),
+)
 
 # Which rows the closing summary compares, when they survived the filter.
 HEADLINE = ("gen_salix", "gen_namedtuple", "gen_msgspec")
@@ -194,10 +186,27 @@ def dep_ms(c: Construct, work: Path) -> float:
     return statistics.median(samples) / 1000
 
 
-def build_constructors() -> dict[str, Callable[[int, int, int], object]]:
-    """Real in-process 3-field constructors (avoids exec/PEP-649 quirks)."""
+def _constructor(c: Construct) -> Callable[[int, int, int], object] | None:
+    try:
+        return c.ctor()
+    except ImportError:
+        return None
 
-    return {c.key: c.ctor() for c in CONSTRUCTS}
+
+def build_constructors() -> dict[str, Callable[[int, int, int], object]]:
+    """Real in-process 3-field constructors (avoids exec/PEP-649 quirks).
+
+    Building one is also the availability test, because there is no cheaper
+    question that gives the right answer. find_spec proves a module can be
+    located, which is not that it imports: an unbuilt salix/ holds py.typed and
+    the stub and is a namespace package, and the `records` on PyPI is a SQL
+    library with no `record` in it. A rival that is installed and still broken
+    for some other reason stays loud -- only ImportError means "not here".
+    """
+
+    built = ((c.key, _constructor(c)) for c in CONSTRUCTS)
+
+    return {key: ctor for key, ctor in built if ctor is not None}
 
 
 def instantiate_ns(ctor: Callable[[int, int, int], object]) -> float:
@@ -212,9 +221,10 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp)
         rows = {
-            c.key: Row(c.label, dep_ms(c, work), per_type_us(c, work),
+            c.key: Row(c.label, c.short, dep_ms(c, work), per_type_us(c, work),
                        instantiate_ns(ctors[c.key]))
             for c in CONSTRUCTS
+            if c.key in ctors
         }
 
     w = max(len(r.label) for r in rows.values())
@@ -227,10 +237,10 @@ def main() -> None:
     def total(r: Row, n: int) -> float:
         return r.dep_ms + n * r.per_type_us / 1000
 
-    headline = [(rows[k].label.split()[0], rows[k]) for k in HEADLINE if k in rows]
+    headline = [rows[k] for k in HEADLINE if k in rows]
     for n in (1, 10, 100, 1000):
         print(f"  N={n:<5}  "
-              + "   ".join(f"{name} {total(row, n):8.3f} ms" for name, row in headline))
+              + "   ".join(f"{r.short} {total(r, n):8.3f} ms" for r in headline))
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,43 @@ requires-python = ">=3.10"
 authors = [{ name = "JP Hutchins", email = "jphutchins@gmail.com" }]
 license = "MIT"
 license-files = ["LICENSE"]
+keywords = [
+    "struct",
+    "dataclass",
+    "slots",
+    "frozen",
+    "immutable",
+    "import-time",
+    "free-threading",
+    "c-extension",
+]
+# No "License :: OSI Approved :: MIT License": PyPI rejects a distribution that
+# carries it alongside License-Expression.
+#
+# PyPy and GraalPy satisfy requires-python, find no wheel, and cannot compile
+# this source; the CPython classifier is the declared signal for that.
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: C",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Repository = "https://github.com/JPHutchins/salix"
+Issues = "https://github.com/JPHutchins/salix/issues"
+Changelog = "https://github.com/JPHutchins/salix/blob/main/CHANGELOG.md"
 
 # The C source is wired up in setup.py because setuptools does not yet support
 # declaring ext_modules in pyproject.toml.


### PR DESCRIPTION
Closes #17. Partially addresses #25 — three of its items belong to batches that own those files; see below.

### PyPI metadata (#17)

`METADATA` had no `Classifier`, no `Project-URL` and no `Keywords`. On publication day the page would have carried no link to the source and no statement of which interpreters this supports. Generated from this branch:

```
Project-URL: Repository, https://github.com/JPHutchins/salix
Project-URL: Issues, https://github.com/JPHutchins/salix/issues
Project-URL: Changelog, https://github.com/JPHutchins/salix/blob/main/CHANGELOG.md
Keywords: struct,dataclass,slots,frozen,immutable,import-time,free-threading,c-extension
Classifier: Development Status :: 3 - Alpha
...
Classifier: Programming Language :: Python :: Implementation :: CPython
Classifier: Programming Language :: Python :: Free Threading :: 3 - Stable
Classifier: Typing :: Typed
```

Fifteen classifiers, each checked against the `trove-classifiers` package rather than recalled — an invalid one is rejected at upload, and two here are recent enough to doubt (`3.15`, and the free-threading one).

`Development Status :: 3 - Alpha` is the one judgement call; it is a one-line change if you would rather say Beta.

### Repository files (#25)

`CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `.github/dependabot.yml`, and the `bench/` import fix.

<details>
<summary><b>Why the changelog is a scaffold and not a history</b></summary>

Nothing has been released, so there is no baseline to describe changes against. Reconstructing one commit by commit would produce a document that claims to be a release history and is not. It says that, and says where entries go once there is a version to hang them on. `Project-URL: Changelog` now has a target either way.

</details>

<details>
<summary><b>The bench fix, both directions run</b></summary>

`bench/bench.py:158` imported `records` unconditionally, although `record-type` is declared `python_version>='3.11'` and has no wheel for the newest interpreters. In an environment without it:

```
  File "bench.py", line 158, in build_constructors
    from records import record
ModuleNotFoundError: No module named 'records'
```

— before printing a single row. After, in the same environment, the row simply is not there:

```
construct                 import ms   us/type   inst ns
-------------------------------------------------------
salix (this project)          0.151       8.6      54.2
msgspec.Struct                9.926       9.6      61.2
typing.NamedTuple             1.602      70.6     137.6
dataclass (frozen+slots)      9.918     346.4     232.9
```

and with it installed, all five rows are back. Every row is a rival to measure against, not a requirement, so the filter is general rather than special-cased to `records`.

</details>

<details>
<summary><b>What is left in #25, and why it is not here</b></summary>

| item | where it goes | why |
| --- | --- | --- |
| `-std=c2x` → `-std=c23` | with #32 | Needs every compiler in the matrix to accept the new spelling, the zig-bundled clang included. That is a cross-build question, not a one-word edit. |
| tentative definitions at `src/meta.c:71`, `src/mixin.c:13` | the batch that owns those files | `meta.c` is where PR #27 is, and the struct-identity work touches both. |
| `src/salix.c` stale header comment | with #7 | The same comment carries a second stale claim — the free-threading one, which is #7. Fixing half a comment twice is worse than fixing it once. |

</details>

`camas check` green at 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in batches, simplest first; this is batch 3 of 12, and #26 indexes the rest.
