### PR TITLE
fix: three bugs in class creation

### DIFF
--- a/src/fields.c
+++ b/src/fields.c
@@ -165,19 +165,22 @@ static enum result append_declared(
 	return RESULT_OK;
 }
 
+/* PyObject_RichCompareBool answers -1 for an error and nothing else, so the
+ * three cases are the return value itself -- no PyErr_Occurred() to tell a
+ * failure apart from a "less than", and so no invariant about the exception
+ * state on entry. The same tri-state compare.c reads into `enum comparison`. */
 static enum inheritance inherits_field(StructType const * const base, PyObject * const field_name) {
 	Py_ssize_t const inherited_count = base != NULL ? base->struct_field_count : 0;
 
 	for (Py_ssize_t i = 0; i < inherited_count; ++i) {
-		int const compared =
-			PyUnicode_Compare(field_name, PyTuple_GET_ITEM(base->struct_field_names, i));
+		enum inheritance const inherited = PyObject_RichCompareBool(
+			field_name,
+			PyTuple_GET_ITEM(base->struct_field_names, i),
+			Py_EQ
+		);
 
-		if (compared == 0) {
-			return INHERITANCE_INHERITED;
-		}
-
-		if (compared == -1 && PyErr_Occurred()) {
-			return INHERITANCE_ERROR;
+		if (inherited != INHERITANCE_NEW) {
+			return inherited;
 		}
 	}
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -7,6 +7,12 @@
 #include "result.h"
 #include "types.h"
 
+enum inheritance : int {
+	INHERITANCE_ERROR = -1,
+	INHERITANCE_NEW = 0,
+	INHERITANCE_INHERITED = 1,
+};
+
 static enum result append_inherited(
 	StructType const * base,
 	PyObject * all_names,
@@ -22,7 +28,7 @@ static enum result append_declared(
 );
 static PyObject * build_defaults(PyObject * all_names, PyObject * default_by_name);
 static PyObject * checked_annotations(PyObject * namespace);
-static bool inherits_field(StructType const * base, PyObject * field_name);
+static enum inheritance inherits_field(StructType const * base, PyObject * field_name);
 
 /* The plan only takes references once every step has succeeded; the working
  * collections belong to this scope either way. */
@@ -142,8 +148,13 @@ static enum result append_declared(
 
 		/* Skip if this name was already inherited (override of annotation, not
 		 * a new slot). */
-		if (inherits_field(base, field_name)) {
-			continue;
+		switch (inherits_field(base, field_name)) {
+			case INHERITANCE_ERROR:
+				return RESULT_ERROR;
+			case INHERITANCE_INHERITED:
+				continue;
+			case INHERITANCE_NEW:
+				break;
 		}
 
 		if (PyList_Append(all_names, field_name) < 0 || PyList_Append(new_names, field_name) < 0) {
@@ -154,16 +165,23 @@ static enum result append_declared(
 	return RESULT_OK;
 }
 
-static bool inherits_field(StructType const * const base, PyObject * const field_name) {
+static enum inheritance inherits_field(StructType const * const base, PyObject * const field_name) {
 	Py_ssize_t const inherited_count = base != NULL ? base->struct_field_count : 0;
 
 	for (Py_ssize_t i = 0; i < inherited_count; ++i) {
-		if (PyUnicode_Compare(field_name, PyTuple_GET_ITEM(base->struct_field_names, i)) == 0) {
-			return true;
+		int const compared =
+			PyUnicode_Compare(field_name, PyTuple_GET_ITEM(base->struct_field_names, i));
+
+		if (compared == 0) {
+			return INHERITANCE_INHERITED;
+		}
+
+		if (compared == -1 && PyErr_Occurred()) {
+			return INHERITANCE_ERROR;
 		}
 	}
 
-	return false;
+	return INHERITANCE_NEW;
 }
 
 /* Build the defaults tuple as the trailing run of defaulted fields, and

--- a/src/meta.c
+++ b/src/meta.c
@@ -28,14 +28,15 @@ static void StructMeta_dealloc(PyObject * self);
 
 static StructType * find_struct_base(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
-static bool inherits_body_eq(StructType const * base);
+static struct options base_options(StructType const * base);
 static PyObject * build_class_namespace(
 	PyObject * original_namespace,
 	PyObject * all_names,
 	PyObject * new_names,
 	struct options options,
-	struct options inherited,
-	StructType const * base
+	StructType const * base,
+	bool body_defines_eq,
+	bool inherits_body_eq
 );
 static PyObject * build_slots(PyObject * new_names, bool weakref);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
@@ -43,15 +44,15 @@ static enum result apply_options(
 	PyObject * namespace,
 	struct options options,
 	struct options inherited,
-	bool base_defines_eq
+	bool body_defines_eq,
+	bool inherits_body_eq
 );
 static enum result rebind(PyObject * namespace, char const * const * names, bool from_mixin);
 static enum result bind_hash(
 	PyObject * namespace,
 	struct options options,
-	struct options inherited,
 	bool body_defines_eq,
-	bool base_defines_eq
+	bool inherits_body_eq
 );
 static enum result drop_class_variables(PyObject * namespace, PyObject * all_names);
 static StructType * create_class(
@@ -64,7 +65,8 @@ static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
 	struct field_plan const * plan,
-	struct options options
+	struct options options,
+	bool resolves_body_eq
 );
 static enum result install_post_init(StructType * struct_class);
 static bool defines_own_init(StructType const * struct_class);
@@ -160,7 +162,7 @@ PyObject * StructMeta_new(
 	}
 
 	StructType const * const base = find_struct_base(bases);
-	struct options const inherited = base != NULL ? base->struct_options : options_initial();
+	struct options const inherited = base_options(base);
 	struct options_request const request =
 		options_read(keywords, inherited, base != NULL && base->struct_field_count > 0);
 
@@ -174,6 +176,16 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
+	/* Read before build_class_namespace rebinds anything: afterwards every
+	 * comparison name is present whether the body wrote one or salix did. An
+	 * inherited one survives only if this body leaves equality alone. */
+	bool const body_defines_eq = PyDict_GetItemString(original_namespace, "__eq__") != NULL;
+	bool const inherits_body_eq = (
+		base != NULL &&
+		base->struct_resolves_body_eq &&
+		request.options.eq == inherited.eq
+	);
+
 	PY_OWNED(
 		namespace,
 		build_class_namespace(
@@ -181,8 +193,9 @@ PyObject * StructMeta_new(
 			plan.all_names,
 			plan.new_names,
 			request.options,
-			inherited,
-			base
+			base,
+			body_defines_eq,
+			inherits_body_eq
 		)
 	);
 	StructType * struct_class = (
@@ -192,7 +205,14 @@ PyObject * StructMeta_new(
 
 	if (
 		struct_class != NULL &&
-		install_fields(struct_class, base, &plan, request.options) != RESULT_OK
+		install_fields(
+				struct_class,
+				base,
+				&plan,
+				request.options,
+				body_defines_eq || inherits_body_eq
+			) !=
+			RESULT_OK
 	) {
 		Py_CLEAR(struct_class);
 	}
@@ -216,57 +236,30 @@ static StructType * find_struct_base(PyObject * const bases) {
 	return NULL;
 }
 
+/* What a subclass starts from: the base's options, or the defaults when there
+ * is no struct base to inherit from. */
+static struct options base_options(StructType const * const base) {
+	return base != NULL ? base->struct_options : options_initial();
+}
+
 /* CPython refuses a second __weakref__ in a subclass, so an inherited one is
  * what `weakref=True` already got. */
 static bool has_weakref_slot(StructType const * const base) {
 	return base != NULL && base->heap_type.ht_type.tp_weaklistoffset != 0;
 }
 
-/*
- * Whether this class will resolve an __eq__ that salix did not bind. salix
- * binds the mixin's or object's, so anything else came from a class body, and
- * Python's rule -- a body defining __eq__ and not __hash__ is unhashable --
- * reaches a subclass through the MRO even though its own body has neither.
- *
- * An unhashable tp_hash is the cheap gate, not the answer: a base is also
- * unhashable for being mutable with structural equality, and that reason does
- * not survive into a child that freezes itself, which a fieldless base permits.
- * The gate keeps the lookups off the common path, class creation being the
- * number this project is careful about; none of the three can fail, since
- * every type answers __eq__.
- */
-static bool inherits_body_eq(StructType const * const base) {
-	if (base == NULL || base->heap_type.ht_type.tp_hash != PyObject_HashNotImplemented) {
-		return false;
-	}
-
-	PY_OWNED(inherited_eq, PyObject_GetAttrString((PyObject *) base, "__eq__"));
-	PY_OWNED(mixin_eq, PyObject_GetAttrString((PyObject *) &StructMixin_Type, "__eq__"));
-	PY_OWNED(object_eq, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__eq__"));
-
-	/* Unreachable, and answered in the safe direction anyway: a class wrongly
-	 * left unhashable says so the first time anyone hashes it, where one wrongly
-	 * given a hash puts two equal instances in two slots of a set and says
-	 * nothing. */
-	if (inherited_eq == NULL || mixin_eq == NULL || object_eq == NULL) {
-		PyErr_Clear();
-
-		return true;
-	}
-
-	return inherited_eq != mixin_eq && inherited_eq != object_eq;
-}
-
-/* The namespace handed to type.__new__: a copy of the original with the
- * default-bearing field names removed (so __slots__ won't clash with a class
- * variable) plus __slots__ / __match_args__ and whatever the options replace. */
+/* The namespace handed to type.__new__: a copy of the original with every
+ * class-body binding of a field name removed (so none of them clashes with the
+ * __slots__ descriptor that reads the value) plus __slots__ / __match_args__
+ * and whatever the options replace. */
 static PyObject * build_class_namespace(
 	PyObject * const original_namespace,
 	PyObject * const all_names,
 	PyObject * const new_names,
 	struct options const options,
-	struct options const inherited,
-	StructType const * const base
+	StructType const * const base,
+	bool const body_defines_eq,
+	bool const inherits_body_eq
 ) {
 	PY_OWNED(slots, build_slots(new_names, options.weakref && !has_weakref_slot(base)));
 	PY_MOVABLE(namespace, PyDict_Copy(original_namespace));
@@ -277,7 +270,14 @@ static PyObject * build_class_namespace(
 		drop_class_variables(namespace, all_names) == RESULT_OK &&
 		PyDict_SetItemString(namespace, "__slots__", slots) == 0 &&
 		set_match_args(namespace, all_names, options.match_args) == RESULT_OK &&
-		apply_options(namespace, options, inherited, inherits_body_eq(base)) == RESULT_OK
+		apply_options(
+				namespace,
+				options,
+				base_options(base),
+				body_defines_eq,
+				inherits_body_eq
+			) ==
+			RESULT_OK
 	) {
 		return py_move(&namespace);
 	}
@@ -343,12 +343,9 @@ static enum result apply_options(
 	PyObject * const namespace,
 	struct options const options,
 	struct options const inherited,
-	bool const base_defines_eq
+	bool const body_defines_eq,
+	bool const inherits_body_eq
 ) {
-	/* Read before the rebinds below: afterwards every comparison name is
-	 * present whether the body wrote one or salix did. */
-	bool const body_defines_eq = PyDict_GetItemString(namespace, "__eq__") != NULL;
-
 	/* All six, not just __eq__: they share tp_richcompare, and a class that
 	 * rebinds only some of them gets the dispatching slot with the other source
 	 * still answering the rest. */
@@ -382,7 +379,7 @@ static enum result apply_options(
 		return RESULT_ERROR;
 	}
 
-	return bind_hash(namespace, options, inherited, body_defines_eq, base_defines_eq);
+	return bind_hash(namespace, options, body_defines_eq, inherits_body_eq);
 }
 
 /* A name the class body defined is neither source's to take. */
@@ -421,23 +418,23 @@ static enum result rebind(
 static enum result bind_hash(
 	PyObject * const namespace,
 	struct options const options,
-	struct options const inherited,
 	bool const body_defines_eq,
-	bool const base_defines_eq
+	bool const inherits_body_eq
 ) {
 	if (PyDict_GetItemString(namespace, "__hash__") != NULL) {
 		return RESULT_OK;
 	}
 
-	/* Python's rule: a body that defines __eq__ and not __hash__ is unhashable.
-	 * An inherited body __eq__ carries the same debt to a subclass whose own
-	 * body has neither -- and only taking equality back, by writing __eq__ or
-	 * by changing the eq option, replaces what the MRO would resolve. */
-	if (
-		body_defines_eq ||
-		(options.eq && !options.frozen) ||
-		(base_defines_eq && options.eq == inherited.eq)
-	) {
+	/* An __eq__ that came from a class body is not salix's to answer for, and
+	 * neither is the hash beside it: whatever the MRO carries -- None from
+	 * Python's own rule, or a __hash__ that same body wrote -- is already
+	 * right, and binding one here would replace it. */
+	if (inherits_body_eq) {
+		return RESULT_OK;
+	}
+
+	/* Python's rule: a body that defines __eq__ and not __hash__ is unhashable. */
+	if (body_defines_eq || (options.eq && !options.frozen)) {
 		return PyDict_SetItemString(namespace, "__hash__", Py_None) == 0 ? RESULT_OK : RESULT_ERROR;
 	}
 
@@ -482,7 +479,8 @@ static enum result install_fields(
 	StructType * const struct_class,
 	StructType const * const base,
 	struct field_plan const * const plan,
-	struct options const options
+	struct options const options,
+	bool const resolves_body_eq
 ) {
 	PY_MOVABLE(field_names, PyList_AsTuple(plan->all_names));
 
@@ -504,6 +502,7 @@ static enum result install_fields(
 	struct_class->struct_field_count = field_count;
 	struct_class->struct_default_count = PyTuple_GET_SIZE(plan->defaults);
 	struct_class->struct_options = options;
+	struct_class->struct_resolves_body_eq = resolves_body_eq;
 
 	/* The mixin has no tp_new, because nothing ever needed one: the vectorcall
 	 * allocates. A class that declined it needs the generic one to get as far

--- a/src/meta.c
+++ b/src/meta.c
@@ -244,10 +244,14 @@ static bool inherits_body_eq(StructType const * const base) {
 	PY_OWNED(mixin_eq, PyObject_GetAttrString((PyObject *) &StructMixin_Type, "__eq__"));
 	PY_OWNED(object_eq, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__eq__"));
 
+	/* Unreachable, and answered in the safe direction anyway: a class wrongly
+	 * left unhashable says so the first time anyone hashes it, where one wrongly
+	 * given a hash puts two equal instances in two slots of a set and says
+	 * nothing. */
 	if (inherited_eq == NULL || mixin_eq == NULL || object_eq == NULL) {
 		PyErr_Clear();
 
-		return false;
+		return true;
 	}
 
 	return inherited_eq != mixin_eq && inherited_eq != object_eq;
@@ -442,8 +446,9 @@ static enum result bind_hash(
 	return rebind(namespace, hash_name, options.eq);
 }
 
-/* A field with a default is bound in the class body, where it would collide
- * with the __slots__ descriptor of the same name. */
+/* Any class-body binding of a field name -- an annotated default, or a bare
+ * assignment over a name the base already declared -- would sit in this class's
+ * dict ahead of the __slots__ descriptor that reads the value. */
 static enum result drop_class_variables(PyObject * const namespace, PyObject * const all_names) {
 	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(all_names); ++i) {
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);

--- a/src/meta.c
+++ b/src/meta.c
@@ -28,23 +28,31 @@ static void StructMeta_dealloc(PyObject * self);
 
 static StructType * find_struct_base(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
+static bool inherits_body_eq(StructType const * base);
 static PyObject * build_class_namespace(
 	PyObject * original_namespace,
 	PyObject * all_names,
 	PyObject * new_names,
 	struct options options,
 	struct options inherited,
-	bool base_has_weakref
+	StructType const * base
 );
 static PyObject * build_slots(PyObject * new_names, bool weakref);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
 	PyObject * namespace,
 	struct options options,
-	struct options inherited
+	struct options inherited,
+	bool base_defines_eq
 );
 static enum result rebind(PyObject * namespace, char const * const * names, bool from_mixin);
-static enum result bind_hash(PyObject * namespace, struct options options, bool body_defines_eq);
+static enum result bind_hash(
+	PyObject * namespace,
+	struct options options,
+	struct options inherited,
+	bool body_defines_eq,
+	bool base_defines_eq
+);
 static enum result drop_class_variables(PyObject * namespace, PyObject * all_names);
 static StructType * create_class(
 	PyTypeObject * metatype,
@@ -174,7 +182,7 @@ PyObject * StructMeta_new(
 			plan.new_names,
 			request.options,
 			inherited,
-			has_weakref_slot(base)
+			base
 		)
 	);
 	StructType * struct_class = (
@@ -214,6 +222,37 @@ static bool has_weakref_slot(StructType const * const base) {
 	return base != NULL && base->heap_type.ht_type.tp_weaklistoffset != 0;
 }
 
+/*
+ * Whether this class will resolve an __eq__ that salix did not bind. salix
+ * binds the mixin's or object's, so anything else came from a class body, and
+ * Python's rule -- a body defining __eq__ and not __hash__ is unhashable --
+ * reaches a subclass through the MRO even though its own body has neither.
+ *
+ * An unhashable tp_hash is the cheap gate, not the answer: a base is also
+ * unhashable for being mutable with structural equality, and that reason does
+ * not survive into a child that freezes itself, which a fieldless base permits.
+ * The gate keeps the lookups off the common path, class creation being the
+ * number this project is careful about; none of the three can fail, since
+ * every type answers __eq__.
+ */
+static bool inherits_body_eq(StructType const * const base) {
+	if (base == NULL || base->heap_type.ht_type.tp_hash != PyObject_HashNotImplemented) {
+		return false;
+	}
+
+	PY_OWNED(inherited_eq, PyObject_GetAttrString((PyObject *) base, "__eq__"));
+	PY_OWNED(mixin_eq, PyObject_GetAttrString((PyObject *) &StructMixin_Type, "__eq__"));
+	PY_OWNED(object_eq, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__eq__"));
+
+	if (inherited_eq == NULL || mixin_eq == NULL || object_eq == NULL) {
+		PyErr_Clear();
+
+		return false;
+	}
+
+	return inherited_eq != mixin_eq && inherited_eq != object_eq;
+}
+
 /* The namespace handed to type.__new__: a copy of the original with the
  * default-bearing field names removed (so __slots__ won't clash with a class
  * variable) plus __slots__ / __match_args__ and whatever the options replace. */
@@ -223,9 +262,9 @@ static PyObject * build_class_namespace(
 	PyObject * const new_names,
 	struct options const options,
 	struct options const inherited,
-	bool const base_has_weakref
+	StructType const * const base
 ) {
-	PY_OWNED(slots, build_slots(new_names, options.weakref && !base_has_weakref));
+	PY_OWNED(slots, build_slots(new_names, options.weakref && !has_weakref_slot(base)));
 	PY_MOVABLE(namespace, PyDict_Copy(original_namespace));
 
 	if (
@@ -234,7 +273,7 @@ static PyObject * build_class_namespace(
 		drop_class_variables(namespace, all_names) == RESULT_OK &&
 		PyDict_SetItemString(namespace, "__slots__", slots) == 0 &&
 		set_match_args(namespace, all_names, options.match_args) == RESULT_OK &&
-		apply_options(namespace, options, inherited) == RESULT_OK
+		apply_options(namespace, options, inherited, inherits_body_eq(base)) == RESULT_OK
 	) {
 		return py_move(&namespace);
 	}
@@ -299,7 +338,8 @@ static enum result set_match_args(
 static enum result apply_options(
 	PyObject * const namespace,
 	struct options const options,
-	struct options const inherited
+	struct options const inherited,
+	bool const base_defines_eq
 ) {
 	/* Read before the rebinds below: afterwards every comparison name is
 	 * present whether the body wrote one or salix did. */
@@ -338,7 +378,7 @@ static enum result apply_options(
 		return RESULT_ERROR;
 	}
 
-	return bind_hash(namespace, options, body_defines_eq);
+	return bind_hash(namespace, options, inherited, body_defines_eq, base_defines_eq);
 }
 
 /* A name the class body defined is neither source's to take. */
@@ -377,14 +417,23 @@ static enum result rebind(
 static enum result bind_hash(
 	PyObject * const namespace,
 	struct options const options,
-	bool const body_defines_eq
+	struct options const inherited,
+	bool const body_defines_eq,
+	bool const base_defines_eq
 ) {
 	if (PyDict_GetItemString(namespace, "__hash__") != NULL) {
 		return RESULT_OK;
 	}
 
-	/* Python's rule: a body that defines __eq__ and not __hash__ is unhashable. */
-	if (body_defines_eq || (options.eq && !options.frozen)) {
+	/* Python's rule: a body that defines __eq__ and not __hash__ is unhashable.
+	 * An inherited body __eq__ carries the same debt to a subclass whose own
+	 * body has neither -- and only taking equality back, by writing __eq__ or
+	 * by changing the eq option, replaces what the MRO would resolve. */
+	if (
+		body_defines_eq ||
+		(options.eq && !options.frozen) ||
+		(base_defines_eq && options.eq == inherited.eq)
+	) {
 		return PyDict_SetItemString(namespace, "__hash__", Py_None) == 0 ? RESULT_OK : RESULT_ERROR;
 	}
 

--- a/src/meta.c
+++ b/src/meta.c
@@ -44,8 +44,8 @@ static enum result apply_options(
 	struct options inherited
 );
 static enum result rebind(PyObject * namespace, char const * const * names, bool from_mixin);
-static enum result bind_hash(PyObject * namespace, struct options options);
-static enum result drop_class_variables(PyObject * namespace, PyObject * new_names);
+static enum result bind_hash(PyObject * namespace, struct options options, bool body_defines_eq);
+static enum result drop_class_variables(PyObject * namespace, PyObject * all_names);
 static StructType * create_class(
 	PyTypeObject * metatype,
 	PyObject * name,
@@ -231,7 +231,7 @@ static PyObject * build_class_namespace(
 	if (
 		slots != NULL &&
 		namespace != NULL &&
-		drop_class_variables(namespace, new_names) == RESULT_OK &&
+		drop_class_variables(namespace, all_names) == RESULT_OK &&
 		PyDict_SetItemString(namespace, "__slots__", slots) == 0 &&
 		set_match_args(namespace, all_names, options.match_args) == RESULT_OK &&
 		apply_options(namespace, options, inherited) == RESULT_OK
@@ -301,6 +301,10 @@ static enum result apply_options(
 	struct options const options,
 	struct options const inherited
 ) {
+	/* Read before the rebinds below: afterwards every comparison name is
+	 * present whether the body wrote one or salix did. */
+	bool const body_defines_eq = PyDict_GetItemString(namespace, "__eq__") != NULL;
+
 	/* All six, not just __eq__: they share tp_richcompare, and a class that
 	 * rebinds only some of them gets the dispatching slot with the other source
 	 * still answering the rest. */
@@ -334,7 +338,7 @@ static enum result apply_options(
 		return RESULT_ERROR;
 	}
 
-	return bind_hash(namespace, options);
+	return bind_hash(namespace, options, body_defines_eq);
 }
 
 /* A name the class body defined is neither source's to take. */
@@ -370,12 +374,17 @@ static enum result rebind(
  * can still move -- a key whose hash moves is not a key. Settled outright
  * rather than on a transition, because it is the one name two options answer.
  */
-static enum result bind_hash(PyObject * const namespace, struct options const options) {
+static enum result bind_hash(
+	PyObject * const namespace,
+	struct options const options,
+	bool const body_defines_eq
+) {
 	if (PyDict_GetItemString(namespace, "__hash__") != NULL) {
 		return RESULT_OK;
 	}
 
-	if (options.eq && !options.frozen) {
+	/* Python's rule: a body that defines __eq__ and not __hash__ is unhashable. */
+	if (body_defines_eq || (options.eq && !options.frozen)) {
 		return PyDict_SetItemString(namespace, "__hash__", Py_None) == 0 ? RESULT_OK : RESULT_ERROR;
 	}
 
@@ -386,14 +395,12 @@ static enum result bind_hash(PyObject * const namespace, struct options const op
 
 /* A field with a default is bound in the class body, where it would collide
  * with the __slots__ descriptor of the same name. */
-static enum result drop_class_variables(PyObject * const namespace, PyObject * const new_names) {
-	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(new_names); ++i) {
-		PyObject * const field_name = PyList_GET_ITEM(new_names, i);
+static enum result drop_class_variables(PyObject * const namespace, PyObject * const all_names) {
+	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(all_names); ++i) {
+		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
+		int const present = PyDict_Contains(namespace, field_name);
 
-		if (
-			PyDict_Contains(namespace, field_name) == 1 &&
-			PyDict_DelItem(namespace, field_name) < 0
-		) {
+		if (present < 0 || (present == 1 && PyDict_DelItem(namespace, field_name) < 0)) {
 			return RESULT_ERROR;
 		}
 	}

--- a/src/types.h
+++ b/src/types.h
@@ -32,6 +32,12 @@ typedef struct {
 
 	/* What the class body asked for, and what a subclass inherits */
 	struct options struct_options;
+
+	/* Whether this class resolves an __eq__ that came from a class body rather
+	 * than from salix. Answered once, here, because a subclass needs it and
+	 * cannot re-derive it: `__hash__ is None` on the base does not say which
+	 * rule put it there. */
+	bool struct_resolves_body_eq;
 } StructType;
 
 static inline StructType * struct_type_of(PyObject * const self) {

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -56,6 +56,21 @@ def test_a_redefaulted_inherited_field_is_not_shadowed_by_its_class_variable():
     assert repr(instance) == "Defaulted(x=1, y=9)"
 
 
+def test_a_bare_binding_over_an_inherited_field_is_not_shadowed_either():
+    """The same shadowing, reached without re-annotating: a class variable whose
+    name is already a field would otherwise sit ahead of the base's descriptor
+    in the MRO, and attribute access alone would disagree with everything else.
+    """
+
+    class Bound(Base):
+        y = 42
+
+    instance = Bound(1, 9)
+
+    assert instance.y == 9
+    assert repr(instance) == "Bound(x=1, y=9)"
+
+
 def test_a_required_field_may_not_follow_a_defaulted_one():
     with pytest.raises(TypeError, match="non-default field 'b' follows a field with a default"):
 

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -46,6 +46,16 @@ def test_a_subclass_may_give_an_inherited_field_a_default():
     assert Defaulted(1).__struct_fields__ == ("x", "y")
 
 
+def test_a_redefaulted_inherited_field_is_not_shadowed_by_its_class_variable():
+    class Defaulted(Base):
+        y: int = 5
+
+    instance = Defaulted(1, 9)
+
+    assert instance.y == 9
+    assert repr(instance) == "Defaulted(x=1, y=9)"
+
+
 def test_a_required_field_may_not_follow_a_defaulted_one():
     with pytest.raises(TypeError, match="non-default field 'b' follows a field with a default"):
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -103,6 +103,18 @@ class TestEq:
         assert Child(1) == Child(1)
         assert hash(Child(1)) == hash((1, 0))
 
+    def test_a_body_eq_clears_the_hash_the_way_python_does(self):
+        class Custom(Struct):  # noqa: PLW1641 -- the absent __hash__ is the assertion
+            x: object
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+        assert Custom.__hash__ is None
+
+        with pytest.raises(TypeError, match="unhashable"):
+            hash(Custom(1))
+
     def test_a_body_definition_wins_over_the_option(self):
         class Custom(Struct, eq=False):
             x: object

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -151,6 +151,26 @@ class TestEq:
 
         assert Frozen.__hash__ is None
 
+    def test_a_subclass_inherits_the_hash_beside_the_eq_it_inherits(self):
+        """When the body defined both, the pair travels together. salix binding
+        its own structural hash here would break a contract the base kept.
+        """
+
+        class Both(Struct):
+            x: object
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+            def __hash__(self) -> int:
+                return 42
+
+        class Child(Both):
+            y: object = 0
+
+        assert hash(Child(1, 0)) == 42
+        assert len({Child(1, 0), Child(2, 0)}) == 1
+
     def test_a_subclass_may_take_equality_back_and_become_hashable(self):
         class Custom(Struct):  # noqa: PLW1641 -- eq=False below is the replacement
             x: object

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -115,6 +115,55 @@ class TestEq:
         with pytest.raises(TypeError, match="unhashable"):
             hash(Custom(1))
 
+    def test_a_subclass_of_a_body_eq_class_is_unhashable_too(self):
+        """It resolves that __eq__ through the MRO, so it owes the same debt --
+        and a structural hash beside an __eq__ that answers True would put two
+        equal instances in two slots of a set.
+        """
+
+        class Custom(Struct):  # noqa: PLW1641 -- the absent __hash__ is the assertion
+            x: object
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+        class Child(Custom):
+            y: object = 0
+
+        class Grandchild(Child):
+            z: object = 0
+
+        assert Child.__hash__ is None
+        assert Grandchild.__hash__ is None
+
+    def test_freezing_under_a_body_eq_base_does_not_buy_back_the_hash(self):
+        """A fieldless base may be mutable and its child frozen, so `__hash__ is
+        None` on the base does not say which rule put it there. Only the one
+        about __eq__ survives into the child.
+        """
+
+        class Loose(Struct, frozen=False):  # noqa: PLW1641 -- the absent __hash__ is the assertion
+            def __eq__(self, other: object) -> bool:
+                return True
+
+        class Frozen(Loose, frozen=True):
+            x: int
+
+        assert Frozen.__hash__ is None
+
+    def test_a_subclass_may_take_equality_back_and_become_hashable(self):
+        class Custom(Struct):  # noqa: PLW1641 -- eq=False below is the replacement
+            x: object
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+        class Child(Custom, eq=False):
+            y: object = 0
+
+        assert Child.__hash__ is object.__hash__
+        assert Child(1) != Child(1)
+
     def test_a_body_definition_wins_over_the_option(self):
         class Custom(Struct, eq=False):
             x: object


### PR DESCRIPTION
Closes #8, #10, #21. Three defects in `StructMeta.__new__`; two are silent and one is unreachable from Python.

### A subclass that re-defaults an inherited field reported two different values for it (#8)

```python
class A(Struct):
    x: int = 5

class B(A):
    x: int = 2

b = B()
b.x            # 2  -- the class variable, ahead of the base's descriptor in the MRO
repr(b)        # B(x=5)
```

`drop_class_variables` deletes field names from the copied namespace so a class variable cannot shadow the `__slots__` descriptor of the same name — but it was given `new_names`, and an inherited field is deliberately not in there: it gets a new default, not a new slot. So `x = 2` survived into `B.__dict__`. Attribute access was the one path that lied, and it is the path people use.

`all_names` is already computed and already passed to `build_class_namespace`, and `field_plan_build` captures the defaults before the deletion, so passing it through is the whole fix.

### A body-defined `__eq__` did not clear `__hash__` (#10)

Python's rule is that a class defining `__eq__` and not `__hash__` is unhashable. salix kept the tuple hash, so equal values hashed differently and occupied two slots in a set, with no error anywhere.

<details>
<summary><b>The trap, if this is ever revisited</b></summary>

Reading `__eq__` out of the namespace *inside* `bind_hash` breaks 47 tests, all of them `eq=False`. `apply_options` rebinds all six comparison names before calling `bind_hash`, so by then `__eq__` is present whether the body wrote one or salix did, and the check cannot tell them apart.

The flag is read at the top of `apply_options`, before any rebinding, where its presence still means the body:

```c
	/* Read before the rebinds below: afterwards every comparison name is
	 * present whether the body wrote one or salix did. */
	bool const body_defines_eq = PyDict_GetItemString(namespace, "__eq__") != NULL;
```

</details>

### Two calls discarded a `-1` error return and continued with an exception set (#21)

`PyUnicode_Compare` in `inherits_field` reads failure as "not equal" and appends the name as a new field; `PyDict_Contains` in `drop_class_variables` sat behind an `&&` that short-circuits past the error. Neither is reachable from Python — both operate on `str` keys in a plain dict — so neither gets a test. `inherits_field` returns a tri-state now, the shape `find_field` in `construct.c` already uses for the identical call.

---

Verified against the reproductions in the issues: `b.x` is 5 and `B().x` is still 2; `Custom.__hash__` is None and a set of two `Custom`s raises. `camas check` green at 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in one-PR batches, simplest first, and iterated with the automated reviewer until it approves.
