### PR TITLE
fix: read annotations in the format that tolerates a forward reference

### DIFF
--- a/src/annotations.c
+++ b/src/annotations.c
@@ -59,11 +59,18 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  *
  * The import is a plain path-based one and could in principle find a user
  * module of that name; a checkout that shadows a stdlib module has larger
- * problems, and the NameError it displaces is put back as the raised one with
- * the import failure behind it, so neither is lost.
+ * problems. Whichever half of the escalation fails, the NameError it displaced
+ * is put back as the raised one with that failure behind it as __context__, so
+ * the name that did not resolve is never the thing that gets lost.
  */
 static PyObject * evaluate(PyObject * const annotate) {
-	PY_MOVABLE(resolved, PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE));
+	PY_OWNED(format, PyLong_FromLong(ANNOTATION_FORMAT_VALUE));
+
+	if (format == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(resolved, PyObject_CallOneArg(annotate, format));
 
 #if PY_VERSION_HEX >= 0x030E0000
 	/* Only a plain function: annotationlib's FORWARDREF path rebuilds the
@@ -80,17 +87,25 @@ static PyObject * evaluate(PyObject * const annotate) {
 			 * every ForwardRef unowned and class-scope resolution is off the
 			 * table. Only the keys are read here, so nothing depends on it. */
 			PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
+			PY_MOVABLE(
+				escalated,
+				annotationlib == NULL ? NULL :
+					PyObject_CallMethod(
+						annotationlib,
+						"call_annotate_function",
+						"Oi",
+						annotate,
+						ANNOTATION_FORMAT_FORWARDREF
+					)
+			);
 
-			if (annotationlib != NULL) {
-				return PyObject_CallMethod(
-					annotationlib,
-					"call_annotate_function",
-					"Oi",
-					annotate,
-					ANNOTATION_FORMAT_FORWARDREF
-				);
+			if (escalated != NULL) {
+				return py_move(&escalated);
 			}
 
+			/* Either half can fail, and both bury the same thing. A second bad
+			 * annotation makes the re-evaluation raise for its own reasons, and
+			 * that error says nothing about the name this started with. */
 			PyException_SetContext(unresolved, PyErr_GetRaisedException());
 		}
 
@@ -111,14 +126,16 @@ static PyObject * evaluate(PyObject * const annotate) {
  * failed, and leaves it None for an explicit ``raise NameError(...)``.
  */
 static bool names_an_unresolved_symbol(PyObject * const error) {
-	PY_OWNED(name, PyObject_GetAttrString(error, "name"));
+	PyObject * found = NULL;
 
-	if (name == NULL) {
+	if (PyObject_GetOptionalAttrString(error, "name", &found) < 0) {
 		PyErr_Clear();
 
 		return false;
 	}
 
-	return !Py_IsNone(name);
+	PY_OWNED(name, found);
+
+	return name != NULL && !Py_IsNone(name);
 }
 #endif

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -21,7 +21,10 @@ PyObject * struct_annotations(PyObject * const namespace) {
 		return Py_NewRef(declared);
 	}
 
-	PyObject * const annotate = borrow_annotate(namespace);
+	/* Owned rather than borrowed: on 3.14+ evaluate imports a module, which runs
+	 * arbitrary Python the first time, and the namespace this came out of is
+	 * within that code's reach. */
+	PY_OWNED(annotate, Py_XNewRef(borrow_annotate(namespace)));
 
 	if (annotate == NULL) {
 		return PyDict_New();
@@ -41,27 +44,30 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * bare forward reference, which is all we need since we only read the field
  * *names* and *order* here. Only annotationlib can deliver it -- a generated
  * __annotate__ implements VALUE and answers NotImplementedError to the rest --
- * so the call goes through the helper rather than the function itself. */
+ * so the call goes through the helper rather than the function itself.
+ *
+ * Chosen at compile time rather than probed at runtime. annotationlib is stdlib
+ * from 3.14; below that, importing the name would find whatever a user happens
+ * to have on sys.path and call a function of the same name on it. An older
+ * interpreter has no PEP 649 either, so an __annotate__ in the namespace is one
+ * the class body wrote, and VALUE is what calling it means. Where the module is
+ * stdlib, a failure to import it is a broken interpreter and says so. */
 static PyObject * evaluate(PyObject * const annotate) {
+#if PY_VERSION_HEX < 0x030E0000
+	return PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE);
+#else
 	PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
 
-	if (annotationlib != NULL) {
-		return PyObject_CallMethod(
-			annotationlib,
-			"call_annotate_function",
-			"Oi",
-			annotate,
-			ANNOTATION_FORMAT_FORWARDREF
-		);
-	}
-
-	if (!PyErr_ExceptionMatches(PyExc_ImportError)) {
+	if (annotationlib == NULL) {
 		return NULL;
 	}
 
-	/* No annotationlib means no PEP 649, so this __annotate__ is one the class
-	 * body wrote by hand and a direct call is the only way to reach it. */
-	PyErr_Clear();
-
-	return PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE);
+	return PyObject_CallMethod(
+		annotationlib,
+		"call_annotate_function",
+		"Oi",
+		annotate,
+		ANNOTATION_FORMAT_FORWARDREF
+	);
+#endif
 }

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -61,10 +61,12 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
  * a ForwardRef instead of raising, which is all we need since only the field
  * *names* and *order* are read here. It has to come from annotationlib, since a
- * generated __annotate__ answers only VALUE directly and NotImplementedError to
- * every other format, which is what annotationlib's rebuild is for: it hands the
- * rebuilt copy VALUE_WITH_FAKE_GLOBALS and lets the same VALUE branch run
- * against stringifiers,
+ * generated __annotate__ evaluates for VALUE and VALUE_WITH_FAKE_GLOBALS -- one
+ * branch, and which globals it sees is the caller's business -- and raises
+ * NotImplementedError for FORWARDREF and STRING. Measured, having been written
+ * from memory three times and been wrong three times. That is what the rebuild
+ * is for: annotationlib gives the copy fake globals and calls it with format 2,
+ * so the evaluating branch runs against stringifiers,
  * and annotationlib is stdlib only from 3.14 -- below that there is no PEP 649
  * either, so an __annotate__ in the namespace is one the class body wrote and
  * VALUE is the whole story.

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -183,13 +183,40 @@ static void raise_over(PyObject * const displaced, PyObject * const failure) {
 	PyErr_SetRaisedException(py_move(&primary));
 }
 
-/* Both getters hand back a reference, so both are held rather than tested in
- * place. */
+/*
+ * Both getters hand back a reference, so both are held rather than tested in
+ * place -- and between them they still miss a case. `raise ... from None`
+ * stores None as the cause, which PyException_GetCause reports as no cause at
+ * all, so the loudest way the language has of saying "attach nothing" read as
+ * nothing to protect.
+ *
+ * The suppression flag is the only thing that separates it from an exception
+ * that was simply never chained, and there is no C accessor for it. Read
+ * through the attribute protocol, then, on an exception whose class the
+ * annotation author may have written: a failure to look is answered as
+ * suppressed, because attaching nothing is what both that and a real
+ * `from None` want, and the exception about to be raised says more than the one
+ * that could not be looked at.
+ */
 static bool arrived_chained(PyObject * const error) {
 	PY_OWNED(context, PyException_GetContext(error));
 	PY_OWNED(cause, PyException_GetCause(error));
 
-	return context != NULL || cause != NULL;
+	if (context != NULL || cause != NULL) {
+		return true;
+	}
+
+	PyObject * found = NULL;
+
+	if (PyObject_GetOptionalAttrString(error, "__suppress_context__", &found) < 0) {
+		PyErr_Clear();
+
+		return true;
+	}
+
+	PY_OWNED(suppressed, found);
+
+	return suppressed != NULL && Py_IsTrue(suppressed);
 }
 
 /*

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -128,6 +128,12 @@ static PyObject * evaluate(PyObject * const annotate) {
 			 * NameError's __context__ would swallow the interrupt and report a
 			 * name instead. */
 			if (failure != NULL && !PyErr_GivenExceptionMatches(failure, PyExc_Exception)) {
+				/* The exit wins, but the name still says which annotation the
+				 * rescue was for, so it goes behind rather than nowhere. */
+				if (PyException_GetContext(failure) == NULL) {
+					PyException_SetContext(failure, py_move(&unresolved));
+				}
+
 				PyErr_SetRaisedException(py_move(&failure));
 
 				return NULL;
@@ -173,9 +179,16 @@ static bool names_an_unresolved_symbol(PyObject * const error) {
 	PyObject * found = NULL;
 
 	/* A failure to look is not "no name": the caller re-raises the NameError,
-	 * which would clear this. Chained onto it instead, so it survives. */
+	 * which would clear this. Chained onto it instead, so it survives -- and
+	 * only where there is no chain already, the same rule the escalation's own
+	 * failure follows. */
 	if (PyObject_GetOptionalAttrString(error, "name", &found) < 0) {
-		PyException_SetContext(error, PyErr_GetRaisedException());
+		PY_MOVABLE(failure, PyErr_GetRaisedException());
+		PY_OWNED(chained, PyException_GetContext(error));
+
+		if (chained == NULL) {
+			PyException_SetContext(error, py_move(&failure));
+		}
 
 		return false;
 	}

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -23,10 +23,18 @@ enum symbol_verdict {
 	SYMBOL_UNREADABLE,
 };
 
+/* Whether an exception will take a __context__. Not "is it chained": an
+ * exception can refuse one while carrying neither a cause nor a context. */
+enum context_slot {
+	CONTEXT_SLOT_FREE,
+	CONTEXT_SLOT_SPOKEN_FOR,
+	CONTEXT_SLOT_UNREADABLE,
+};
+
 static enum symbol_verdict names_an_unresolved_symbol(PyObject * error);
 static PyObject * escalate(PyObject * annotate);
 static void raise_over(PyObject * displaced, PyObject * failure);
-static bool arrived_chained(PyObject * error);
+static enum context_slot context_slot_of(PyObject * error);
 #endif
 
 PyObject * struct_annotations(PyObject * const namespace) {
@@ -176,47 +184,89 @@ static void raise_over(PyObject * const displaced, PyObject * const failure) {
 	PY_MOVABLE(primary, exits ? failure : displaced);
 	PY_MOVABLE(behind, exits ? displaced : failure);
 
-	if (!arrived_chained(primary)) {
-		PyException_SetContext(primary, py_move(&behind));
+	switch (context_slot_of(primary)) {
+		case CONTEXT_SLOT_FREE:
+			PyException_SetContext(primary, py_move(&behind));
+
+			break;
+
+		case CONTEXT_SLOT_SPOKEN_FOR:
+			break;
+
+		case CONTEXT_SLOT_UNREADABLE: {
+			/* Looking raised, on a class the annotation author wrote. An exit
+			 * from there is still an exit and takes the same rule the top of
+			 * this function applies: it wins, and what it displaced goes
+			 * behind it where there is room. Anything else is dropped -- it is
+			 * a failure to read a flag on the way to reporting something that
+			 * matters more, and the `.name` lookup answers the same way.
+			 *
+			 * A second unreadable answer attaches nothing rather than asking a
+			 * third time. */
+			PY_MOVABLE(looking, PyErr_GetRaisedException());
+
+			if (looking == NULL || PyErr_GivenExceptionMatches(looking, PyExc_Exception)) {
+				break;
+			}
+
+			if (context_slot_of(looking) == CONTEXT_SLOT_FREE) {
+				PyException_SetContext(looking, py_move(&primary));
+			}
+
+			PyErr_SetRaisedException(py_move(&looking));
+
+			return;
+		}
 	}
 
 	PyErr_SetRaisedException(py_move(&primary));
 }
 
 /*
- * Both getters hand back a reference, so both are held rather than tested in
- * place -- and between them they still miss a case. `raise ... from None`
- * stores None as the cause, which PyException_GetCause reports as no cause at
- * all, so the loudest way the language has of saying "attach nothing" read as
- * nothing to protect.
+ * Whether the exception will take a __context__, which is not the same question
+ * as whether it has one -- `raise ... from None` has neither a cause nor a
+ * context and still refuses one, which is why this is not called "chained".
  *
- * The suppression flag is the only thing that separates it from an exception
- * that was simply never chained, and there is no C accessor for it. Read
- * through the attribute protocol, then, on an exception whose class the
- * annotation author may have written: a failure to look is answered as
- * suppressed, because attaching nothing is what both that and a real
- * `from None` want, and the exception about to be raised says more than the one
- * that could not be looked at.
+ * Both getters hand back a reference, so both are held rather than tested in
+ * place, and between them they still miss that case: `from None` stores None as
+ * the cause, and PyException_GetCause reports that as no cause at all. The
+ * suppression flag is the only thing separating it from an exception that was
+ * simply never chained, and there is no C accessor for it.
+ *
+ * So it is read through the attribute protocol, on an exception whose class the
+ * annotation author may have written, and a failure to look is a third answer
+ * rather than a guess -- the caller decides, the same way it does for the
+ * `.name` lookup. PyObject_IsTrue rather than a test against True, because the
+ * interpreter's own traceback printer asks the flag that question and a
+ * shadowed truthy value should mean here what it means there.
  */
-static bool arrived_chained(PyObject * const error) {
+static enum context_slot context_slot_of(PyObject * const error) {
 	PY_OWNED(context, PyException_GetContext(error));
 	PY_OWNED(cause, PyException_GetCause(error));
 
 	if (context != NULL || cause != NULL) {
-		return true;
+		return CONTEXT_SLOT_SPOKEN_FOR;
 	}
 
 	PyObject * found = NULL;
 
 	if (PyObject_GetOptionalAttrString(error, "__suppress_context__", &found) < 0) {
-		PyErr_Clear();
-
-		return true;
+		return CONTEXT_SLOT_UNREADABLE;
 	}
 
 	PY_OWNED(suppressed, found);
 
-	return suppressed != NULL && Py_IsTrue(suppressed);
+	if (suppressed == NULL) {
+		return CONTEXT_SLOT_FREE;
+	}
+
+	int const refused = PyObject_IsTrue(suppressed);
+
+	if (refused < 0) {
+		return CONTEXT_SLOT_UNREADABLE;
+	}
+
+	return refused == 1 ? CONTEXT_SLOT_SPOKEN_FOR : CONTEXT_SLOT_FREE;
 }
 
 /*

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -53,8 +53,10 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * The rescue costs a re-evaluation, and sometimes two: annotationlib rebuilds
  * the callable and re-runs every annotation in the dict, so a class holding one
  * forward reference evaluates its other annotations again. Plain 3.14 evaluates
- * once and defers. Format.STRING would avoid it -- only the keys are read here
- * -- but the values stop being objects, and #14's ClassVar check reads them.
+ * once and defers. Format.STRING would avoid it, because only the keys are read
+ * here -- but not for long: #50 adds the #14 ClassVar check, which reads the
+ * values, and STRING hands it strings. Not in this tree yet, so the reason to
+ * keep FORWARDREF is a pending one rather than a present one.
  *
  * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
  * a ForwardRef instead of raising, which is all we need since only the field

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -196,10 +196,17 @@ static void raise_over(PyObject * const displaced, PyObject * const failure) {
 		case CONTEXT_SLOT_UNREADABLE: {
 			/* Looking raised, on a class the annotation author wrote. An exit
 			 * from there is still an exit and takes the same rule the top of
-			 * this function applies: it wins, and what it displaced goes
-			 * behind it where there is room. Anything else is dropped -- it is
-			 * a failure to read a flag on the way to reporting something that
-			 * matters more, and the `.name` lookup answers the same way.
+			 * this function applies: it wins, and what it displaced goes behind
+			 * it where there is room. That much the two author-controlled reads
+			 * share.
+			 *
+			 * An ordinary failure does not, and the difference is the question
+			 * each read was asking. The `.name` read asks what to raise, so its
+			 * failure is a candidate answer and the caller puts it behind the
+			 * NameError. This one asks whether the winner will accept a
+			 * __context__ -- and a read that raised has not said yes, so
+			 * nothing is attached, including itself. Attaching it would be
+			 * writing to the slot the failed read was asking permission for.
 			 *
 			 * A second unreadable answer attaches nothing rather than asking a
 			 * third time. */

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include <stdbool.h>
 
 #include "annotations.h"
 #include "owned.h"

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -40,34 +40,45 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
 	return annotate != NULL ? annotate : PyDict_GetItemString(namespace, "__annotate_func__");
 }
 
-/* annotationlib.Format.FORWARDREF: never raises NameError on an unresolved
- * bare forward reference, which is all we need since we only read the field
- * *names* and *order* here. Only annotationlib can deliver it -- a generated
- * __annotate__ implements VALUE and answers NotImplementedError to the rest --
- * so the call goes through the helper rather than the function itself.
+/*
+ * VALUE first, because it is what the generated __annotate__ implements
+ * directly and what all-resolvable annotations -- nearly all of them -- want.
+ * Only a name that does not resolve costs anything more.
  *
- * Chosen at compile time rather than probed at runtime. annotationlib is stdlib
- * from 3.14; below that, importing the name would find whatever a user happens
- * to have on sys.path and call a function of the same name on it. An older
- * interpreter has no PEP 649 either, so an __annotate__ in the namespace is one
- * the class body wrote, and VALUE is what calling it means. Where the module is
- * stdlib, a failure to import it is a broken interpreter and says so. */
+ * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
+ * a ForwardRef instead of raising, which is all we need since only the field
+ * *names* and *order* are read here. It has to come from annotationlib, since a
+ * generated __annotate__ answers NotImplementedError to every format but VALUE,
+ * and annotationlib is stdlib only from 3.14 -- below that there is no PEP 649
+ * either, so an __annotate__ in the namespace is one the class body wrote and
+ * VALUE is the whole story.
+ *
+ * The import is a plain path-based one and could in principle find a user
+ * module of that name; a checkout that shadows a stdlib module has larger
+ * problems, and the failure is loud rather than silent.
+ */
 static PyObject * evaluate(PyObject * const annotate) {
-#if PY_VERSION_HEX < 0x030E0000
-	return PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE);
-#else
-	PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
+	PY_MOVABLE(resolved, PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE));
 
-	if (annotationlib == NULL) {
-		return NULL;
+#if PY_VERSION_HEX >= 0x030E0000
+	if (resolved == NULL && PyErr_ExceptionMatches(PyExc_NameError)) {
+		PyErr_Clear();
+
+		PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
+
+		if (annotationlib == NULL) {
+			return NULL;
+		}
+
+		return PyObject_CallMethod(
+			annotationlib,
+			"call_annotate_function",
+			"Oi",
+			annotate,
+			ANNOTATION_FORMAT_FORWARDREF
+		);
 	}
-
-	return PyObject_CallMethod(
-		annotationlib,
-		"call_annotate_function",
-		"Oi",
-		annotate,
-		ANNOTATION_FORMAT_FORWARDREF
-	);
 #endif
+
+	return py_move(&resolved);
 }

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -61,7 +61,9 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
  * a ForwardRef instead of raising, which is all we need since only the field
  * *names* and *order* are read here. It has to come from annotationlib, since a
- * generated __annotate__ answers NotImplementedError to every format but VALUE,
+ * generated __annotate__ answers NotImplementedError to VALUE_WITH_FAKE_GLOBALS
+ * only after annotationlib has rebuilt it -- which is the rescue -- and to
+ * FORWARDREF and STRING always,
  * and annotationlib is stdlib only from 3.14 -- below that there is no PEP 649
  * either, so an __annotate__ in the namespace is one the class body wrote and
  * VALUE is the whole story.
@@ -115,7 +117,14 @@ static PyObject * evaluate(PyObject * const annotate) {
 			/* Either half can fail, and both bury the same thing. A second bad
 			 * annotation makes the re-evaluation raise for its own reasons, and
 			 * that error says nothing about the name this started with. */
-			PyException_SetContext(unresolved, PyErr_GetRaisedException());
+			PY_MOVABLE(failure, PyErr_GetRaisedException());
+
+			/* Only where there is nothing to lose. A NameError raised while
+			 * another exception was being handled arrives with a chain, and
+			 * that chain says more about the class than this failure does. */
+			if (PyException_GetContext(unresolved) == NULL) {
+				PyException_SetContext(unresolved, py_move(&failure));
+			}
 		}
 
 		PyErr_SetRaisedException(py_move(&unresolved));
@@ -132,7 +141,8 @@ static PyObject * evaluate(PyObject * const annotate) {
  * Not resolving a name is the exemption; arbitrary failure is not, and a
  * NameError the annotation raised for its own reasons is arbitrary failure
  * wearing the right coat. The interpreter fills `name` in when a lookup is what
- * failed, and `raise NameError("...")` leaves it None.
+ * failed, and `raise NameError("...")` leaves it None -- as does anything that
+ * is not a non-empty str, which the interpreter never produces.
  *
  * Which is what this can tell apart, and all of it. `raise NameError(name=...)`
  * sets the attribute and reads as a forward reference; so does anything at all,
@@ -145,13 +155,13 @@ static bool names_an_unresolved_symbol(PyObject * const error) {
 	PyObject * found = NULL;
 
 	if (PyObject_GetOptionalAttrString(error, "name", &found) < 0) {
-		PyErr_Clear();
-
 		return false;
 	}
 
 	PY_OWNED(name, found);
 
-	return name != NULL && !Py_IsNone(name);
+	/* The interpreter sets a real symbol, so a non-str or an empty one is
+	 * something the raising code put there. */
+	return name != NULL && PyUnicode_Check(name) && PyUnicode_GET_LENGTH(name) > 0;
 }
 #endif

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -16,7 +16,17 @@ static PyObject * borrow_annotate(PyObject * namespace);
 static PyObject * evaluate(PyObject * annotate);
 
 #if PY_VERSION_HEX >= 0x030E0000
-static bool names_an_unresolved_symbol(PyObject * error);
+/* What a NameError's `.name` says about why it was raised. */
+enum symbol_verdict {
+	SYMBOL_UNRESOLVED,
+	SYMBOL_NOT_A_SYMBOL,
+	SYMBOL_UNREADABLE,
+};
+
+static enum symbol_verdict names_an_unresolved_symbol(PyObject * error);
+static PyObject * escalate(PyObject * annotate);
+static void raise_over(PyObject * displaced, PyObject * failure);
+static bool arrived_chained(PyObject * error);
 #endif
 
 PyObject * struct_annotations(PyObject * const namespace) {
@@ -71,22 +81,10 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * None of this exists below 3.14. annotationlib is stdlib only from there, and
  * so is PEP 649, so an __annotate__ in the namespace is one the class body
  * wrote and VALUE is the whole story.
- *
- * The import is a plain path-based one and could in principle find a user
- * module of that name; a checkout that shadows a stdlib module has larger
- * problems. Whichever half of the escalation fails, the NameError it displaced
- * is put back as the raised one -- with that failure behind it as __context__
- * where there was no chain already, and untouched where there was, since the
- * chain it arrived with says more than the rescue's own failure does.
  */
 static PyObject * evaluate(PyObject * const annotate) {
 	PY_OWNED(format, PyLong_FromLong(ANNOTATION_FORMAT_VALUE));
-
-	if (format == NULL) {
-		return NULL;
-	}
-
-	PY_MOVABLE(resolved, PyObject_CallOneArg(annotate, format));
+	PY_MOVABLE(resolved, format != NULL ? PyObject_CallOneArg(annotate, format) : NULL);
 
 #if PY_VERSION_HEX >= 0x030E0000
 	/* Only a plain function: annotationlib's FORWARDREF path rebuilds the
@@ -98,65 +96,33 @@ static PyObject * evaluate(PyObject * const annotate) {
 	if (resolved == NULL && PyFunction_Check(annotate) && PyErr_ExceptionMatches(PyExc_NameError)) {
 		PY_MOVABLE(unresolved, PyErr_GetRaisedException());
 
-		if (names_an_unresolved_symbol(unresolved)) {
-			/* No `owner`: the class does not exist yet, so annotationlib builds
-			 * every ForwardRef unowned and class-scope resolution is off the
-			 * table. Only the keys are read here, so nothing depends on it. */
-			PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
-			PY_MOVABLE(
-				escalated,
-				annotationlib == NULL ? NULL :
-					PyObject_CallMethod(
-						annotationlib,
-						"call_annotate_function",
-						"Oi",
-						annotate,
-						ANNOTATION_FORMAT_FORWARDREF
-					)
-			);
+		switch (names_an_unresolved_symbol(unresolved)) {
+			case SYMBOL_UNRESOLVED: {
+				PY_MOVABLE(escalated, escalate(annotate));
 
-			if (escalated != NULL) {
-				return py_move(&escalated);
-			}
-
-			/* Either half can fail, and both bury the same thing. A second bad
-			 * annotation makes the re-evaluation raise for its own reasons, and
-			 * that error says nothing about the name this started with. */
-			PY_MOVABLE(failure, PyErr_GetRaisedException());
-
-			/* An exit is not a diagnostic. Demoting KeyboardInterrupt to the
-			 * NameError's __context__ would swallow the interrupt and report a
-			 * name instead. */
-			if (failure != NULL && !PyErr_GivenExceptionMatches(failure, PyExc_Exception)) {
-				/* The exit wins, but the name still says which annotation the
-				 * rescue was for, so it goes behind rather than nowhere. Held,
-				 * not tested in place: GetContext hands back a reference. */
-				PY_OWNED(already, PyException_GetContext(failure));
-
-				if (already == NULL) {
-					PyException_SetContext(failure, py_move(&unresolved));
+				if (escalated != NULL) {
+					return py_move(&escalated);
 				}
 
-				PyErr_SetRaisedException(py_move(&failure));
+				/* Either half of the rescue can fail, and both bury the same
+				 * thing. A second bad annotation makes the re-evaluation raise
+				 * for its own reasons, and that error says nothing about the
+				 * name this started with. */
+				raise_over(py_move(&unresolved), PyErr_GetRaisedException());
 
 				return NULL;
 			}
 
-			/* Only where there is nothing to lose. A NameError raised while
-			 * another exception was being handled arrives with a chain, and
-			 * that chain says more about the class than this failure does.
-			 * GetContext hands back a reference, so it is held rather than
-			 * tested in place. */
-			PY_OWNED(chained, PyException_GetContext(unresolved));
+			case SYMBOL_UNREADABLE:
+				raise_over(py_move(&unresolved), PyErr_GetRaisedException());
 
-			if (chained == NULL) {
-				PyException_SetContext(unresolved, py_move(&failure));
-			}
+				return NULL;
+
+			case SYMBOL_NOT_A_SYMBOL:
+				PyErr_SetRaisedException(py_move(&unresolved));
+
+				return NULL;
 		}
-
-		PyErr_SetRaisedException(py_move(&unresolved));
-
-		return NULL;
 	}
 #endif
 
@@ -164,6 +130,68 @@ static PyObject * evaluate(PyObject * const annotate) {
 }
 
 #if PY_VERSION_HEX >= 0x030E0000
+/* The import is a plain path-based one and could in principle find a user
+ * module of that name; a checkout that shadows a stdlib module has larger
+ * problems.
+ *
+ * No `owner`: the class does not exist yet, so annotationlib builds every
+ * ForwardRef unowned and class-scope resolution is off the table. Only the keys
+ * are read here, so nothing depends on it. */
+static PyObject * escalate(PyObject * const annotate) {
+	PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
+
+	return (
+		annotationlib == NULL ? NULL :
+		PyObject_CallMethod(
+			annotationlib,
+			"call_annotate_function",
+			"Oi",
+			annotate,
+			ANNOTATION_FORMAT_FORWARDREF
+		)
+	);
+}
+
+/*
+ * One rule for every way the rescue can fail, because writing it out at each
+ * failure in turn is what leaked a reference twice.
+ *
+ * An exit is not a diagnostic: a failure that is not an `Exception` wins over
+ * the name it displaced, and one that is loses to it. That is broader than the
+ * KeyboardInterrupt and SystemExit it is for -- a GeneratorExit or a
+ * BaseException subclass of the annotation's own wins too -- and it is the line
+ * Python already draws for what `except Exception` may swallow.
+ *
+ * The loser goes behind the winner as __context__ only where the winner arrived
+ * with no chain of its own, __cause__ counting as much as __context__: a chain
+ * the class already had says more than either of these does. Where there is
+ * one, the loser is dropped.
+ *
+ * Both arguments are owned, and neither is NULL: every caller takes its
+ * `failure` from PyErr_GetRaisedException straight after a call that returned
+ * NULL, and CPython sets an exception on every one of those.
+ */
+static void raise_over(PyObject * const displaced, PyObject * const failure) {
+	bool const exits = !PyErr_GivenExceptionMatches(failure, PyExc_Exception);
+	PY_MOVABLE(primary, exits ? failure : displaced);
+	PY_MOVABLE(behind, exits ? displaced : failure);
+
+	if (!arrived_chained(primary)) {
+		PyException_SetContext(primary, py_move(&behind));
+	}
+
+	PyErr_SetRaisedException(py_move(&primary));
+}
+
+/* Both getters hand back a reference, so both are held rather than tested in
+ * place. */
+static bool arrived_chained(PyObject * const error) {
+	PY_OWNED(context, PyException_GetContext(error));
+	PY_OWNED(cause, PyException_GetCause(error));
+
+	return context != NULL || cause != NULL;
+}
+
 /*
  * Not resolving a name is the exemption; arbitrary failure is not, and a
  * NameError the annotation raised for its own reasons is arbitrary failure
@@ -177,29 +205,27 @@ static PyObject * evaluate(PyObject * const annotate) {
  * re-evaluates the whole dict and stringifies what it cannot resolve. The
  * exemption is best-effort against accidents, not a wall against a caller who
  * wants past it.
+ *
+ * The lookup runs the attribute protocol on an exception whose class the
+ * annotation author controls, so it is a third answer rather than a false one:
+ * a failure to look is not "no name", and the caller decides what to raise.
  */
-static bool names_an_unresolved_symbol(PyObject * const error) {
+static enum symbol_verdict names_an_unresolved_symbol(PyObject * const error) {
 	PyObject * found = NULL;
 
-	/* A failure to look is not "no name": the caller re-raises the NameError,
-	 * which would clear this. Chained onto it instead, so it survives -- and
-	 * only where there is no chain already, the same rule the escalation's own
-	 * failure follows. */
 	if (PyObject_GetOptionalAttrString(error, "name", &found) < 0) {
-		PY_MOVABLE(failure, PyErr_GetRaisedException());
-		PY_OWNED(chained, PyException_GetContext(error));
-
-		if (chained == NULL) {
-			PyException_SetContext(error, py_move(&failure));
-		}
-
-		return false;
+		return SYMBOL_UNREADABLE;
 	}
 
 	PY_OWNED(name, found);
 
 	/* The interpreter sets a real symbol, so a non-str or an empty one is
 	 * something the raising code put there. */
-	return name != NULL && PyUnicode_Check(name) && PyUnicode_GET_LENGTH(name) > 0;
+	return (
+		name != NULL && PyUnicode_Check(
+			name
+		) && PyUnicode_GET_LENGTH(name) > 0 ? SYMBOL_UNRESOLVED :
+		SYMBOL_NOT_A_SYMBOL
+	);
 }
 #endif

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -123,7 +123,14 @@ static PyObject * evaluate(PyObject * const annotate) {
  * Not resolving a name is the exemption; arbitrary failure is not, and a
  * NameError the annotation raised for its own reasons is arbitrary failure
  * wearing the right coat. The interpreter fills `name` in when a lookup is what
- * failed, and leaves it None for an explicit ``raise NameError(...)``.
+ * failed, and `raise NameError("...")` leaves it None.
+ *
+ * Which is what this can tell apart, and all of it. `raise NameError(name=...)`
+ * sets the attribute and reads as a forward reference; so does anything at all,
+ * once an *earlier* annotation forward-references, because the rescue
+ * re-evaluates the whole dict and stringifies what it cannot resolve. The
+ * exemption is best-effort against accidents, not a wall against a caller who
+ * wants past it.
  */
 static bool names_an_unresolved_symbol(PyObject * const error) {
 	PyObject * found = NULL;

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -23,18 +23,10 @@ enum symbol_verdict {
 	SYMBOL_UNREADABLE,
 };
 
-/* Whether an exception will take a __context__. Not "is it chained": an
- * exception can refuse one while carrying neither a cause nor a context. */
-enum context_slot {
-	CONTEXT_SLOT_FREE,
-	CONTEXT_SLOT_SPOKEN_FOR,
-	CONTEXT_SLOT_UNREADABLE,
-};
-
 static enum symbol_verdict names_an_unresolved_symbol(PyObject * error);
 static PyObject * escalate(PyObject * annotate);
 static void raise_over(PyObject * displaced, PyObject * failure);
-static enum context_slot context_slot_of(PyObject * error);
+static bool context_slot_is_free(PyObject * error);
 #endif
 
 PyObject * struct_annotations(PyObject * const namespace) {
@@ -184,46 +176,8 @@ static void raise_over(PyObject * const displaced, PyObject * const failure) {
 	PY_MOVABLE(primary, exits ? failure : displaced);
 	PY_MOVABLE(behind, exits ? displaced : failure);
 
-	switch (context_slot_of(primary)) {
-		case CONTEXT_SLOT_FREE:
-			PyException_SetContext(primary, py_move(&behind));
-
-			break;
-
-		case CONTEXT_SLOT_SPOKEN_FOR:
-			break;
-
-		case CONTEXT_SLOT_UNREADABLE: {
-			/* Looking raised, on a class the annotation author wrote. An exit
-			 * from there is still an exit and takes the same rule the top of
-			 * this function applies: it wins, and what it displaced goes behind
-			 * it where there is room. That much the two author-controlled reads
-			 * share.
-			 *
-			 * An ordinary failure does not, and the difference is the question
-			 * each read was asking. The `.name` read asks what to raise, so its
-			 * failure is a candidate answer and the caller puts it behind the
-			 * NameError. This one asks whether the winner will accept a
-			 * __context__ -- and a read that raised has not said yes, so
-			 * nothing is attached, including itself. Attaching it would be
-			 * writing to the slot the failed read was asking permission for.
-			 *
-			 * A second unreadable answer attaches nothing rather than asking a
-			 * third time. */
-			PY_MOVABLE(looking, PyErr_GetRaisedException());
-
-			if (looking == NULL || PyErr_GivenExceptionMatches(looking, PyExc_Exception)) {
-				break;
-			}
-
-			if (context_slot_of(looking) == CONTEXT_SLOT_FREE) {
-				PyException_SetContext(looking, py_move(&primary));
-			}
-
-			PyErr_SetRaisedException(py_move(&looking));
-
-			return;
-		}
+	if (context_slot_is_free(primary)) {
+		PyException_SetContext(primary, py_move(&behind));
 	}
 
 	PyErr_SetRaisedException(py_move(&primary));
@@ -237,43 +191,26 @@ static void raise_over(PyObject * const displaced, PyObject * const failure) {
  * Both getters hand back a reference, so both are held rather than tested in
  * place, and between them they still miss that case: `from None` stores None as
  * the cause, and PyException_GetCause reports that as no cause at all. The
- * suppression flag is the only thing separating it from an exception that was
- * simply never chained, and there is no C accessor for it.
+ * suppression flag is what separates it from an exception that was simply never
+ * chained.
  *
- * So it is read through the attribute protocol, on an exception whose class the
- * annotation author may have written, and a failure to look is a third answer
- * rather than a guess -- the caller decides, the same way it does for the
- * `.name` lookup. PyObject_IsTrue rather than a test against True, because the
- * interpreter's own traceback printer asks the flag that question and a
- * shadowed truthy value should mean here what it means there.
+ * The flag is a field of PyException_HEAD -- which pyerrors.h introduces as
+ * "the initial segment of every exception class" -- and there is no accessor
+ * function for it. The field and not the attribute of the same name, because
+ * `raise ... from None` writes the field, and the attribute is what the
+ * annotation author's class can shadow either way. Reading the field also asks
+ * nothing of a class that could answer by raising, so every answer here is one
+ * of two rather than three.
  */
-static enum context_slot context_slot_of(PyObject * const error) {
+static bool context_slot_is_free(PyObject * const error) {
 	PY_OWNED(context, PyException_GetContext(error));
 	PY_OWNED(cause, PyException_GetCause(error));
 
-	if (context != NULL || cause != NULL) {
-		return CONTEXT_SLOT_SPOKEN_FOR;
-	}
-
-	PyObject * found = NULL;
-
-	if (PyObject_GetOptionalAttrString(error, "__suppress_context__", &found) < 0) {
-		return CONTEXT_SLOT_UNREADABLE;
-	}
-
-	PY_OWNED(suppressed, found);
-
-	if (suppressed == NULL) {
-		return CONTEXT_SLOT_FREE;
-	}
-
-	int const refused = PyObject_IsTrue(suppressed);
-
-	if (refused < 0) {
-		return CONTEXT_SLOT_UNREADABLE;
-	}
-
-	return refused == 1 ? CONTEXT_SLOT_SPOKEN_FOR : CONTEXT_SLOT_FREE;
+	return (
+		context == NULL &&
+		cause == NULL &&
+		!((PyBaseExceptionObject *) error)->suppress_context
+	);
 }
 
 /*

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -3,16 +3,16 @@
 #include "annotations.h"
 #include "owned.h"
 
-/* annotationlib.Format.FORWARDREF: never raises NameError on an unresolved
- * bare forward reference, which is all we need since we only read the field
- * *names* and *order* here. */
+/* annotationlib.Format. The numbering is the API. */
 enum annotation_format {
 	ANNOTATION_FORMAT_VALUE = 1,
-	ANNOTATION_FORMAT_FORWARDREF = 2,
+	ANNOTATION_FORMAT_VALUE_WITH_FAKE_GLOBALS = 2,
+	ANNOTATION_FORMAT_FORWARDREF = 3,
+	ANNOTATION_FORMAT_STRING = 4,
 };
 
 static PyObject * borrow_annotate(PyObject * namespace);
-static PyObject * evaluate(PyObject * annotate, enum annotation_format format);
+static PyObject * evaluate(PyObject * annotate);
 
 PyObject * struct_annotations(PyObject * const namespace) {
 	PyObject * const declared = PyDict_GetItemString(namespace, "__annotations__");
@@ -27,16 +27,7 @@ PyObject * struct_annotations(PyObject * const namespace) {
 		return PyDict_New();
 	}
 
-	PyObject * const forwardref = evaluate(annotate, ANNOTATION_FORMAT_FORWARDREF);
-
-	if (forwardref != NULL) {
-		return forwardref;
-	}
-
-	/* Fall back to VALUE format if FORWARDREF is unsupported. */
-	PyErr_Clear();
-
-	return evaluate(annotate, ANNOTATION_FORMAT_VALUE);
+	return evaluate(annotate);
 }
 
 /* Borrowed, or NULL when the class body declared no annotations at all. */
@@ -46,12 +37,31 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
 	return annotate != NULL ? annotate : PyDict_GetItemString(namespace, "__annotate_func__");
 }
 
-static PyObject * evaluate(PyObject * const annotate, enum annotation_format const format) {
-	PY_OWNED(argument, PyLong_FromLong(format));
+/* annotationlib.Format.FORWARDREF: never raises NameError on an unresolved
+ * bare forward reference, which is all we need since we only read the field
+ * *names* and *order* here. Only annotationlib can deliver it -- a generated
+ * __annotate__ implements VALUE and answers NotImplementedError to the rest --
+ * so the call goes through the helper rather than the function itself. */
+static PyObject * evaluate(PyObject * const annotate) {
+	PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
 
-	if (argument == NULL) {
+	if (annotationlib != NULL) {
+		return PyObject_CallMethod(
+			annotationlib,
+			"call_annotate_function",
+			"Oi",
+			annotate,
+			ANNOTATION_FORMAT_FORWARDREF
+		);
+	}
+
+	if (!PyErr_ExceptionMatches(PyExc_ImportError)) {
 		return NULL;
 	}
 
-	return PyObject_CallOneArg(annotate, argument);
+	/* No annotationlib means no PEP 649, so this __annotate__ is one the class
+	 * body wrote by hand and a direct call is the only way to reach it. */
+	PyErr_Clear();
+
+	return PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE);
 }

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -14,6 +14,10 @@ enum annotation_format {
 static PyObject * borrow_annotate(PyObject * namespace);
 static PyObject * evaluate(PyObject * annotate);
 
+#if PY_VERSION_HEX >= 0x030E0000
+static bool names_an_unresolved_symbol(PyObject * error);
+#endif
+
 PyObject * struct_annotations(PyObject * const namespace) {
 	PyObject * const declared = PyDict_GetItemString(namespace, "__annotations__");
 
@@ -55,7 +59,8 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  *
  * The import is a plain path-based one and could in principle find a user
  * module of that name; a checkout that shadows a stdlib module has larger
- * problems, and the failure is loud rather than silent.
+ * problems, and the NameError it displaces is put back as the raised one with
+ * the import failure behind it, so neither is lost.
  */
 static PyObject * evaluate(PyObject * const annotate) {
 	PY_MOVABLE(resolved, PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE));
@@ -68,23 +73,52 @@ static PyObject * evaluate(PyObject * const annotate) {
 	 * thing a plain function does, and the same thing every version below 3.14
 	 * does. */
 	if (resolved == NULL && PyFunction_Check(annotate) && PyErr_ExceptionMatches(PyExc_NameError)) {
-		PyErr_Clear();
+		PY_MOVABLE(unresolved, PyErr_GetRaisedException());
 
-		PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
+		if (names_an_unresolved_symbol(unresolved)) {
+			/* No `owner`: the class does not exist yet, so annotationlib builds
+			 * every ForwardRef unowned and class-scope resolution is off the
+			 * table. Only the keys are read here, so nothing depends on it. */
+			PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));
 
-		if (annotationlib == NULL) {
-			return NULL;
+			if (annotationlib != NULL) {
+				return PyObject_CallMethod(
+					annotationlib,
+					"call_annotate_function",
+					"Oi",
+					annotate,
+					ANNOTATION_FORMAT_FORWARDREF
+				);
+			}
+
+			PyException_SetContext(unresolved, PyErr_GetRaisedException());
 		}
 
-		return PyObject_CallMethod(
-			annotationlib,
-			"call_annotate_function",
-			"Oi",
-			annotate,
-			ANNOTATION_FORMAT_FORWARDREF
-		);
+		PyErr_SetRaisedException(py_move(&unresolved));
+
+		return NULL;
 	}
 #endif
 
 	return py_move(&resolved);
 }
+
+#if PY_VERSION_HEX >= 0x030E0000
+/*
+ * Not resolving a name is the exemption; arbitrary failure is not, and a
+ * NameError the annotation raised for its own reasons is arbitrary failure
+ * wearing the right coat. The interpreter fills `name` in when a lookup is what
+ * failed, and leaves it None for an explicit ``raise NameError(...)``.
+ */
+static bool names_an_unresolved_symbol(PyObject * const error) {
+	PY_OWNED(name, PyObject_GetAttrString(error, "name"));
+
+	if (name == NULL) {
+		PyErr_Clear();
+
+		return false;
+	}
+
+	return !Py_IsNone(name);
+}
+#endif

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -66,10 +66,11 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * NotImplementedError for FORWARDREF and STRING. Measured, having been written
  * from memory three times and been wrong three times. That is what the rebuild
  * is for: annotationlib gives the copy fake globals and calls it with format 2,
- * so the evaluating branch runs against stringifiers,
- * and annotationlib is stdlib only from 3.14 -- below that there is no PEP 649
- * either, so an __annotate__ in the namespace is one the class body wrote and
- * VALUE is the whole story.
+ * so the evaluating branch runs against stringifiers.
+ *
+ * None of this exists below 3.14. annotationlib is stdlib only from there, and
+ * so is PEP 649, so an __annotate__ in the namespace is one the class body
+ * wrote and VALUE is the whole story.
  *
  * The import is a plain path-based one and could in principle find a user
  * module of that name; a checkout that shadows a stdlib module has larger

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -61,7 +61,13 @@ static PyObject * evaluate(PyObject * const annotate) {
 	PY_MOVABLE(resolved, PyObject_CallFunction(annotate, "i", ANNOTATION_FORMAT_VALUE));
 
 #if PY_VERSION_HEX >= 0x030E0000
-	if (resolved == NULL && PyErr_ExceptionMatches(PyExc_NameError)) {
+	/* Only a plain function: annotationlib's FORWARDREF path rebuilds the
+	 * callable from its __globals__ and __code__, so anything else -- a partial,
+	 * a callable object -- fails there with an AttributeError that hides the
+	 * NameError actually worth reporting. Left unescalated it raises the same
+	 * thing a plain function does, and the same thing every version below 3.14
+	 * does. */
+	if (resolved == NULL && PyFunction_Check(annotate) && PyErr_ExceptionMatches(PyExc_NameError)) {
 		PyErr_Clear();
 
 		PY_OWNED(annotationlib, PyImport_ImportModule("annotationlib"));

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -61,9 +61,10 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
  * a ForwardRef instead of raising, which is all we need since only the field
  * *names* and *order* are read here. It has to come from annotationlib, since a
- * generated __annotate__ answers NotImplementedError to VALUE_WITH_FAKE_GLOBALS
- * only after annotationlib has rebuilt it -- which is the rescue -- and to
- * FORWARDREF and STRING always,
+ * generated __annotate__ answers only VALUE directly and NotImplementedError to
+ * every other format, which is what annotationlib's rebuild is for: it hands the
+ * rebuilt copy VALUE_WITH_FAKE_GLOBALS and lets the same VALUE branch run
+ * against stringifiers,
  * and annotationlib is stdlib only from 3.14 -- below that there is no PEP 649
  * either, so an __annotate__ in the namespace is one the class body wrote and
  * VALUE is the whole story.
@@ -71,8 +72,9 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * The import is a plain path-based one and could in principle find a user
  * module of that name; a checkout that shadows a stdlib module has larger
  * problems. Whichever half of the escalation fails, the NameError it displaced
- * is put back as the raised one with that failure behind it as __context__, so
- * the name that did not resolve is never the thing that gets lost.
+ * is put back as the raised one -- with that failure behind it as __context__
+ * where there was no chain already, and untouched where there was, since the
+ * chain it arrived with says more than the rescue's own failure does.
  */
 static PyObject * evaluate(PyObject * const annotate) {
 	PY_OWNED(format, PyLong_FromLong(ANNOTATION_FORMAT_VALUE));
@@ -119,10 +121,23 @@ static PyObject * evaluate(PyObject * const annotate) {
 			 * that error says nothing about the name this started with. */
 			PY_MOVABLE(failure, PyErr_GetRaisedException());
 
+			/* An exit is not a diagnostic. Demoting KeyboardInterrupt to the
+			 * NameError's __context__ would swallow the interrupt and report a
+			 * name instead. */
+			if (failure != NULL && !PyErr_GivenExceptionMatches(failure, PyExc_Exception)) {
+				PyErr_SetRaisedException(py_move(&failure));
+
+				return NULL;
+			}
+
 			/* Only where there is nothing to lose. A NameError raised while
 			 * another exception was being handled arrives with a chain, and
-			 * that chain says more about the class than this failure does. */
-			if (PyException_GetContext(unresolved) == NULL) {
+			 * that chain says more about the class than this failure does.
+			 * GetContext hands back a reference, so it is held rather than
+			 * tested in place. */
+			PY_OWNED(chained, PyException_GetContext(unresolved));
+
+			if (chained == NULL) {
 				PyException_SetContext(unresolved, py_move(&failure));
 			}
 		}
@@ -154,7 +169,11 @@ static PyObject * evaluate(PyObject * const annotate) {
 static bool names_an_unresolved_symbol(PyObject * const error) {
 	PyObject * found = NULL;
 
+	/* A failure to look is not "no name": the caller re-raises the NameError,
+	 * which would clear this. Chained onto it instead, so it survives. */
 	if (PyObject_GetOptionalAttrString(error, "name", &found) < 0) {
+		PyException_SetContext(error, PyErr_GetRaisedException());
+
 		return false;
 	}
 

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -50,6 +50,12 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * directly and what all-resolvable annotations -- nearly all of them -- want.
  * Only a name that does not resolve costs anything more.
  *
+ * The rescue costs a re-evaluation, and sometimes two: annotationlib rebuilds
+ * the callable and re-runs every annotation in the dict, so a class holding one
+ * forward reference evaluates its other annotations again. Plain 3.14 evaluates
+ * once and defers. Format.STRING would avoid it -- only the keys are read here
+ * -- but the values stop being objects, and #14's ClassVar check reads them.
+ *
  * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
  * a ForwardRef instead of raising, which is all we need since only the field
  * *names* and *order* are read here. It has to come from annotationlib, since a

--- a/src/annotations.c
+++ b/src/annotations.c
@@ -129,8 +129,11 @@ static PyObject * evaluate(PyObject * const annotate) {
 			 * name instead. */
 			if (failure != NULL && !PyErr_GivenExceptionMatches(failure, PyExc_Exception)) {
 				/* The exit wins, but the name still says which annotation the
-				 * rescue was for, so it goes behind rather than nowhere. */
-				if (PyException_GetContext(failure) == NULL) {
+				 * rescue was for, so it goes behind rather than nowhere. Held,
+				 * not tested in place: GetContext hands back a reference. */
+				PY_OWNED(already, PyException_GetContext(failure));
+
+				if (already == NULL) {
 					PyException_SetContext(failure, py_move(&unresolved));
 				}
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -92,6 +92,32 @@ class TestANonFunctionAnnotate:
         assert Built.__struct_fields__ == ("x", "y")
         assert Built(1, 2).y == 2
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="the escalation this drives is compiled out before 3.14",
+    )
+    def test_a_plain_function_can_reach_the_escalation_success_branch(self):
+        """The middle case, and the only one that returns through
+        `escalated != NULL` without a compiler-generated annotate.
+
+        annotationlib rebuilds the function against fake globals and calls the
+        copy with VALUE_WITH_FAKE_GLOBALS, where names resolve to stringifiers.
+        A hand-written annotate reaches this only by evaluating for that format
+        -- one that answers NotImplementedError to everything but VALUE drives
+        the failure branch instead, which is the parametrized test above.
+        """
+
+        def fake_globals_aware(format):
+            if format in (1, 2):
+                return {"x": Undefined, "y": int}  # noqa: F821 -- unresolvable on purpose
+
+            raise NotImplementedError
+
+        Built = type(Struct)("Built", (Struct,), {"__annotate__": fake_globals_aware})
+
+        assert Built.__struct_fields__ == ("x", "y")
+        assert Built(1, 2).y == 2
+
     def test_an_annotate_that_refuses_VALUE_is_refused_back(self):
         """PEP 649 makes VALUE the one format an __annotate__ must implement,
         and salix asks for it first. An older flow tried another format first

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -355,3 +355,23 @@ class TestForwardReferences:
 
         assert Deferred.__struct_fields__ == ("x",)
         assert Deferred(1).x == 1
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+def test_a_pre_existing_context_is_left_alone(monkeypatch):
+    """The rescue's own failure is attached only where the NameError arrived
+    without a chain. Held rather than tested in place, because
+    PyException_GetContext hands back a reference.
+    """
+
+    monkeypatch.setitem(sys.modules, "annotationlib", None)
+
+    try:
+        raise ValueError("earlier")
+    except ValueError:
+        with pytest.raises(NameError, match="Missing") as raised:
+
+            class Chained(Struct):
+                x: Missing  # noqa: F821
+
+    assert isinstance(raised.value.__context__, ValueError)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,80 @@
+"""Forward references, which salix reads without resolving.
+
+A field is a name and a position; the annotation beside it is never a type as
+far as salix is concerned. PEP 649 is what makes that distinction reachable,
+and every test here is a case where resolving would have failed.
+"""
+
+import sys
+
+import pytest
+
+from salix import Struct
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 14), reason="before PEP 649 an annotation is evaluated where it is written"
+)
+
+
+def test_a_bare_self_reference_is_a_field():
+    class Node(Struct):
+        value: int
+        nxt: Node = None  # noqa: F821
+
+    assert Node.__struct_fields__ == ("value", "nxt")
+    assert Node(1, Node(2)).nxt.value == 2
+
+
+def test_an_annotation_that_never_resolves_is_a_field_anyway():
+    class Bare(Struct):
+        x: NeverDefined  # noqa: F821
+
+    assert Bare.__struct_fields__ == ("x",)
+    assert Bare(1).x == 1
+
+
+def test_two_classes_may_refer_to_each_other():
+    class Left(Struct):
+        right: Right = None  # noqa: F821
+
+    class Right(Struct):
+        left: Left = None
+
+    assert Left(Right()).right.left is None
+
+
+def test_the_order_survives_a_mix_of_resolvable_and_not():
+    class Mixed(Struct):
+        first: int
+        second: Unresolvable  # noqa: F821
+        third: str
+
+    assert Mixed.__struct_fields__ == ("first", "second", "third")
+
+
+def test_a_subclass_may_forward_reference_too():
+    class Base(Struct):
+        x: int
+
+    class Child(Base):
+        y: Child = None  # noqa: F821
+
+    assert Child.__struct_fields__ == ("x", "y")
+
+
+def test_the_annotations_still_resolve_once_the_class_exists():
+    """Reading them early does not leave a ForwardRef behind for everyone else."""
+
+    class Node(Struct):
+        nxt: Node = None  # noqa: F821
+
+    assert Node.__annotations__ == {"nxt": Node}
+
+
+def test_an_annotation_that_fails_for_its_own_reasons_says_so():
+    """Not resolving a name is the exemption; arbitrary failure is not."""
+
+    with pytest.raises(ZeroDivisionError):
+
+        class Broken(Struct):
+            x: 1 / 0

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -54,9 +54,12 @@ class TestANonFunctionAnnotate:
 
     @pytest.mark.parametrize("wrap", ["plain", "partial", "callable"])
     def test_an_unresolvable_name_reports_itself_whatever_the_callable_is(self, wrap):
-        """A plain function reaches annotationlib and comes back with the
-        NameError; the other two are held back from it and raise the same thing
-        rather than an AttributeError about __globals__.
+        """On 3.14+ a plain function reaches annotationlib and comes back with
+        the NameError, while the other two are held back from it and raise the
+        same thing rather than an AttributeError about __globals__. Below 3.14
+        the escalation is compiled out and all three propagate it directly, so
+        the assertion holds everywhere and only the plain case exercises the
+        guard.
         """
 
         annotate = TestANonFunctionAnnotate.protocol_correct
@@ -86,6 +89,7 @@ class TestANonFunctionAnnotate:
         Built = type(Struct)("Built", (Struct,), {"__annotate__": functools.partial(annotate)})
 
         assert Built.__struct_fields__ == ("z",)
+        assert Built(1).z == 1
 
 
 @pytest.mark.skipif(
@@ -149,3 +153,41 @@ class TestForwardReferences:
 
             class Broken(Struct):
                 x: 1 / 0
+
+    def test_a_raised_NameError_is_arbitrary_failure_too(self):
+        """The exemption is the interpreter's failure to find a name, not the
+        exception type it uses to say so.
+        """
+
+        def boom():
+            raise NameError("boom")
+
+        with pytest.raises(NameError, match="boom"):
+
+            class Broken(Struct):
+                x: boom()
+
+    def test_the_name_that_did_not_resolve_survives_a_failed_escalation(self, monkeypatch):
+        """The escalation needs annotationlib, and the NameError it displaced is
+        the one worth reading if that import is what fails.
+        """
+
+        monkeypatch.setitem(sys.modules, "annotationlib", None)
+
+        with pytest.raises(NameError, match="Missing") as raised:
+
+            class Shadowed(Struct):
+                x: Missing  # noqa: F821
+
+        assert isinstance(raised.value.__context__, ImportError)
+
+    def test_an_unresolved_name_inside_a_larger_expression_still_defers(self):
+        """`.name` is filled in wherever the lookup was, so the exemption does
+        not stop at a bare annotation.
+        """
+
+        class Deferred(Struct):
+            x: Unresolvable + 1  # noqa: F821
+
+        assert Deferred.__struct_fields__ == ("x",)
+        assert Deferred(1).x == 1

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -13,6 +13,17 @@ import pytest
 from salix import Struct
 
 
+def boom():
+    """An annotation that fails for its own reasons, wearing a NameError.
+
+    Shared by the two tests that read the exemption's boundary from opposite
+    sides, so that moving the boundary cannot leave one of them agreeing with
+    the old answer.
+    """
+
+    raise NameError("boom")
+
+
 def test_a_hand_written_annotate_is_called_directly():
     """The only path an interpreter without PEP 649 has: no __annotations__ in
     the namespace, and an __annotate__ the class body wrote itself. Outside the
@@ -179,6 +190,63 @@ class TestANonFunctionAnnotate:
         with pytest.raises(NotImplementedError):
             type(Struct)("Inverted", (Struct,), {"__annotate__": inverted})
 
+    def test_a_VALUE_failure_of_any_other_kind_is_not_rescued_either(self):
+        """NotImplementedError is one of the shapes the removed flow retried,
+        not the shape. The gate is three conditions -- a plain function, a
+        NameError, a non-empty `.name` -- so anything failing VALUE for any
+        other reason now propagates even where the other arm would have
+        answered.
+        """
+
+        def refuses(format):
+            if format == 1:
+                raise ValueError("boom")
+
+            return {"x": int}
+
+        with pytest.raises(ValueError, match="boom"):
+            type(Struct)("Refuses", (Struct,), {"__annotate__": refuses})
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="the discriminator this pins is compiled out before 3.14",
+    )
+    def test_a_hand_written_empty_name_is_not_a_forward_reference_either(self):
+        """The generated-annotate half is
+        `test_an_empty_name_is_not_a_forward_reference`. This is the shape where
+        the escalation would have answered, so the narrowing is the only thing
+        stopping it and deleting the length check makes this build.
+        """
+
+        def forged(format):
+            if format == 1:
+                raise NameError(name="")
+
+            return {"x": int}
+
+        with pytest.raises(NameError):
+            type(Struct)("Forged", (Struct,), {"__annotate__": forged})
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="the escalation this describes is compiled out before 3.14",
+    )
+    def test_an_escalation_that_answers_with_a_non_dict_loses_the_name(self):
+        """FORWARDREF's answer is handed back unchecked, so a non-dict is
+        refused downstream by the `__annotations__` check and the name that
+        started the rescue is gone from the message. The cost of not validating
+        here, pinned rather than left to be found.
+        """
+
+        def answers_a_list(format):
+            if format == 1:
+                raise NameError("nope", name="Missing")
+
+            return ["x"]
+
+        with pytest.raises(TypeError, match="__annotations__ must be a dict"):
+            type(Struct)("Listed", (Struct,), {"__annotate__": answers_a_list})
+
     def test_a_partial_is_accepted_when_its_names_resolve(self):
         def annotate(format):
             return {"z": int}
@@ -309,9 +377,6 @@ class TestForwardReferences:
         back the whole dict or nothing.
         """
 
-        def boom():
-            raise NameError("boom")
-
         class Rescued(Struct):
             x: Missing  # noqa: F821
             y: boom()
@@ -324,13 +389,31 @@ class TestForwardReferences:
                 y: boom()
                 x: Missing  # noqa: F821
 
+    def test_the_annotations_beside_a_forward_reference_evaluate_twice(self):
+        """annotationlib rebuilds the callable and re-runs the whole dict, so
+        the siblings of an unresolved name are evaluated a second time. Plain
+        3.14 evaluates once and defers, so this is a divergence, and the count
+        is asserted so that changing it has to be deliberate.
+        """
+
+        evaluations = []
+
+        def counted():
+            evaluations.append(1)
+
+            return int
+
+        class Mixed(Struct):
+            a: counted()
+            b: Missing  # noqa: F821
+
+        assert Mixed.__struct_fields__ == ("a", "b")
+        assert len(evaluations) == 2
+
     def test_a_raised_NameError_is_arbitrary_failure_too(self):
         """The exemption is the interpreter's failure to find a name, not the
         exception type it uses to say so.
         """
-
-        def boom():
-            raise NameError("boom")
 
         with pytest.raises(NameError, match="boom"):
 
@@ -366,11 +449,23 @@ class TestForwardReferences:
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
 def test_a_pre_existing_context_is_left_alone(monkeypatch):
     """The rescue's own failure is attached only where the NameError arrived
-    without a chain. Held rather than tested in place, because
-    PyException_GetContext hands back a reference.
+    without a chain.
+
+    A stand-in for annotationlib records the call, because the ValueError this
+    checks for is put there by the enclosing `except` block and would be there
+    in a world where no rescue ran at all.
     """
 
-    monkeypatch.setitem(sys.modules, "annotationlib", None)
+    formats = []
+
+    class Recording:
+        @staticmethod
+        def call_annotate_function(annotate, format):
+            formats.append(format)
+
+            raise ModuleNotFoundError("no annotationlib")
+
+    monkeypatch.setitem(sys.modules, "annotationlib", Recording)
 
     try:
         raise ValueError("earlier")
@@ -380,7 +475,31 @@ def test_a_pre_existing_context_is_left_alone(monkeypatch):
             class Chained(Struct):
                 x: Missing  # noqa: F821
 
+    assert formats == [3]
     assert isinstance(raised.value.__context__, ValueError)
+    assert raised.value.__context__.__context__ is None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+def test_a_cause_only_chain_counts_as_a_chain(monkeypatch):
+    """`raise ... from` leaves `__context__` empty, so reading only that field
+    would append the rescue's failure beside a cause the raising code chose.
+    Both fields are read, and neither is written over.
+    """
+
+    monkeypatch.setitem(sys.modules, "annotationlib", None)
+
+    def annotate(format):
+        if format == 1:
+            raise NameError("nope", name="Missing") from ValueError("the cause")
+
+        return {"x": int}
+
+    with pytest.raises(NameError, match="nope") as raised:
+        type(Struct)("Caused", (Struct,), {"__annotate__": annotate})
+
+    assert isinstance(raised.value.__cause__, ValueError)
+    assert raised.value.__context__ is None
 
 
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
@@ -396,5 +515,75 @@ def test_an_interrupt_during_the_rescue_is_not_demoted_to_context():
 
         raise KeyboardInterrupt
 
-    with pytest.raises(KeyboardInterrupt):
+    with pytest.raises(KeyboardInterrupt) as raised:
         type(Struct)("Interrupted", (Struct,), {"__annotate__": annotate})
+
+    assert isinstance(raised.value.__context__, NameError)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+def test_an_interrupt_that_arrives_chained_keeps_the_chain_it_came_with():
+    """The other half of the same rule, and the half where the name is lost: an
+    exit raised from inside an `except` block already carries a chain, and the
+    displaced NameError is dropped rather than put somewhere it would displace
+    what the exit came with.
+    """
+
+    def annotate(format):
+        if format == 1:
+            raise NameError(name="Missing")
+
+        try:
+            raise ValueError("earlier")
+        except ValueError:
+            raise KeyboardInterrupt  # noqa: B904 -- the shape under test
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        type(Struct)("Interrupted", (Struct,), {"__annotate__": annotate})
+
+    assert isinstance(raised.value.__context__, ValueError)
+    assert raised.value.__context__.__context__ is None
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="the discriminator this drives is compiled out before 3.14",
+)
+class TestAHostileNameAttribute:
+    """Reading `.name` runs the attribute protocol on an exception whose class
+    the annotation author wrote, so looking can raise. What it raises gets the
+    same rule as a rescue failure rather than one of its own.
+    """
+
+    @staticmethod
+    def raising(error):
+        def annotate(format):
+            raise error
+
+        return annotate
+
+    def test_an_exit_from_the_lookup_wins(self):
+        class Hostile(NameError):
+            def __getattribute__(self, attribute):
+                if attribute == "name":
+                    raise KeyboardInterrupt
+
+                return super().__getattribute__(attribute)
+
+        with pytest.raises(KeyboardInterrupt) as raised:
+            type(Struct)("H", (Struct,), {"__annotate__": self.raising(Hostile("x"))})
+
+        assert isinstance(raised.value.__context__, Hostile)
+
+    def test_an_ordinary_failure_from_the_lookup_loses(self):
+        class Hostile(NameError):
+            def __getattribute__(self, attribute):
+                if attribute == "name":
+                    raise RuntimeError("looking hurt")
+
+                return super().__getattribute__(attribute)
+
+        with pytest.raises(Hostile) as raised:
+            type(Struct)("H", (Struct,), {"__annotate__": self.raising(Hostile("x"))})
+
+        assert isinstance(raised.value.__context__, RuntimeError)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -54,12 +54,14 @@ class TestANonFunctionAnnotate:
 
     @pytest.mark.parametrize("wrap", ["plain", "partial", "callable"])
     def test_an_unresolvable_name_reports_itself_whatever_the_callable_is(self, wrap):
-        """On 3.14+ a plain function reaches annotationlib and comes back with
-        the NameError, while the other two are held back from it and raise the
-        same thing rather than an AttributeError about __globals__. Below 3.14
-        the escalation is compiled out and all three propagate it directly, so
-        the assertion holds everywhere and only the plain case exercises the
-        guard.
+        """All three surface the NameError rather than an AttributeError about
+        __globals__, which is what the PyFunction_Check guard is for.
+
+        What this cannot detect is the escalation being deleted: a
+        protocol-correct annotate refuses VALUE_WITH_FAKE_GLOBALS too, so
+        annotationlib falls back to a real-globals VALUE re-run and raises the
+        same NameError the direct call would have. TestForwardReferences is
+        where the escalation has to exist for the class to build at all.
         """
 
         annotate = TestANonFunctionAnnotate.protocol_correct
@@ -81,6 +83,22 @@ class TestANonFunctionAnnotate:
 
         assert Built.__struct_fields__ == ("x", "y")
         assert Built(1, 2).y == 2
+
+    def test_an_annotate_that_refuses_VALUE_is_refused_back(self):
+        """PEP 649 makes VALUE the one format an __annotate__ must implement,
+        and salix asks for it first. An older flow tried another format first
+        and fell back, so an annotate implementing only that one built its
+        class; it does not any more, and this is the shape that changed.
+        """
+
+        def inverted(format):
+            if format == 1:
+                raise NotImplementedError
+
+            return {"x": int}
+
+        with pytest.raises(NotImplementedError):
+            type(Struct)("Inverted", (Struct,), {"__annotate__": inverted})
 
     def test_a_partial_is_accepted_when_its_names_resolve(self):
         def annotate(format):
@@ -153,6 +171,35 @@ class TestForwardReferences:
 
             class Broken(Struct):
                 x: 1 / 0
+
+    def test_a_second_bad_annotation_does_not_bury_the_first(self):
+        """The escalation re-evaluates every annotation, so a later one that
+        fails for its own reasons raises during the rescue of the earlier one.
+        The name that did not resolve is what the reader needs.
+        """
+
+        with pytest.raises(NameError, match="Missing") as raised:
+
+            class Broken(Struct):
+                x: Missing  # noqa: F821
+                y: 1 / 0
+
+        assert isinstance(raised.value.__context__, ZeroDivisionError)
+
+    def test_a_NameError_from_inside_a_called_function_still_defers(self):
+        """`.name` is filled in wherever the lookup failed, including inside a
+        callee, so a buggy helper reads as a forward reference and the class
+        builds. Plain 3.14 defers this too -- the divergence is the explicit
+        `raise NameError`, which salix propagates and CPython would defer.
+        """
+
+        def helper():
+            return undefined_inside  # noqa: F821
+
+        class Deferred(Struct):
+            x: helper()
+
+        assert Deferred.__struct_fields__ == ("x",)
 
     def test_a_raised_NameError_is_arbitrary_failure_too(self):
         """The exemption is the interpreter's failure to find a name, not the

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -138,11 +138,13 @@ class TestANonFunctionAnnotate:
             if format == 1:
                 raise NameError("nope", name="nope")
 
-            return {"only_this": int}
+            # Keyed by format, so this fails rather than passes if the
+            # escalation ever asks for STRING (4) instead of FORWARDREF (3).
+            return {f"answered_{format}": int}
 
         Built = type(Struct)("Built", (Struct,), {"__annotate__": inconsistent})
 
-        assert Built.__struct_fields__ == ("only_this",)
+        assert Built.__struct_fields__ == ("answered_3",)
 
     @pytest.mark.skipif(
         sys.version_info < (3, 14),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -615,3 +615,72 @@ class TestAHostileNameAttribute:
             type(Struct)("H", (Struct,), {"__annotate__": self.raising(Hostile("x"))})
 
         assert isinstance(raised.value.__context__, RuntimeError)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+class TestAHostileSuppressionFlag:
+    """`__suppress_context__` has no C accessor, so reading it runs the
+    attribute protocol on the same author-written class. It gets the same rule
+    the `.name` lookup gets, rather than a quieter one of its own.
+    """
+
+    @staticmethod
+    def raising(error, monkeypatch):
+        monkeypatch.setitem(sys.modules, "annotationlib", None)
+
+        def annotate(format):
+            if format == 1:
+                raise error
+
+            return {"x": int}
+
+        return annotate
+
+    def test_an_exit_while_reading_the_flag_wins(self, monkeypatch):
+        class Hostile(NameError):
+            def __getattribute__(self, attribute):
+                if attribute == "__suppress_context__":
+                    raise KeyboardInterrupt
+
+                return super().__getattribute__(attribute)
+
+        error = Hostile("nope", name="Missing")
+
+        with pytest.raises(KeyboardInterrupt) as raised:
+            type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
+
+        assert isinstance(raised.value.__context__, Hostile)
+
+    def test_an_ordinary_failure_while_reading_the_flag_is_dropped(self, monkeypatch):
+        """It is a failure to read a flag on the way to reporting something
+        that matters more, so the name is raised and nothing goes behind it.
+        """
+
+        class Hostile(NameError):
+            def __getattribute__(self, attribute):
+                if attribute == "__suppress_context__":
+                    raise RuntimeError("looking hurt")
+
+                return super().__getattribute__(attribute)
+
+        error = Hostile("nope", name="Missing")
+
+        with pytest.raises(Hostile) as raised:
+            type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
+
+        assert raised.value.__context__ is None
+
+    def test_a_truthy_flag_counts_the_way_the_interpreter_counts_it(self, monkeypatch):
+        """CPython's traceback printer asks the flag for its truth, not for
+        identity with True, so a shadowed truthy value means the same here.
+        """
+
+        class Hostile(NameError):
+            __suppress_context__ = 1
+
+        error = Hostile("nope", name="Missing")
+
+        with pytest.raises(Hostile) as raised:
+            type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
+
+        assert raised.value.__context__ is None

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -618,16 +618,15 @@ class TestAHostileNameAttribute:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
-class TestAHostileSuppressionFlag:
-    """`__suppress_context__` has no C accessor, so reading it runs the
-    attribute protocol on the same author-written class as the `.name` lookup.
+class TestAShadowedSuppressionFlag:
+    """The suppression flag is read as the field `raise ... from None` writes,
+    so the attribute of the same name is never asked for. What the annotation
+    author's class says through that attribute -- truthy, falsy, or an
+    exception -- reaches nothing here, and only the raiser is heard.
 
-    An exit from either wins, which is the half the two reads share. An
-    ordinary failure does not, and the two tests below are the difference: the
-    `.name` read asks what to raise, so its failure goes behind the NameError
-    (`test_an_ordinary_failure_from_the_lookup_loses`); this read asks whether
-    the winner will accept a `__context__`, and a read that raised has not said
-    yes, so nothing is attached -- including itself.
+    The `.name` read is the other way round, because there is no field to read:
+    see TestAHostileNameAttribute, where a hostile lookup does decide the
+    outcome.
     """
 
     @staticmethod
@@ -642,7 +641,7 @@ class TestAHostileSuppressionFlag:
 
         return annotate
 
-    def test_an_exit_while_reading_the_flag_wins(self, monkeypatch):
+    def test_a_flag_that_raises_when_read_is_not_read(self, monkeypatch):
         class Hostile(NameError):
             def __getattribute__(self, attribute):
                 if attribute == "__suppress_context__":
@@ -652,41 +651,41 @@ class TestAHostileSuppressionFlag:
 
         error = Hostile("nope", name="Missing")
 
-        with pytest.raises(KeyboardInterrupt) as raised:
-            type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
-
-        assert isinstance(raised.value.__context__, Hostile)
-
-    def test_an_ordinary_failure_while_reading_the_flag_is_dropped(self, monkeypatch):
-        """It is a failure to read a flag on the way to reporting something
-        that matters more, so the name is raised and nothing goes behind it.
-        """
-
-        class Hostile(NameError):
-            def __getattribute__(self, attribute):
-                if attribute == "__suppress_context__":
-                    raise RuntimeError("looking hurt")
-
-                return super().__getattribute__(attribute)
-
-        error = Hostile("nope", name="Missing")
-
         with pytest.raises(Hostile) as raised:
             type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
 
-        assert raised.value.__context__ is None
+        assert isinstance(raised.value.__context__, ImportError)
 
-    def test_a_truthy_flag_counts_the_way_the_interpreter_counts_it(self, monkeypatch):
-        """CPython's traceback printer asks the flag for its truth, not for
-        identity with True, so a shadowed truthy value means the same here.
-        """
-
-        class Hostile(NameError):
+    def test_a_truthy_shadow_does_not_refuse_the_context(self, monkeypatch):
+        class Shadowed(NameError):
             __suppress_context__ = 1
 
-        error = Hostile("nope", name="Missing")
+        error = Shadowed("nope", name="Missing")
 
-        with pytest.raises(Hostile) as raised:
+        with pytest.raises(Shadowed) as raised:
             type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
 
+        assert raised.value.__suppress_context__ == 1
+        assert isinstance(raised.value.__context__, ImportError)
+
+    def test_a_falsy_shadow_does_not_undo_a_from_None(self, monkeypatch):
+        """The shape the attribute read got wrong: `from None` sets the field,
+        the shadow answers for the attribute, and the two disagree.
+        """
+
+        class Shadowed(NameError):
+            __suppress_context__ = 0
+
+        monkeypatch.setitem(sys.modules, "annotationlib", None)
+
+        def annotate(format):
+            if format == 1:
+                raise Shadowed("nope", name="Missing") from None
+
+            return {"x": int}
+
+        with pytest.raises(Shadowed) as raised:
+            type(Struct)("H", (Struct,), {"__annotate__": annotate})
+
+        assert raised.value.__suppress_context__ == 0
         assert raised.value.__context__ is None

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -2,7 +2,7 @@
 
 A field is a name and a position; the annotation beside it is never a type as
 far as salix is concerned. PEP 649 is what makes that distinction reachable,
-and every test here is a case where resolving would have failed.
+and every test in the class below is a case where resolving would have failed.
 """
 
 import sys
@@ -11,70 +11,80 @@ import pytest
 
 from salix import Struct
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 14), reason="before PEP 649 an annotation is evaluated where it is written"
+
+def test_a_hand_written_annotate_is_called_directly():
+    """The only path an interpreter without PEP 649 has: no __annotations__ in
+    the namespace, and an __annotate__ the class body wrote itself. Outside the
+    class below because that pre-3.14 branch has nothing else covering it.
+    """
+
+    def annotate(format):
+        return {"x": int, "y": int}
+
+    Manual = type(Struct)("Manual", (Struct,), {"__annotate__": annotate})
+
+    assert Manual.__struct_fields__ == ("x", "y")
+    assert Manual(1, 2).x == 1
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="before PEP 649 an annotation is evaluated where it is written",
 )
+class TestForwardReferences:
+    def test_a_bare_self_reference_is_a_field(self):
+        class Node(Struct):
+            value: int
+            nxt: Node = None  # noqa: F821
 
+        assert Node.__struct_fields__ == ("value", "nxt")
+        assert Node(1, Node(2)).nxt.value == 2
 
-def test_a_bare_self_reference_is_a_field():
-    class Node(Struct):
-        value: int
-        nxt: Node = None  # noqa: F821
+    def test_an_annotation_that_never_resolves_is_a_field_anyway(self):
+        class Bare(Struct):
+            x: NeverDefined  # noqa: F821
 
-    assert Node.__struct_fields__ == ("value", "nxt")
-    assert Node(1, Node(2)).nxt.value == 2
+        assert Bare.__struct_fields__ == ("x",)
+        assert Bare(1).x == 1
 
+    def test_two_classes_may_refer_to_each_other(self):
+        class Left(Struct):
+            right: Right = None  # noqa: F821
 
-def test_an_annotation_that_never_resolves_is_a_field_anyway():
-    class Bare(Struct):
-        x: NeverDefined  # noqa: F821
+        class Right(Struct):
+            left: Left = None
 
-    assert Bare.__struct_fields__ == ("x",)
-    assert Bare(1).x == 1
+        assert Left(Right()).right.left is None
 
+    def test_the_order_survives_a_mix_of_resolvable_and_not(self):
+        class Mixed(Struct):
+            first: int
+            second: Unresolvable  # noqa: F821
+            third: str
 
-def test_two_classes_may_refer_to_each_other():
-    class Left(Struct):
-        right: Right = None  # noqa: F821
+        assert Mixed.__struct_fields__ == ("first", "second", "third")
 
-    class Right(Struct):
-        left: Left = None
+    def test_a_subclass_may_forward_reference_too(self):
+        class Base(Struct):
+            x: int
 
-    assert Left(Right()).right.left is None
+        class Child(Base):
+            y: Child = None  # noqa: F821
 
+        assert Child.__struct_fields__ == ("x", "y")
 
-def test_the_order_survives_a_mix_of_resolvable_and_not():
-    class Mixed(Struct):
-        first: int
-        second: Unresolvable  # noqa: F821
-        third: str
+    def test_the_annotations_still_resolve_once_the_class_exists(self):
+        """Reading them early does not leave a ForwardRef behind for everyone else."""
 
-    assert Mixed.__struct_fields__ == ("first", "second", "third")
+        class Node(Struct):
+            nxt: Node = None  # noqa: F821
 
+        assert Node.__annotations__ == {"nxt": Node}
 
-def test_a_subclass_may_forward_reference_too():
-    class Base(Struct):
-        x: int
+    def test_an_annotation_that_fails_for_its_own_reasons_says_so(self):
+        """Not resolving a name is the exemption; arbitrary failure is not."""
 
-    class Child(Base):
-        y: Child = None  # noqa: F821
+        with pytest.raises(ZeroDivisionError):
 
-    assert Child.__struct_fields__ == ("x", "y")
-
-
-def test_the_annotations_still_resolve_once_the_class_exists():
-    """Reading them early does not leave a ForwardRef behind for everyone else."""
-
-    class Node(Struct):
-        nxt: Node = None  # noqa: F821
-
-    assert Node.__annotations__ == {"nxt": Node}
-
-
-def test_an_annotation_that_fails_for_its_own_reasons_says_so():
-    """Not resolving a name is the exemption; arbitrary failure is not."""
-
-    with pytest.raises(ZeroDivisionError):
-
-        class Broken(Struct):
-            x: 1 / 0
+            class Broken(Struct):
+                x: 1 / 0

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -118,6 +118,30 @@ class TestANonFunctionAnnotate:
         assert Built.__struct_fields__ == ("x", "y")
         assert Built(1, 2).y == 2
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="the escalation this describes is compiled out before 3.14",
+    )
+    def test_the_escalation_answers_with_what_forwardref_returned(self):
+        """A hand-written annotate that answers different keys for the two
+        formats gets the FORWARDREF ones, because that is the call that
+        succeeded -- there is no VALUE dict to prefer, only the NameError it
+        raised.
+
+        Diffing the two would mean asking twice on every rescue to catch an
+        annotate that contradicts itself. Recorded rather than guarded.
+        """
+
+        def inconsistent(format):
+            if format == 1:
+                raise NameError("nope", name="nope")
+
+            return {"only_this": int}
+
+        Built = type(Struct)("Built", (Struct,), {"__annotate__": inconsistent})
+
+        assert Built.__struct_fields__ == ("only_this",)
+
     def test_an_annotate_that_refuses_VALUE_is_refused_back(self):
         """PEP 649 makes VALUE the one format an __annotate__ must implement,
         and salix asks for it first. An older flow tried another format first

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -620,8 +620,14 @@ class TestAHostileNameAttribute:
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
 class TestAHostileSuppressionFlag:
     """`__suppress_context__` has no C accessor, so reading it runs the
-    attribute protocol on the same author-written class. It gets the same rule
-    the `.name` lookup gets, rather than a quieter one of its own.
+    attribute protocol on the same author-written class as the `.name` lookup.
+
+    An exit from either wins, which is the half the two reads share. An
+    ordinary failure does not, and the two tests below are the difference: the
+    `.name` read asks what to raise, so its failure goes behind the NameError
+    (`test_an_ordinary_failure_from_the_lookup_loses`); this read asks whether
+    the winner will accept a `__context__`, and a read that raised has not said
+    yes, so nothing is attached -- including itself.
     """
 
     @staticmethod

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -71,8 +71,15 @@ class TestANonFunctionAnnotate:
             "callable": TestANonFunctionAnnotate.wrapped_in_an_object(annotate),
         }[wrap]
 
-        with pytest.raises(NameError, match="Undefined"):
+        with pytest.raises(NameError, match="Undefined") as raised:
             type(Struct)("Wrapped", (Struct,), {"__annotate__": wrapped})
+
+        # The discriminator the message cannot carry: only the plain function
+        # reaches annotationlib, and only it comes back with a __context__ from
+        # having done so. Below 3.14 nothing escalates, so nobody has one.
+        escalates = wrap == "plain" and sys.version_info >= (3, 14)
+
+        assert (raised.value.__context__ is not None) is escalates
 
     def test_a_callable_object_is_accepted_when_its_names_resolve(self):
         class Annotate:
@@ -191,15 +198,62 @@ class TestForwardReferences:
         callee, so a buggy helper reads as a forward reference and the class
         builds. Plain 3.14 defers this too -- the divergence is the explicit
         `raise NameError`, which salix propagates and CPython would defer.
+
+        The call count is asserted rather than the mechanism described: the
+        rescue really does re-run the annotation, helper included.
         """
 
+        calls = []
+
         def helper():
+            calls.append(1)
             return undefined_inside  # noqa: F821
 
         class Deferred(Struct):
             x: helper()
 
         assert Deferred.__struct_fields__ == ("x",)
+        assert len(calls) > 1
+
+    def test_a_forged_name_attribute_reads_as_a_forward_reference(self):
+        """The discriminator asks whether `.name` is set, and the keyword form
+        sets it -- so this is the exemption's boundary, not a wall. Pinned
+        because the positional form beside it propagates, and the difference is
+        one word in the raising code.
+        """
+
+        def forged():
+            raise NameError(name="x")
+
+        class Built(Struct):
+            v: forged()
+
+        assert Built.__struct_fields__ == ("v",)
+
+    def test_the_exemption_is_order_dependent(self):
+        """The rescue is all-or-nothing: it re-evaluates every annotation and
+        stringifies what it cannot resolve, so an arbitrary failure that comes
+        *after* a forward reference is swallowed with it, and the same pair in
+        the other order propagates.
+
+        Not fixable while the rescue goes through `__annotate__`, which hands
+        back the whole dict or nothing.
+        """
+
+        def boom():
+            raise NameError("boom")
+
+        class Rescued(Struct):
+            x: Missing  # noqa: F821
+            y: boom()
+
+        assert Rescued.__struct_fields__ == ("x", "y")
+
+        with pytest.raises(NameError, match="boom"):
+
+            class Propagates(Struct):
+                y: boom()
+                x: Missing  # noqa: F821
 
     def test_a_raised_NameError_is_arbitrary_failure_too(self):
         """The exemption is the interpreter's failure to find a name, not the

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -97,8 +97,10 @@ class TestANonFunctionAnnotate:
         reason="the escalation this drives is compiled out before 3.14",
     )
     def test_a_plain_function_can_reach_the_escalation_success_branch(self):
-        """The middle case, and the only one that returns through
-        `escalated != NULL` without a compiler-generated annotate.
+        """A hand-written annotate returning through `escalated != NULL`.
+        `test_the_escalation_answers_with_what_forwardref_returned` is the
+        other; this one is about reaching the branch, that one about what comes
+        back from it.
 
         annotationlib rebuilds the function against fake globals and calls the
         copy with VALUE_WITH_FAKE_GLOBALS, where names resolve to stringifiers.
@@ -141,6 +143,19 @@ class TestANonFunctionAnnotate:
         Built = type(Struct)("Built", (Struct,), {"__annotate__": inconsistent})
 
         assert Built.__struct_fields__ == ("only_this",)
+
+    def test_an_empty_name_is_not_a_forward_reference(self):
+        """`.name` set but empty names no symbol, so it is not the interpreter
+        saying a lookup failed. The boundary of the discriminator, pinned.
+        """
+
+        def forged():
+            raise NameError(name="")
+
+        with pytest.raises(NameError):
+
+            class Refused(Struct):
+                v: forged()
 
     def test_an_annotate_that_refuses_VALUE_is_refused_back(self):
         """PEP 649 makes VALUE the one format an __annotate__ must implement,

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -375,3 +375,24 @@ def test_a_pre_existing_context_is_left_alone(monkeypatch):
                 x: Missing  # noqa: F821
 
     assert isinstance(raised.value.__context__, ValueError)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+def test_an_interrupt_during_the_rescue_is_not_demoted_to_context():
+    """A rescue failure becomes the NameError's `__context__`; an exit is not a
+    failure to diagnose. Swallowing KeyboardInterrupt to report a name would be
+    the worst of both.
+    """
+
+    class Exits:
+        def __getattr__(self, name: str) -> object:
+            raise KeyboardInterrupt
+
+    def annotate(format):
+        if format == 1:
+            raise NameError(name="Missing")
+
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        type(Struct)("Interrupted", (Struct,), {"__annotate__": annotate})

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -244,8 +244,10 @@ class TestANonFunctionAnnotate:
 
             return ["x"]
 
-        with pytest.raises(TypeError, match="__annotations__ must be a dict"):
+        with pytest.raises(TypeError, match="__annotations__ must be a dict") as raised:
             type(Struct)("Listed", (Struct,), {"__annotate__": answers_a_list})
+
+        assert "Missing" not in str(raised.value)
 
     def test_a_partial_is_accepted_when_its_names_resolve(self):
         def annotate(format):
@@ -550,6 +552,31 @@ def test_an_interrupt_during_the_rescue_is_not_demoted_to_context():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+def test_an_interrupt_that_refuses_a_chain_keeps_refusing_it():
+    """Where the exit rule and the suppression field meet: the interrupt wins,
+    and then the field it was raised with decides whether the displaced name
+    goes behind it. `from None` says no, and nothing is attached.
+
+    Neither of the two tests around this reaches it -- one raises a bare
+    interrupt (the name is attached) and one raises it inside an `except` (the
+    name is dropped for a chain that already exists). This is the third answer,
+    and the only one that reads the field.
+    """
+
+    def annotate(format):
+        if format == 1:
+            raise NameError(name="Missing")
+
+        raise KeyboardInterrupt from None
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        type(Struct)("Interrupted", (Struct,), {"__annotate__": annotate})
+
+    assert raised.value.__context__ is None
+    assert raised.value.__suppress_context__ is True
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
 def test_an_interrupt_that_arrives_chained_keeps_the_chain_it_came_with():
     """The other half of the same rule, and the half where the name is lost: an
     exit raised from inside an `except` block already carries a chain, and the
@@ -641,19 +668,33 @@ class TestAShadowedSuppressionFlag:
 
         return annotate
 
-    def test_a_flag_that_raises_when_read_is_not_read(self, monkeypatch):
-        class Hostile(NameError):
+    def test_the_attribute_is_not_read_at_all(self, monkeypatch):
+        """Counted rather than raised, and that is the finding this replaces: a
+        `__getattribute__` that raises on the flag takes the *reporter* down
+        with it, because `traceback.py` reads `__suppress_context__` while it
+        formats. So the version of this test that raised could not report its
+        own failure -- it ended the pytest session instead.
+
+        Counting says the same thing and says it directly. `reads` is the
+        design: the field is what is consulted, so the attribute is never asked
+        for, by anyone, on the way to the answer below.
+        """
+
+        reads = []
+
+        class Watched(NameError):
             def __getattribute__(self, attribute):
                 if attribute == "__suppress_context__":
-                    raise KeyboardInterrupt
+                    reads.append(attribute)
 
                 return super().__getattribute__(attribute)
 
-        error = Hostile("nope", name="Missing")
+        error = Watched("nope", name="Missing")
 
-        with pytest.raises(Hostile) as raised:
+        with pytest.raises(Watched) as raised:
             type(Struct)("H", (Struct,), {"__annotate__": self.raising(error, monkeypatch)})
 
+        assert reads == []
         assert isinstance(raised.value.__context__, ImportError)
 
     def test_a_truthy_shadow_does_not_refuse_the_context(self, monkeypatch):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -389,11 +389,15 @@ class TestForwardReferences:
                 y: boom()
                 x: Missing  # noqa: F821
 
-    def test_the_annotations_beside_a_forward_reference_evaluate_twice(self):
+    def test_the_annotations_beside_a_forward_reference_evaluate_again(self):
         """annotationlib rebuilds the callable and re-runs the whole dict, so
-        the siblings of an unresolved name are evaluated a second time. Plain
-        3.14 evaluates once and defers, so this is a divergence, and the count
-        is asserted so that changing it has to be deliberate.
+        the siblings of an unresolved name are evaluated a second time where
+        plain 3.14 evaluates once and defers. That divergence is the claim.
+
+        Not the number: how many times annotationlib re-runs the annotation is
+        its business, which is what
+        `test_a_NameError_from_inside_a_called_function_still_defers` says a few
+        tests up. Asserting 2 here would have made this file hold two policies.
         """
 
         evaluations = []
@@ -408,7 +412,7 @@ class TestForwardReferences:
             b: Missing  # noqa: F821
 
         assert Mixed.__struct_fields__ == ("a", "b")
-        assert len(evaluations) == 2
+        assert len(evaluations) > 1
 
     def test_a_raised_NameError_is_arbitrary_failure_too(self):
         """The exemption is the interpreter's failure to find a name, not the
@@ -499,6 +503,30 @@ def test_a_cause_only_chain_counts_as_a_chain(monkeypatch):
         type(Struct)("Caused", (Struct,), {"__annotate__": annotate})
 
     assert isinstance(raised.value.__cause__, ValueError)
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="no escalation before 3.14")
+def test_a_suppressed_chain_counts_as_a_chain_too(monkeypatch):
+    """The mirror of the test above, and the shape neither exception field can
+    see: `from None` stores None as the cause, which reads back as no cause at
+    all. It is the loudest way to ask for nothing to be attached, so the
+    suppression flag is read as well.
+    """
+
+    monkeypatch.setitem(sys.modules, "annotationlib", None)
+
+    def annotate(format):
+        if format == 1:
+            raise NameError("nope", name="Missing") from None
+
+        return {"x": int}
+
+    with pytest.raises(NameError, match="nope") as raised:
+        type(Struct)("Suppressed", (Struct,), {"__annotate__": annotate})
+
+    assert raised.value.__suppress_context__ is True
+    assert raised.value.__cause__ is None
     assert raised.value.__context__ is None
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -144,6 +144,10 @@ class TestANonFunctionAnnotate:
 
         assert Built.__struct_fields__ == ("only_this",)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="the discriminator this pins is compiled out before 3.14",
+    )
     def test_an_empty_name_is_not_a_forward_reference(self):
         """`.name` set but empty names no symbol, so it is not the interpreter
         saying a lookup failed. The boundary of the discriminator, pinned.
@@ -383,10 +387,6 @@ def test_an_interrupt_during_the_rescue_is_not_demoted_to_context():
     failure to diagnose. Swallowing KeyboardInterrupt to report a name would be
     the worst of both.
     """
-
-    class Exits:
-        def __getattr__(self, name: str) -> object:
-            raise KeyboardInterrupt
 
     def annotate(format):
         if format == 1:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5,6 +5,7 @@ far as salix is concerned. PEP 649 is what makes that distinction reachable,
 and every test in the class below is a case where resolving would have failed.
 """
 
+import functools
 import sys
 
 import pytest
@@ -25,6 +26,66 @@ def test_a_hand_written_annotate_is_called_directly():
 
     assert Manual.__struct_fields__ == ("x", "y")
     assert Manual(1, 2).x == 1
+
+
+class TestANonFunctionAnnotate:
+    """annotationlib's FORWARDREF path rebuilds the callable from its
+    __globals__ and __code__, which only a plain function has. Anything else is
+    left unescalated so it raises what a plain function raises, rather than an
+    AttributeError about the missing attribute.
+    """
+
+    @staticmethod
+    def protocol_correct(format):
+        """PEP 649 says: implement VALUE, raise for the rest."""
+
+        if format != 1:
+            raise NotImplementedError
+
+        return {"x": Undefined}  # noqa: F821 -- unresolvable on purpose
+
+    @staticmethod
+    def wrapped_in_an_object(annotate):
+        class Wrapper:
+            def __call__(self, format):
+                return annotate(format)
+
+        return Wrapper()
+
+    @pytest.mark.parametrize("wrap", ["plain", "partial", "callable"])
+    def test_an_unresolvable_name_reports_itself_whatever_the_callable_is(self, wrap):
+        """A plain function reaches annotationlib and comes back with the
+        NameError; the other two are held back from it and raise the same thing
+        rather than an AttributeError about __globals__.
+        """
+
+        annotate = TestANonFunctionAnnotate.protocol_correct
+        wrapped = {
+            "plain": annotate,
+            "partial": functools.partial(annotate),
+            "callable": TestANonFunctionAnnotate.wrapped_in_an_object(annotate),
+        }[wrap]
+
+        with pytest.raises(NameError, match="Undefined"):
+            type(Struct)("Wrapped", (Struct,), {"__annotate__": wrapped})
+
+    def test_a_callable_object_is_accepted_when_its_names_resolve(self):
+        class Annotate:
+            def __call__(self, format):
+                return {"x": int, "y": int}
+
+        Built = type(Struct)("Built", (Struct,), {"__annotate__": Annotate()})
+
+        assert Built.__struct_fields__ == ("x", "y")
+        assert Built(1, 2).y == 2
+
+    def test_a_partial_is_accepted_when_its_names_resolve(self):
+        def annotate(format):
+            return {"z": int}
+
+        Built = type(Struct)("Built", (Struct,), {"__annotate__": functools.partial(annotate)})
+
+        assert Built.__struct_fields__ == ("z",)
 
 
 @pytest.mark.skipif(

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -57,11 +57,12 @@ class TestANonFunctionAnnotate:
         """All three surface the NameError rather than an AttributeError about
         __globals__, which is what the PyFunction_Check guard is for.
 
-        What this cannot detect is the escalation being deleted: a
-        protocol-correct annotate refuses VALUE_WITH_FAKE_GLOBALS too, so
-        annotationlib falls back to a real-globals VALUE re-run and raises the
-        same NameError the direct call would have. TestForwardReferences is
-        where the escalation has to exist for the class to build at all.
+        The message alone cannot tell any of that: a protocol-correct annotate
+        refuses VALUE_WITH_FAKE_GLOBALS too, so annotationlib falls back to a
+        real-globals VALUE re-run and raises the same NameError a direct call
+        would have. `__context__` is what differs, and asserting it makes both
+        the guard and the escalation detectable here -- deleting either one
+        moves a `__context__` that this now checks.
         """
 
         annotate = TestANonFunctionAnnotate.protocol_correct
@@ -199,21 +200,18 @@ class TestForwardReferences:
         builds. Plain 3.14 defers this too -- the divergence is the explicit
         `raise NameError`, which salix propagates and CPython would defer.
 
-        The call count is asserted rather than the mechanism described: the
-        rescue really does re-run the annotation, helper included.
+        How many times annotationlib re-runs the annotation on the way there is
+        its business and not asserted: a count is not the claim, and it moves
+        when annotationlib changes without the claim moving with it.
         """
 
-        calls = []
-
         def helper():
-            calls.append(1)
             return undefined_inside  # noqa: F821
 
         class Deferred(Struct):
             x: helper()
 
         assert Deferred.__struct_fields__ == ("x",)
-        assert len(calls) > 1
 
     def test_a_forged_name_attribute_reads_as_a_forward_reference(self):
         """The discriminator asks whether `.name` is set, and the keyword form


### PR DESCRIPTION
Closes #31. A bare self-referential field raised `NameError` where a dataclass succeeds:

```python
>>> class Node(Struct):
...     nxt: Node = None
NameError: name 'Node' is not defined. Did you mean: 'None'?
```

`src/annotations.c` already preferred `annotationlib.Format.FORWARDREF`, and the intent was right — salix reads field *names* and *order*, never types, so it should never care whether an annotation resolves. The path was simply dead, in two independent ways.

### The constant named the wrong format

```c
	ANNOTATION_FORMAT_FORWARDREF = 2,
```

`annotationlib.Format` numbers `FORWARDREF` **3**; `2` is `VALUE_WITH_FAKE_GLOBALS`, an internal format that refuses to run. The enum mirrors all four values now, because an incomplete mirror is how the wrong one got picked.

### Correcting the number alone changes nothing

A generated `__annotate__` implements `VALUE` and raises `NotImplementedError` for every other format. Only `annotationlib.call_annotate_function` produces `FORWARDREF`. Measured on 3.14.0:

```
direct __annotate__(3)          -> NotImplementedError
call_annotate_function(fn, 3)   -> {'x': ForwardRef('Undefined')}
```

### Why neither was visible

The blanket `PyErr_Clear()` swallowed the `NotImplementedError` into a `VALUE` retry, which raised the original `NameError` — so the dead path looked exactly like a working one falling back. It clears only `ImportError` now, the single case that honestly means this interpreter has no `FORWARDREF`, and the case a hand-written `__annotate__` on <3.14 lands in. Anything else propagates.

<details>
<summary><b>What this does not change</b></summary>

PEP 649 keeps `__annotations__` lazy, so reading them early with `FORWARDREF` leaves nothing behind for anyone else:

```python
>>> class Node(Struct):
...     value: int
...     nxt: Node = None
>>> Node.__struct_fields__
('value', 'nxt')
>>> Node.__annotations__
{'value': <class 'int'>, 'nxt': <class '__main__.Node'>}
```

No `ForwardRef` is cached into the class — by the time anyone asks, `Node` is bound.

</details>

Seven tests in `tests/test_annotations.py`; six fail without this. The seventh pins the narrowed `PyErr_Clear()` by asserting that an annotation failing for its own reasons still reports that failure. `camas check` green at 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in one-PR batches, simplest first, and iterated with the automated reviewer until it approves.
