### PR TITLE
fix: make the release path something that could actually run

### DIFF
--- a/.github/actions/code-review-setup/action.yml
+++ b/.github/actions/code-review-setup/action.yml
@@ -14,8 +14,8 @@ runs:
     # as the runner and cannot take a write lock in that store -- `nix develop` dies with
     # `opening lock file ...-source.lock: Permission denied` on a cache hit.
     #
-    # Pinned by digest, not the @main CI takes: this step runs in the job that holds the model key,
-    # so what it installs has to be a thing that cannot change under us.
+    # Pinned by digest, and CI now pins the same one: this step runs in the job that holds the model
+    # key, so what it installs has to be a thing that cannot change under us.
     - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
     # Digest-pinned for the same reason, so the pin above is not theatre -- both of these run before
     # the agent, in the same job, with the same key in the environment.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Set explicitly: the repository default lives outside this file and can change
+# without a commit.
+permissions:
+  contents: read
+
 jobs:
   # Every wheel for every interpreter, cross-compiled on one runner, which also
   # emits the fan-out for the legs below. The legs are the only other jobs, so
@@ -18,12 +23,12 @@ jobs:
     outputs:
       coverage: ${{ steps.emit.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       # Keyed on what determines the closure. A source-only change misses the
       # key but still restores through the prefix, so the interpreter archives
       # -- the expensive part -- survive and only the compiles re-run.
-      - uses: nix-community/cache-nix-action@v7
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -35,7 +40,7 @@ jobs:
       - run: nix develop --command uv sync --no-install-workspace
       - run: nix develop --command uv run --no-sync camas ci
       - run: nix build .#default --out-link result-wheels
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: wheels
           path: result-wheels/*.whl
@@ -54,9 +59,9 @@ jobs:
       matrix: ${{ fromJSON(needs.wheels.outputs.coverage) }}
     runs-on: ${{ matrix.OS }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: wheels
           path: result-wheels

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,11 @@ jobs:
   # this is what keeps the runner count down.
   wheels:
     runs-on: ubuntu-latest
+    # cache-nix-action purges here, and deleting a cache is a REST call the
+    # workflow-level `contents: read` would leave without a scope.
+    permissions:
+      contents: read
+      actions: write
     outputs:
       coverage: ${{ steps.emit.outputs.matrix }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,29 +7,47 @@ on:
   push:
     tags: ["v*"]
 
+# Two tags are two refs, so grouping by ref would let both publish at once.
+# Never cancelled: a half-finished upload is the state worth avoiding.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    # 50 cross builds is not fast; six hours is still not the number.
+    timeout-minutes: 120
     environment: pypi
     permissions:
+      contents: read
       # Trusted Publishing: PyPI takes a short-lived OIDC token from this
-      # workflow, so there is no API token to hold, rotate or leak.
+      # workflow, so there is no API token to hold, rotate or leak. It is also
+      # why every action below is pinned to a commit: a tag can be moved and a
+      # branch always is, and this is the job that can publish as salix.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: nix-community/cache-nix-action@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5G
 
-      - run: nix develop --command python tools/check_tag.py "${{ github.ref_name }}"
+      - run: nix develop --command uv sync --no-install-workspace
 
-      # The same check CI runs, on the same source: every wheel built and
-      # verified, the payloads matched to their tags, twine --strict over all of
-      # them and the sdist, and the native wheel installed and tested.
-      - run: nix flake check --all-systems
+      # Through env: so the tag reaches the shell as a value, never as text.
+      - env:
+          TAG: ${{ github.ref_name }}
+        run: nix develop --command uv run --no-sync python tools/check_tag.py "$TAG"
+
+      # Invoked, not restated -- restating it is how the old step went stale.
+      # A tag can point at a commit CI never saw, so this cannot be skipped.
+      - run: nix develop --command uv run --no-sync camas ci
 
       - run: nix build .#release --out-link result-release
 
@@ -40,4 +58,4 @@ jobs:
           cp -L result-release/*.whl result-release/*.tar.gz dist/
           ls -l dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,10 @@ on:
   push:
     tags: ["v*"]
 
-# Two tags are two refs, so grouping by ref would let both publish at once.
-# Never cancelled: a half-finished upload is the state worth avoiding.
+# Two tags are two refs, so grouping by ref would let both publish at once. A
+# running release is never cancelled -- a half-finished upload is the state
+# worth avoiding -- but GitHub holds only one run pending per group, so a third
+# tag pushed while one waits replaces it.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,6 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -39,6 +36,9 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5G
+          # Restore-only. Saving is a REST call needing actions: write, which
+          # this job deliberately does not have; CI owns the cache.
+          save: false
 
       - run: nix develop --command uv sync --no-install-workspace
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -2,7 +2,7 @@
 name = "salix-tests"
 version = "0"
 requires-python = ">=3.10"
-dependencies = ["pytest>=9", "hypothesis>=6"]
+dependencies = ["pytest>=9", "hypothesis>=6", "packaging>=24"]
 
 [tool.uv]
 package = false

--- a/tests/test_check_tag.py
+++ b/tests/test_check_tag.py
@@ -102,6 +102,23 @@ def test_the_pattern_accepts_exactly_what_packaging_calls_canonical():
     ] == []
 
 
+@pytest.mark.parametrize("declared", ["1.0", "1", "[\"1.0.0\"]", "true"])
+def test_a_version_that_is_not_a_string_is_refused_with_a_message(declared, tmp_path):
+    (tmp_path / "pyproject.toml").write_text(f"[project]\nversion = {declared}\n")
+
+    result = subprocess.run(
+        [sys.executable, str(CHECK_TAG), "v1.0"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "must be a string" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_no_argument_is_refused(tmp_path):
     result = subprocess.run(
         [sys.executable, str(CHECK_TAG)], cwd=tmp_path, capture_output=True, text=True, check=False

--- a/tests/test_check_tag.py
+++ b/tests/test_check_tag.py
@@ -1,0 +1,69 @@
+"""The release gate, exercised the way the release runs it."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHECK_TAG = Path(__file__).resolve().parent.parent / "tools" / "check_tag.py"
+
+# wheel-smoke copies tests/ into the nix store on its own, and the release
+# invokes the script through `uv run`, which takes 3.14.
+pytestmark = [
+    pytest.mark.skipif(not CHECK_TAG.exists(), reason="tools/ is not beside these tests"),
+    pytest.mark.skipif(sys.version_info < (3, 11), reason="check_tag.py needs tomllib"),
+]
+
+
+def check(tag: str, declared: str, where: Path) -> subprocess.CompletedProcess[str]:
+    (where / "pyproject.toml").write_text(f'[project]\nversion = "{declared}"\n')
+
+    return subprocess.run(
+        [sys.executable, str(CHECK_TAG), tag],
+        cwd=where,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "declared",
+    ["1.0.0", "0.1.0", "1.0", "1", "1.0.0rc1", "1.0.0a1", "1.0.0b2", "1.0.0.post1",
+     "1.0.0.dev0", "1.0.0rc1.post1.dev2", "1!1.0.0", "0.0.0"],
+)
+def test_a_canonical_version_matching_its_tag_passes(declared, tmp_path):
+    assert check(f"v{declared}", declared, tmp_path).returncode == 0
+
+
+@pytest.mark.parametrize(
+    "declared",
+    ["1.0.0-rc1", "1.0.0.rc1", "01.0.0", "1.0.0.RELEASE", "1.0.0-1", "1.0.0.rev1",
+     "1.0.0alpha1", "1.0.0RC1", "0!1.0.0", "1.0.0+local", "", "v1.0.0"],
+)
+def test_a_version_pypi_would_rename_is_refused(declared, tmp_path):
+    result = check(f"v{declared}", declared, tmp_path)
+
+    assert result.returncode != 0
+    assert "canonical PEP 440" in result.stderr
+
+
+def test_a_tag_that_names_another_version_is_refused(tmp_path):
+    result = check("v1.0.1", "1.0.0", tmp_path)
+
+    assert result.returncode != 0
+    assert "v1.0.0" in result.stderr
+
+
+def test_a_tag_without_the_v_is_refused(tmp_path):
+    assert check("1.0.0", "1.0.0", tmp_path).returncode != 0
+
+
+def test_no_argument_is_refused(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(CHECK_TAG)], cwd=tmp_path, capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode != 0
+    assert "usage" in result.stderr

--- a/tests/test_check_tag.py
+++ b/tests/test_check_tag.py
@@ -40,7 +40,8 @@ def test_a_canonical_version_matching_its_tag_passes(declared, tmp_path):
 @pytest.mark.parametrize(
     "declared",
     ["1.0.0-rc1", "1.0.0.rc1", "01.0.0", "1.0.0.RELEASE", "1.0.0-1", "1.0.0.rev1",
-     "1.0.0alpha1", "1.0.0RC1", "0!1.0.0", "1.0.0+local", "", "v1.0.0"],
+     "1.0.0alpha1", "1.0.0RC1", "0!1.0.0", "1.0.0+local", "", "v1.0.0",
+     "1.0.0rc01", "1.0.0.post01", "1.0.0.dev01", "1.0.0.dev2.post1", "1.0.0.post1.rc1"],
 )
 def test_a_version_pypi_would_rename_is_refused(declared, tmp_path):
     result = check(f"v{declared}", declared, tmp_path)
@@ -53,11 +54,52 @@ def test_a_tag_that_names_another_version_is_refused(tmp_path):
     result = check("v1.0.1", "1.0.0", tmp_path)
 
     assert result.returncode != 0
-    assert "v1.0.0" in result.stderr
+    assert "1.0.1" in result.stderr
+    assert "1.0.0" in result.stderr
 
 
 def test_a_tag_without_the_v_is_refused(tmp_path):
     assert check("1.0.0", "1.0.0", tmp_path).returncode != 0
+
+
+def test_the_pattern_accepts_exactly_what_packaging_calls_canonical():
+    """The gate carries a regex instead of importing `packaging`, so that it
+    cannot fail on a dependency at the one moment it matters. This is the
+    price: the equivalence is asserted here rather than assumed.
+    """
+
+    from importlib.util import module_from_spec, spec_from_file_location
+    from itertools import product
+
+    from packaging.version import InvalidVersion, Version
+
+    spec = spec_from_file_location("check_tag", CHECK_TAG)
+    assert spec is not None and spec.loader is not None
+    check_tag = module_from_spec(spec)
+    spec.loader.exec_module(check_tag)
+
+    def packaging_calls_it_canonical(version: str) -> bool:
+        try:
+            return str(Version(version)) == version
+        except InvalidVersion:
+            return False
+
+    generated = (
+        head + pre + post + dev
+        for head, pre, post, dev in product(
+            ["1", "1.0", "1.0.0", "01.0.0", "1.00", "0!1.0", "1!1.0", "v1.0", "", "x"],
+            ["", "a1", "b2", "rc1", "-rc1", ".rc1", "c1", "alpha1", "a01", "RC1"],
+            ["", ".post1", "-1", ".post01", ".rev1", "-post1", ".POST1"],
+            ["", ".dev0", ".dev", "-dev1", ".DEV0"],
+        )
+    )
+
+    assert [
+        version
+        for version in generated
+        if bool(check_tag.CANONICAL_VERSION.fullmatch(version))
+        != packaging_calls_it_canonical(version)
+    ] == []
 
 
 def test_no_argument_is_refused(tmp_path):

--- a/tools/check_tag.py
+++ b/tools/check_tag.py
@@ -9,10 +9,20 @@ them -- caught here, before an upload that cannot be taken back.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
 import tomllib
+
+# PEP 440's canonical form, and nothing else. PyPI accepts `1.0.0-rc1` and
+# publishes `1.0.0rc1`, so comparing a tag against a declared version that is
+# not already normalised is the disagreement this gate exists to catch. Local
+# versions are absent because PyPI refuses them.
+CANONICAL_VERSION = re.compile(
+    r"([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*"
+    r"((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?"
+)
 
 
 def declared_version(pyproject: Path) -> str:
@@ -29,10 +39,16 @@ def main() -> None:
             raise SystemExit("usage: check_tag.py TAG")
 
     declared = declared_version(Path("pyproject.toml"))
-    named = tag.removeprefix("v")
 
-    if named != declared:
-        raise SystemExit(f"tag {tag} names {named}, but pyproject.toml declares {declared}")
+    if CANONICAL_VERSION.fullmatch(declared) is None:
+        raise SystemExit(
+            f"pyproject.toml declares {declared}, which is not a canonical PEP 440 "
+            f"version, so PyPI would publish it under a different string than the "
+            f"tag names. Write the normalised form: 1.0.0rc1, not 1.0.0-rc1."
+        )
+
+    if tag != f"v{declared}":
+        raise SystemExit(f"tag {tag} names something other than v{declared}")
 
     print(f"{tag} matches the declared version {declared}")
 

--- a/tools/check_tag.py
+++ b/tools/check_tag.py
@@ -26,7 +26,12 @@ CANONICAL_VERSION = re.compile(
 
 
 def declared_version(pyproject: Path) -> str:
-    version: str = tomllib.loads(pyproject.read_text())["project"]["version"]
+    version = tomllib.loads(pyproject.read_text())["project"]["version"]
+
+    if not isinstance(version, str):
+        raise SystemExit(
+            f"pyproject.toml declares a {type(version).__name__} version; it must be a string"
+        )
 
     return version
 

--- a/tools/check_tag.py
+++ b/tools/check_tag.py
@@ -48,7 +48,9 @@ def main() -> None:
         )
 
     if tag != f"v{declared}":
-        raise SystemExit(f"tag {tag} names something other than v{declared}")
+        raise SystemExit(
+            f"tag {tag} names {tag.removeprefix('v')}, but pyproject.toml declares {declared}"
+        )
 
     print(f"{tag} matches the declared version {declared}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -440,60 +440,6 @@ wheels = [
 ]
 
 [[package]]
-name = "salix"
-version = "0.0.0"
-source = { virtual = "." }
-
-[package.dev-dependencies]
-dev = [
-    { name = "camas", extra = ["mcp"] },
-    { name = "setuptools" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "camas", extras = ["mcp"], specifier = "==0.1.29" },
-    { name = "setuptools", specifier = ">=77" },
-]
-
-[[package]]
-name = "salix-bench"
-version = "0"
-source = { virtual = "bench" }
-dependencies = [
-    { name = "msgspec" },
-    { name = "record-type", marker = "python_full_version >= '3.11'" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "msgspec", specifier = ">=0.21" },
-    { name = "record-type", marker = "python_full_version >= '3.11'", specifier = ">=2023.1.post1" },
-]
-
-[[package]]
-name = "salix-tests"
-version = "0"
-source = { virtual = "tests" }
-dependencies = [
-    { name = "hypothesis" },
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "hypothesis", specifier = ">=6" },
-    { name = "pytest", specifier = ">=9" },
-]
-
-[[package]]
-name = "salix-tools"
-version = "0"
-source = { virtual = "tools" }
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1138,6 +1084,62 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
+
+[[package]]
+name = "salix"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "camas", extra = ["mcp"] },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "camas", extras = ["mcp"], specifier = "==0.1.29" },
+    { name = "setuptools", specifier = ">=77" },
+]
+
+[[package]]
+name = "salix-bench"
+version = "0"
+source = { virtual = "bench" }
+dependencies = [
+    { name = "msgspec" },
+    { name = "record-type", marker = "python_full_version >= '3.11'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "msgspec", specifier = ">=0.21" },
+    { name = "record-type", marker = "python_full_version >= '3.11'", specifier = ">=2023.1.post1" },
+]
+
+[[package]]
+name = "salix-tests"
+version = "0"
+source = { virtual = "tests" }
+dependencies = [
+    { name = "hypothesis" },
+    { name = "packaging" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hypothesis", specifier = ">=6" },
+    { name = "packaging", specifier = ">=24" },
+    { name = "pytest", specifier = ">=9" },
+]
+
+[[package]]
+name = "salix-tools"
+version = "0"
+source = { virtual = "tools" }
 
 [[package]]
 name = "setuptools"


### PR DESCRIPTION
Closes #16. Closes #22. Closes #35.

The release workflow has never executed — no tags, no runs — and as written it could not have finished. Three things, all in the job that holds `id-token: write`.

### It ran a command that cannot succeed (#16)

Step 4 was `nix flake check --all-systems`, the exact command `d713085` removed from `tasks.py` for being unrunnable on a runner. `--all-systems` does not evaluate the other systems; it builds them, and an x86_64 box cannot build the `aarch64-darwin` check. `release.yaml` predates that fix and was the only file still carrying the flag.

The flag is the symptom. The defect is that this file **restated** a task instead of invoking the one definition, which is how it went stale. It now runs `camas ci`.

<details>
<summary><b>Why <code>camas ci</code> and not <code>camas flake_check</code> — the one judgement call here</b></summary>

The comment above the old step claimed "the same check CI runs". That was wrong twice: the flag, and the five other tasks in `ci` that the release skipped.

`on: push: tags` fires for a tag on **any** commit, including one CI never saw, so the release cannot assume the checks passed somewhere else. And `ci` is `Parallel(flake_check, free_threaded, format_check, lint, analyze, type_check)` where `nix flake check` dominates at ~240s — so making the claim true costs almost nothing in wall-clock.

If you would rather the release trust CI and only build the artifacts, it is a one-word change back to `camas flake_check`.

</details>

### It pulled actions from mutable branches (#22)

`id-token: write` mints the PyPI Trusted Publishing token. The job pulled `nix-installer-action@main` — a branch, so whatever that repo's default points at when the job starts — and `gh-action-pypi-publish@release/v1`, also a branch. `@v7` tags are no better; a tag moves.

Every action is now pinned to a commit SHA resolved through the GitHub API, annotated tag objects dereferenced to their commits, with the version in a trailing comment. `ci.yaml` took the same treatment. `.github/dependabot.yml` is what keeps them current — it is in #40.

Also in this pass: explicit `permissions: contents: read` on `ci.yaml`, which had none; a `concurrency` group on `release.yaml` keyed by workflow rather than ref, because two tags are two refs and would otherwise publish at once; `timeout-minutes`, because the default is six hours; and the tag passed through `env:` so it reaches the shell as a value rather than as interpolated text.

### The version gate compared raw strings (#35)

Measured, old script against new, same synthetic `pyproject.toml`:

| declared | tag | old | new | what PyPI publishes |
| --- | --- | --- | --- | --- |
| `1.0.0` | `v1.0.0` | PASS | PASS | `1.0.0` |
| `1.0.0rc1` | `v1.0.0rc1` | PASS | PASS | `1.0.0rc1` |
| `1.0` | `v1.0` | PASS | PASS | `1.0` |
| `1.0.0-rc1` | `v1.0.0-rc1` | PASS | **refuse** | `1.0.0rc1` — tag names something else |
| `01.0.0` | `v01.0.0` | PASS | **refuse** | `1.0.0` — tag names something else |
| `1.0.0.RELEASE` | `v1.0.0.RELEASE` | PASS | **refuse** | not a version at all |
| `1.0.0+local` | `v1.0.0+local` | PASS | **refuse** | rejected on upload |

The gate exists to catch that disagreement and passed all four of them.

<details>
<summary><b>Canonical form, and why there is no <code>packaging</code> dependency</b></summary>

The rule is now: the declared version must already be in PEP 440 **canonical** form, and the tag must be exactly `v` + that string. That makes the comparison correct rather than usually correct, and rejects an unparseable version on the way — the strictest of the three shapes #35 suggested, and the only one where the tag and the published distribution can never name different things.

Adding `packaging` to a gate whose whole value is that it cannot itself fail is a poor trade, so the canonical form is a regex. It was not written from memory — it was checked against `str(Version(v)) == v` over **4620 generated strings**, every combination of epoch, release, pre, post and dev segment this produces:

```
checked 4620 non-local strings, 0 disagreements: []
```

Local versions (`1.0+ubuntu.1`) are the only place the regex and `packaging` differ, and they are excluded deliberately: PyPI refuses to accept one.

`tests/test_check_tag.py` runs the gate the way the release runs it — subprocess, synthetic `pyproject.toml` — over both tables. It skips below 3.11, because the script reads `pyproject.toml` with `tomllib` and the release invokes it through `uv run`, which takes 3.14, the first interpreter `.python-version` names. That skip is itself a finding: the previous arrangement would have silently depended on whichever `python` the runner's `PATH` happened to expose inside `nix develop`.

</details>

Verified that `.#release` still evaluates (`salix-release`) and that all four workflow files parse. `camas check` green at 25/25.

This unblocks #1, which is the remaining half of publishing and only @JPHutchins can do: set the version, and register the Trusted Publisher on PyPI.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in batches, simplest first; this is batch 4 of 12, and #26 indexes the rest.
