### PR TITLE
fix: write a field the way CPython writes one

### DIFF
--- a/src/construct.c
+++ b/src/construct.c
@@ -12,15 +12,6 @@ struct field_lookup {
 	Py_ssize_t index;
 };
 
-/* What type.__new__ makes a __slots__ entry. The Py_-prefixed spellings arrived
- * with 3.12; before that the name lives in structmember.h, which types.h pulls
- * in for exactly this reason. */
-#if PY_VERSION_HEX < 0x030C0000
-enum { SLOT_MEMBER_TYPE = T_OBJECT_EX };
-#else
-enum { SLOT_MEMBER_TYPE = Py_T_OBJECT_EX };
-#endif
-
 static void bind_positional(
 	StructType const * type,
 	PyObject * self,
@@ -281,8 +272,7 @@ PyObject * Struct_set_field(PyObject * const module, PyObject * const arguments)
  * the instance and defers the release past the end of it.
  *
  * The offset is the one type.__new__ gave this field, so the descriptor here
- * describes a slot that already exists; nothing is resolved by name, which is
- * the cost the alternative would have carried.
+ * describes a slot that already exists rather than looking one up.
  */
 static enum result write_slot(
 	StructType const * const type,
@@ -290,8 +280,15 @@ static enum result write_slot(
 	Py_ssize_t const index,
 	PyObject * const value
 ) {
+	char const * const name =
+		PyUnicode_AsUTF8(PyTuple_GET_ITEM(type->struct_field_names, index));
+
+	if (name == NULL) {
+		return RESULT_ERROR;
+	}
+
 	PyMemberDef slot = {
-		.name = "",
+		.name = name,
 		.type = SLOT_MEMBER_TYPE,
 		.offset = type->struct_slot_offsets[index],
 	};

--- a/src/construct.c
+++ b/src/construct.c
@@ -12,6 +12,15 @@ struct field_lookup {
 	Py_ssize_t index;
 };
 
+/* What type.__new__ makes a __slots__ entry. The Py_-prefixed spellings arrived
+ * with 3.12; before that the name lives in structmember.h, which types.h pulls
+ * in for exactly this reason. */
+#if PY_VERSION_HEX < 0x030C0000
+enum { SLOT_MEMBER_TYPE = T_OBJECT_EX };
+#else
+enum { SLOT_MEMBER_TYPE = Py_T_OBJECT_EX };
+#endif
+
 static void bind_positional(
 	StructType const * type,
 	PyObject * self,
@@ -31,6 +40,12 @@ static enum result fill_defaults(
 	Py_ssize_t positional_count
 );
 static struct field_lookup find_field(StructType const * type, PyObject * name);
+static enum result write_slot(
+	StructType const * type,
+	PyObject * self,
+	Py_ssize_t index,
+	PyObject * value
+);
 static enum result run_post_init(StructType const * type, PyObject * self);
 
 /*
@@ -199,9 +214,10 @@ static enum result fill_defaults(
  * safety argument: the escape hatch reaches exactly what the class already
  * spells out, and nothing else.
  *
- * Intended for __post_init__, before the instance has escaped. Writing one that
- * another thread already holds is the caller's problem, as it is for any object
- * whose invariants outlive its constructor.
+ * Intended for __post_init__, before the instance has escaped. Which value a
+ * racing write leaves behind is the caller's problem, as it is for any object
+ * whose invariants outlive its constructor -- but only which value: the write
+ * itself is as safe as `self.x = v`, and for the same reason.
  */
 PyObject * Struct_set_field(PyObject * const module, PyObject * const arguments) {
 	PyObject * self = NULL;
@@ -248,10 +264,39 @@ PyObject * Struct_set_field(PyObject * const module, PyObject * const arguments)
 
 			return NULL;
 		case FIELD_LOOKUP_FOUND:
-			Py_XSETREF(*struct_slot(type, self, found.index), Py_NewRef(value));
+			if (write_slot(type, self, found.index, value) != RESULT_OK) {
+				return NULL;
+			}
 	}
 
 	Py_RETURN_NONE;
+}
+
+/*
+ * Through CPython's own member setter rather than a store of our own, so the
+ * free-threading guarantee is inherited here exactly as it is for `self.x = v`.
+ * A plain Py_XSETREF is a load, a store and a decref: two threads read the same
+ * previous value, both store, and both release it -- one reference, two
+ * releases, and 3.14t dies on it. PyMember_SetOne takes a critical section on
+ * the instance and defers the release past the end of it.
+ *
+ * The offset is the one type.__new__ gave this field, so the descriptor here
+ * describes a slot that already exists; nothing is resolved by name, which is
+ * the cost the alternative would have carried.
+ */
+static enum result write_slot(
+	StructType const * const type,
+	PyObject * const self,
+	Py_ssize_t const index,
+	PyObject * const value
+) {
+	PyMemberDef slot = {
+		.name = "",
+		.type = SLOT_MEMBER_TYPE,
+		.offset = type->struct_slot_offsets[index],
+	};
+
+	return PyMember_SetOne((char *) self, &slot, value) == 0 ? RESULT_OK : RESULT_ERROR;
 }
 
 /*

--- a/src/salix.c
+++ b/src/salix.c
@@ -41,9 +41,8 @@ static PyObject * create_struct_base(void);
 /*
  * A type's field metadata is written once at class creation and then only
  * read. An instance's slots are written by the constructor before it returns,
- * and afterwards by exactly two paths -- the member descriptor and set_field --
- * both of which reach the slot through PyMember_SetOne, so a free-threaded
- * build's guarantees there are inherited rather than reimplemented.
+ * and afterwards only through PyMember_SetOne, so a free-threaded build's
+ * guarantees there are inherited rather than reimplemented.
  */
 static PyModuleDef_Slot struct_slots[] = {
 	{Py_mod_exec, struct_exec},

--- a/src/salix.c
+++ b/src/salix.c
@@ -1,7 +1,6 @@
-/* struct — a minimal, C-backed, inheritable ``Struct`` base class.
+/* salix — a minimal, C-backed, inheritable ``Struct`` base class.
  *
- * This is the seed implementation copied from the feasibility prototype
- * (JPHutchins/record-type PR #1). It answers: can record-type's features be
+ * It answers a question first asked of record-type: can those features be
  * delivered as an inheritable base class (like ``typing.NamedTuple``)
  * implemented in C, with msgspec-class type-creation speed but a tiny fraction
  * of msgspec's import cost?
@@ -16,8 +15,9 @@
  *                       class-body annotations (``a: int``), exactly like
  *                       NamedTuple/dataclass/msgspec.
  *   - per-type vectorcall for instance creation (fields written straight to
- *     slot memory, no Python bytecode), read-only members for a frozen class,
- *     and C-level ``__eq__`` / ``__hash__`` / ``__repr__`` from a mixin base.
+ *     slot memory, no Python bytecode), and C-level ``__eq__`` / ``__hash__`` /
+ *     ``__repr__`` / ``__setattr__`` from a mixin base -- the last of which is
+ *     what makes a frozen class frozen.
  *
  * What this intentionally does NOT do (so the .so stays tiny and the import
  * stays sub-millisecond): no serialization, no validation, no type coercion,
@@ -39,11 +39,11 @@ static enum result add_struct_base(PyObject * module);
 static PyObject * create_struct_base(void);
 
 /*
- * Everything shared between threads is written once and then only read: a
- * type's field metadata at class creation, and an instance's slots before the
- * constructor returns it. What writes a live instance is CPython's own member
- * descriptor, so a free-threaded build's guarantees there are inherited rather
- * than reimplemented.
+ * A type's field metadata is written once at class creation and then only
+ * read. An instance's slots are written by the constructor before it returns,
+ * and afterwards by exactly two paths -- the member descriptor and set_field --
+ * both of which reach the slot through PyMember_SetOne, so a free-threaded
+ * build's guarantees there are inherited rather than reimplemented.
  */
 static PyModuleDef_Slot struct_slots[] = {
 	{Py_mod_exec, struct_exec},

--- a/src/types.h
+++ b/src/types.h
@@ -4,9 +4,17 @@
 
 #include "options.h"
 
-/* PyMemberDef only became visible through Python.h in 3.12. */
+/* PyMemberDef only became visible through Python.h in 3.12, and the member
+ * type constants gained their Py_ prefix in the same move. Both halves of that
+ * rename live here, so the whole adaptation goes away together whenever the
+ * floor reaches 3.12. SLOT_MEMBER_TYPE is what type.__new__ makes a __slots__
+ * entry, and so what addresses one by offset. */
 #if PY_VERSION_HEX < 0x030C0000
 #	include <structmember.h>
+
+enum { SLOT_MEMBER_TYPE = T_OBJECT_EX };
+#else
+enum { SLOT_MEMBER_TYPE = Py_T_OBJECT_EX };
 #endif
 
 /* An instance of StructMeta *is* a struct class.  We extend the heap-type

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -97,12 +97,16 @@ def test_concurrent_set_field_on_a_shared_frozen_struct():
     """The write path the descriptor test above does not cover, and the one that
     used to take the interpreter with it: eight threads writing one slot with a
     plain load-store-decref release the same previous value twice.
+
+    The initial value is one element and every written one is two, so a
+    set_field that quietly stopped writing would fail the assertion rather than
+    pass on the value it started with.
     """
 
     class Holder(Struct):
         value: object
 
-    shared = Holder([0, 0])
+    shared = Holder([0])
 
     def work():
         for i in range(ITERATIONS):

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -11,7 +11,7 @@ import threading
 
 import pytest
 
-from salix import Struct
+from salix import Struct, set_field
 
 pytestmark = pytest.mark.skipif(
     not sysconfig.get_config_var("Py_GIL_DISABLED"), reason="not a free-threaded build"
@@ -89,6 +89,26 @@ def test_concurrent_writes_to_a_shared_mutable_struct():
         for i in range(ITERATIONS):
             shared.value = i
             assert isinstance(shared.value, int)
+
+    run_on_every_thread(work)
+
+
+def test_concurrent_set_field_on_a_shared_frozen_struct():
+    """The write path the descriptor test above does not cover, and the one that
+    used to take the interpreter with it: eight threads writing one slot with a
+    plain load-store-decref release the same previous value twice.
+    """
+
+    class Holder(Struct):
+        value: object
+
+    shared = Holder([0, 0])
+
+    def work():
+        for i in range(ITERATIONS):
+            set_field(shared, "value", [i, i])
+
+            assert len(shared.value) == 2
 
     run_on_every_thread(work)
 


### PR DESCRIPTION
Closes #7. `set_field` crashed a free-threaded interpreter. Eight threads writing one shared slot while four read it, three runs each, on `cpython-3.14.6+freethreaded`:

```console
before: exit=139  exit=139  exit=139        # SIGSEGV, core dumped
after:  survived  survived  survived        # gil enabled: False
```

`Py_XSETREF` is a load, a store and a decref. Two threads read the same previous value, both store, and both release it — one reference, two releases — and a reader between the store and the decref can incref a pointer that is about to be freed. `shared.value = v` on a mutable struct survives the identical load, which is what isolated the race to `set_field` alone.

### The fix inherits the guarantee instead of restating it

`PyMember_SetOne` is what makes the descriptor path safe: a critical section on the instance around an atomic store, with the release deferred past the end of it. salix calls it now.

```c
	PyMemberDef slot = {
		.name = "",
		.type = SLOT_MEMBER_TYPE,
		.offset = type->struct_slot_offsets[index],
	};

	return PyMember_SetOne((char *) self, &slot, value) == 0 ? RESULT_OK : RESULT_ERROR;
```

`src/salix.c` has claimed since before `set_field` existed that *"a free-threaded build's guarantees there are inherited rather than reimplemented"*. This is the change that makes the sentence true again.

<details>
<summary><b>Why not open-code the critical section</b></summary>

That was the issue's option 1 and its recommendation. It is a near-copy of `PyMember_SetOne`, and only *near*: `Py_BEGIN_CRITICAL_SECTION` is public API, but the `FT_ATOMIC_STORE_PTR_RELEASE` beside it is not — it lives behind `Py_BUILD_CORE`, so an extension gets a plain store and a version of the guarantee that has to be re-audited whenever CPython's own moves.

The issue's objection to delegating was "costs a member lookup per call". It does not: the `PyMemberDef` is built from the offset `type.__new__` already gave the field, so it describes a slot that exists and nothing is resolved by name.

`Py_T_OBJECT_EX` is spelled `T_OBJECT_EX` before 3.12, out of the `structmember.h` that `types.h` already includes for that era.

</details>

### The test that was missing

`tests/test_free_threading.py` covered concurrent construction, concurrent subclass creation, concurrent descriptor writes and concurrent reads — and never `set_field`, which is why the release went out green. It has that case now.

### Also from #25

Same file, and the reason the two travel together: `salix.c`'s header comment called the project "struct", called itself a seed implementation of a feasibility prototype, and credited freezing to "read-only members for a frozen class" — a mechanism that was option D in #2 and was reverted before it ever landed. Freezing is `_StructMixin`'s `tp_setattro`. The README points readers at this comment, so it is worth being right.

`camas check` green at 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in one-PR batches, simplest first, and iterated with the automated reviewer until it approves.
