### PR TITLE
fix: ask whether the object is actually a struct

### DIFF
--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -2,12 +2,8 @@ from typing import Any, Final
 
 from typing_extensions import dataclass_transform
 
-class _StructMeta(type):
-    __struct_fields__: Final[tuple[str, ...]]
-    __struct_defaults__: Final[tuple[Any, ...]]
-
 @dataclass_transform(frozen_default=True)
-class Struct(metaclass=_StructMeta):
+class Struct:
     __struct_fields__: Final[tuple[str, ...]]
     __struct_defaults__: Final[tuple[Any, ...]]
     def __init_subclass__(

--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -2,12 +2,12 @@ from typing import Any, Final
 
 from typing_extensions import dataclass_transform
 
-class StructMeta(type):
+class _StructMeta(type):
     __struct_fields__: Final[tuple[str, ...]]
     __struct_defaults__: Final[tuple[Any, ...]]
 
 @dataclass_transform(frozen_default=True)
-class Struct(metaclass=StructMeta):
+class Struct(metaclass=_StructMeta):
     __struct_fields__: Final[tuple[str, ...]]
     __struct_defaults__: Final[tuple[Any, ...]]
     def __init_subclass__(

--- a/src/compare.c
+++ b/src/compare.c
@@ -1,7 +1,6 @@
 #include <Python.h>
 
 #include "compare.h"
-#include "mixin.h"
 #include "owned.h"
 #include "types.h"
 
@@ -24,7 +23,7 @@ static enum comparison values_equal(
 );
 
 PyObject * Struct_rich_compare(PyObject * const self, PyObject * const other, int const op) {
-	if (!PyObject_TypeCheck(other, &StructMixin_Type)) {
+	if (!is_struct(self) || !is_struct(other)) {
 		Py_RETURN_NOTIMPLEMENTED;
 	}
 

--- a/src/construct.c
+++ b/src/construct.c
@@ -1,7 +1,6 @@
 #include <Python.h>
 
 #include "construct.h"
-#include "meta.h"
 #include "owned.h"
 #include "result.h"
 #include "types.h"
@@ -219,7 +218,7 @@ PyObject * Struct_set_field(PyObject * const module, PyObject * const arguments)
 		return NULL;
 	}
 
-	if (!PyObject_TypeCheck((PyObject *) Py_TYPE(self), &StructMeta_Type)) {
+	if (!is_struct(self)) {
 		PyErr_Format(
 			PyExc_TypeError,
 			"set_field() expects a struct, not %.200s",

--- a/src/hash.c
+++ b/src/hash.c
@@ -24,7 +24,13 @@ Py_hash_t Struct_hash(PyObject * const self) {
 	 * NotImplemented and the co-base's reflected __eq__ says yes -- so an
 	 * identity hash made it equal to a value it could not be looked up beside.
 	 * Refusing to hash is what puts equality and hashing back in one place, and
-	 * being unhashable is an ordinary thing for an object to be. #66. */
+	 * being unhashable is an ordinary thing for an object to be. #66.
+	 *
+	 * Unhashable to the operator and not to the ABC: collections.abc.Hashable
+	 * asks whether tp_hash is non-NULL, and the mixin's is, so an impostor is an
+	 * instance of it and raises when hashed. Setting tp_hash to NULL is not
+	 * available -- it is the same slot every struct hashes through. CPython's
+	 * own writable memoryview diverges the same way. */
 	if (!is_struct(self)) {
 		PyErr_Format(PyExc_TypeError, "unhashable type: '%.200s'", Py_TYPE(self)->tp_name);
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -18,6 +18,10 @@ enum : Py_hash_t {
  * a Python frame, so the interpreter's own depth limit never sees the descent.
  */
 Py_hash_t Struct_hash(PyObject * const self) {
+	if (!is_struct(self)) {
+		return PyBaseObject_Type.tp_hash(self);
+	}
+
 	StructType const * const type = struct_type_of(self);
 	PY_OWNED(values, PyTuple_New(type->struct_field_count));
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -18,8 +18,17 @@ enum : Py_hash_t {
  * a Python frame, so the interpreter's own depth limit never sees the descent.
  */
 Py_hash_t Struct_hash(PyObject * const self) {
+	/* Unhashable rather than hashed by pointer, which is the one fallback in
+	 * this file that could not be a local decision. A mixin subclass over a
+	 * value type is compared by that type -- rich_compare answers
+	 * NotImplemented and the co-base's reflected __eq__ says yes -- so an
+	 * identity hash made it equal to a value it could not be looked up beside.
+	 * Refusing to hash is what puts equality and hashing back in one place, and
+	 * being unhashable is an ordinary thing for an object to be. #66. */
 	if (!is_struct(self)) {
-		return PyBaseObject_Type.tp_hash(self);
+		PyErr_Format(PyExc_TypeError, "unhashable type: '%.200s'", Py_TYPE(self)->tp_name);
+
+		return HASH_ERR;
 	}
 
 	StructType const * const type = struct_type_of(self);

--- a/src/meta.c
+++ b/src/meta.c
@@ -62,6 +62,7 @@ static StructType * create_class(
 	PyObject * bases,
 	PyObject * namespace
 );
+static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -214,11 +215,11 @@ PyObject * StructMeta_new(
 		NULL
 	);
 
-	/* Already installed means type.__new__ delegated to a more derived metatype,
-	 * which re-entered here and built the class in full -- or a metaclass __new__
-	 * handed back a struct class it did not just make. Installing over either one
-	 * overwrites a field table without releasing it, and the plan that produced
-	 * it came from this same name, bases and namespace anyway. */
+	/* create_class builds as the winning metatype, so the ordinary handoff no
+	 * longer comes back here already installed. What still can is a metaclass
+	 * __new__ that returned a struct class -- possibly one it did not just make,
+	 * whose slot offsets belong to a layout this plan knows nothing about.
+	 * Installing over that is a field table pointed at the wrong memory. */
 	if (
 		struct_class != NULL &&
 		struct_class->struct_field_names == NULL &&
@@ -507,20 +508,27 @@ static StructType * create_class(
 		return NULL;
 	}
 
-	PY_MOVABLE(created, PyType_Type.tp_new(metatype, type_args, NULL));
+	/* type_new hands off to the winning metatype's tp_new when that is not the
+	 * one it was given. Where the winner would only land back in StructMeta_new,
+	 * building as the winner in the first place reaches the same class without
+	 * the round trip -- which re-planned from the transformed namespace and with
+	 * no keywords, so the requested options and the body's defaults were gone by
+	 * the time it returned. */
+	PyTypeObject * const winner = winning_metatype(metatype, bases);
+	PyTypeObject * const builder = winner->tp_new == StructMeta_new ? winner : metatype;
+	PY_MOVABLE(created, PyType_Type.tp_new(builder, type_args, NULL));
 
 	if (created == NULL) {
 		return NULL;
 	}
 
-	/* type_new hands off to the winning metatype's tp_new when that is not the
-	 * one it was given, so a StructMeta subclass overriding __new__ decides what
-	 * comes back here -- and install_fields writes StructType storage into it. */
+	/* A StructMeta subclass overriding __new__ still decides what comes back
+	 * here -- and install_fields writes StructType storage into it. */
 	if (!is_struct_class(created)) {
 		PyErr_Format(
 			PyExc_TypeError,
 			"%.200s.__new__ returned %.200s, which is not a struct class",
-			metatype->tp_name,
+			winner->tp_name,
 			Py_TYPE(created)->tp_name
 		);
 
@@ -528,6 +536,26 @@ static StructType * create_class(
 	}
 
 	return (StructType *) py_move(&created);
+}
+
+/*
+ * type_new's own rule: the most derived of the requested metatype and the
+ * bases' metatypes builds the class. Metatypes that are unrelated to each
+ * other are a conflict rather than a winner, and this returns the requested one
+ * for that case so type_new raises the error it has always raised.
+ */
+static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
+	PyTypeObject * winner = requested;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyTypeObject * const candidate = Py_TYPE(PyTuple_GET_ITEM(bases, i));
+
+		if (PyType_IsSubtype(candidate, winner)) {
+			winner = candidate;
+		}
+	}
+
+	return winner;
 }
 
 /* The type exists but is not yet a struct; this is what makes it one. */

--- a/src/meta.c
+++ b/src/meta.c
@@ -91,7 +91,7 @@ static struct member_lookup find_member(
 
 PyTypeObject StructMeta_Type = {
 	PyVarObject_HEAD_INIT(NULL, 0)
-	.tp_name = "salix.StructMeta",
+	.tp_name = "salix._StructMeta",
 	.tp_basicsize = sizeof(StructType),
 	.tp_itemsize = sizeof(PyMemberDef),
 	.tp_flags = (
@@ -152,7 +152,7 @@ PyObject * StructMeta_new(
 	if (
 		!PyArg_ParseTuple(
 			args,
-			"UO!O!:StructMeta.__new__",
+			"UO!O!:_StructMeta.__new__",
 			&name,
 			&PyTuple_Type,
 			&bases,
@@ -172,8 +172,8 @@ PyObject * StructMeta_new(
 	if (base == NULL && !inherits_mixin(bases)) {
 		PyErr_SetString(
 			PyExc_TypeError,
-			"a struct class inherits salix.Struct; StructMeta is the metaclass of "
-			"one, not a way to make one"
+			"a struct class inherits salix.Struct; the metaclass of one is not a "
+			"way to make one"
 		);
 
 		return NULL;
@@ -250,7 +250,7 @@ PyObject * StructMeta_new(
  * bindings, the hash, the setattr that makes frozen mean something. Without it
  * in the MRO the class still builds, still constructs and still reports its
  * fields, and is a struct in every visible way except behaviour -- so a bare
- * `metaclass=StructMeta` is refused rather than answered with that.
+ * `metaclass=type(Struct)` is refused rather than answered with that.
  */
 static bool inherits_mixin(PyObject * const bases) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {

--- a/src/meta.c
+++ b/src/meta.c
@@ -26,7 +26,14 @@ static int StructMeta_traverse(PyObject * self, visitproc visit, void * arg);
 static int StructMeta_clear(PyObject * self);
 static void StructMeta_dealloc(PyObject * self);
 
-static bool inherits_mixin(PyObject * bases);
+static PyObject * build_struct_class(
+	PyTypeObject * metatype,
+	StructType const * base,
+	PyObject * name,
+	PyObject * bases,
+	PyObject * original_namespace,
+	PyObject * keywords
+);
 static StructType * find_struct_base(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
 static struct options base_options(StructType const * base);
@@ -128,17 +135,23 @@ static PyGetSetDef StructMeta_getset[] = {
 };
 
 static PyObject * StructMeta_get_field_names(PyObject * const self, void * const closure) {
-	return struct_tuple_or_empty(((StructType *) self)->struct_field_names);
+	return struct_metadata((StructType *) self, STRUCT_FIELD_NAMES);
 }
 
 static PyObject * StructMeta_get_defaults(PyObject * const self, void * const closure) {
-	return struct_tuple_or_empty(((StructType *) self)->struct_defaults);
+	return struct_metadata((StructType *) self, STRUCT_DEFAULTS);
 }
 
 /*
- * Creating a struct class is four steps: work out the fields, build the
- * namespace type.__new__ wants, make the type, then hand it the field table
- * that makes it a struct.
+ * Everything a struct does comes from _StructMixin, and every struct class
+ * carries it because Struct does. A class with no struct base has no way to
+ * have got it: it would build, construct, report its fields, and be a struct
+ * in every visible way except behaviour.
+ *
+ * The one class that legitimately has no struct base is Struct, and the module
+ * builds it through struct_create_root rather than through here -- so this
+ * refusal has no exception to carve out, and there is no shape of `bases` that
+ * gets a caller past it.
  */
 PyObject * StructMeta_new(
 	PyTypeObject * const metatype,
@@ -165,11 +178,7 @@ PyObject * StructMeta_new(
 
 	StructType const * const base = find_struct_base(bases);
 
-	/* A struct base is a mixin subtype already -- Struct is built on the mixin
-	 * and every struct descends from it -- so the scan below is only for the
-	 * classes that have no struct base at all, Struct's own creation among
-	 * them. */
-	if (base == NULL && !inherits_mixin(bases)) {
+	if (base == NULL) {
 		PyErr_SetString(
 			PyExc_TypeError,
 			"a struct class inherits salix.Struct; the metaclass of one is not a "
@@ -179,6 +188,32 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
+	return build_struct_class(metatype, base, name, bases, original_namespace, keywords);
+}
+
+/* Struct itself, built once from module init. The only class with no struct
+ * base, and the only caller that does not come through a metaclass call. */
+PyObject * struct_create_root(
+	PyObject * const name,
+	PyObject * const bases,
+	PyObject * const namespace
+) {
+	return build_struct_class(&StructMeta_Type, NULL, name, bases, namespace, NULL);
+}
+
+/*
+ * Creating a struct class is four steps: work out the fields, build the
+ * namespace type.__new__ wants, make the type, then hand it the field table
+ * that makes it a struct.
+ */
+static PyObject * build_struct_class(
+	PyTypeObject * const metatype,
+	StructType const * const base,
+	PyObject * const name,
+	PyObject * const bases,
+	PyObject * const original_namespace,
+	PyObject * const keywords
+) {
 	struct options const inherited = base_options(base);
 	struct options_request const request =
 		options_read(keywords, inherited, base != NULL && base->struct_field_count > 0);
@@ -243,25 +278,6 @@ PyObject * StructMeta_new(
 	field_plan_clear(&plan);
 
 	return (PyObject *) struct_class;
-}
-
-/*
- * Everything a struct does comes from _StructMixin: the comparison and repr
- * bindings, the hash, the setattr that makes frozen mean something. Without it
- * in the MRO the class still builds, still constructs and still reports its
- * fields, and is a struct in every visible way except behaviour -- so a bare
- * `metaclass=type(Struct)` is refused rather than answered with that.
- */
-static bool inherits_mixin(PyObject * const bases) {
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
-		PyObject * const base = PyTuple_GET_ITEM(bases, i);
-
-		if (PyType_Check(base) && PyType_IsSubtype((PyTypeObject *) base, &StructMixin_Type)) {
-			return true;
-		}
-	}
-
-	return false;
 }
 
 /* Find the (single) struct base among ``bases``. A fieldless one still carries
@@ -554,6 +570,12 @@ static StructType * create_class(
  * raises the metaclass-conflict error it has always raised. For unrelated
  * metatypes that is the first one this locked onto rather than the requested
  * one, which is why the loop can stay this simple.
+ *
+ * It is the third walk of `bases` in a class creation, after find_struct_base
+ * and _PyType_CalculateMetaclass. Measured rather than assumed: replacing the
+ * body with `return requested` moves class creation from 9.77-9.87 to
+ * 9.77-9.87 us for a 16-field class, which is to say it does not move it. The
+ * walk is one Py_TYPE and one PyType_IsSubtype per base, and a class has one.
  */
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;

--- a/src/meta.c
+++ b/src/meta.c
@@ -572,10 +572,11 @@ static StructType * create_class(
  * one, which is why the loop can stay this simple.
  *
  * It is the third walk of `bases` in a class creation, after find_struct_base
- * and _PyType_CalculateMetaclass. Measured rather than assumed: replacing the
- * body with `return requested` moves class creation from 9.77-9.87 to
- * 9.77-9.87 us for a 16-field class, which is to say it does not move it. The
- * walk is one Py_TYPE and one PyType_IsSubtype per base, and a class has one.
+ * and _PyType_CalculateMetaclass. Measured, and smaller than the measurement:
+ * replacing the body with `return requested` leaves class creation at 9.77-9.87
+ * us for a 16-field class either way, so the walk is bounded by the width of
+ * that band rather than shown to be free. It is one Py_TYPE and one
+ * PyType_IsSubtype per base, and a class has one.
  */
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;

--- a/src/meta.c
+++ b/src/meta.c
@@ -265,7 +265,7 @@ static StructType * find_struct_base(PyObject * const bases) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
 
-		if (PyObject_TypeCheck(base, &StructMeta_Type)) {
+		if (is_struct_class(base)) {
 			return (StructType *) base;
 		}
 	}
@@ -540,9 +540,15 @@ static StructType * create_class(
 
 /*
  * type_new's own rule: the most derived of the requested metatype and the
- * bases' metatypes builds the class. Metatypes that are unrelated to each
- * other are a conflict rather than a winner, and this returns the requested one
- * for that case so type_new raises the error it has always raised.
+ * bases' metatypes builds the class. CPython keeps that rule in
+ * _PyType_CalculateMetaclass, which is not in the public API, so it is written
+ * out here rather than called.
+ *
+ * Only the winner is wanted, and only to decide who builds. Metatypes unrelated
+ * to each other are a conflict rather than a winner, and returning the
+ * requested one for that case hands type_new an argument it will reject with
+ * the metaclass-conflict error it has always raised -- the one message a caller
+ * already knows.
  */
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;

--- a/src/meta.c
+++ b/src/meta.c
@@ -77,6 +77,11 @@ static enum result install_fields(
 	struct options options,
 	bool resolves_body_eq
 );
+static enum result reject_unless_planned(
+	StructType const * struct_class,
+	struct field_plan const * plan,
+	struct options options
+);
 static enum result install_post_init(StructType * struct_class);
 static bool defines_own_init(StructType const * struct_class);
 static PyObject * StructMeta_call(PyObject * self, PyObject * args, PyObject * keywords);
@@ -259,20 +264,23 @@ static PyObject * build_struct_class(
 	 * longer comes back here already installed. What still can is a metaclass
 	 * __new__ that returned a struct class -- possibly one it did not just make,
 	 * whose slot offsets belong to a layout this plan knows nothing about.
-	 * Installing over that is a field table pointed at the wrong memory. */
-	if (
-		struct_class != NULL &&
-		struct_class->struct_field_names == NULL &&
-		install_fields(
+	 * Installing over that is a field table pointed at the wrong memory, so the
+	 * class it did build is held to what this call planned instead. */
+	if (struct_class != NULL) {
+		enum result const settled = (
+			struct_class->struct_field_names == NULL ? install_fields(
 				struct_class,
 				base,
 				&plan,
 				request.options,
 				body_defines_eq || inherits_body_eq
-			) !=
-			RESULT_OK
-	) {
-		Py_CLEAR(struct_class);
+			) :
+			reject_unless_planned(struct_class, &plan, request.options)
+		);
+
+		if (settled != RESULT_OK) {
+			Py_CLEAR(struct_class);
+		}
 	}
 
 	field_plan_clear(&plan);
@@ -590,6 +598,57 @@ static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject 
 	}
 
 	return winner;
+}
+
+/*
+ * The class came back already a struct, which means something other than this
+ * call built it. A metaclass __new__ written in Python is one such thing: it is
+ * re-entered through type_new with no keywords and a namespace the transform
+ * has already taken the body defaults out of, so the class it installs is
+ * planned from less than this call was handed. The options and the defaults are
+ * where that shows.
+ *
+ * Refused rather than returned, and rather than installed over: the field table
+ * this call planned describes a layout that class may not have. #55 is where
+ * the hand-off itself is argued -- until it forwards what it was given, a
+ * caller gets an error instead of a class that quietly is not the one asked
+ * for.
+ */
+static enum result reject_unless_planned(
+	StructType const * const struct_class,
+	struct field_plan const * const plan,
+	struct options const options
+) {
+	PY_OWNED(planned, PyList_AsTuple(plan->all_names));
+
+	if (planned == NULL) {
+		return RESULT_ERROR;
+	}
+
+	int const same_fields =
+		PyObject_RichCompareBool(struct_class->struct_field_names, planned, Py_EQ);
+
+	if (same_fields < 0) {
+		return RESULT_ERROR;
+	}
+
+	if (
+		same_fields == 1 &&
+		struct_class->struct_default_count == PyTuple_GET_SIZE(plan->defaults) &&
+		options_agree(struct_class->struct_options, options)
+	) {
+		return RESULT_OK;
+	}
+
+	PyErr_Format(
+		PyExc_TypeError,
+		"%.200s.__new__ returned a struct class this call did not plan: its "
+		"metaclass is re-entered without the keywords or the class body's "
+		"defaults, so what it built is not what was asked for",
+		Py_TYPE(struct_class)->tp_name
+	);
+
+	return RESULT_ERROR;
 }
 
 /* The type exists but is not yet a struct; this is what makes it one. */

--- a/src/meta.c
+++ b/src/meta.c
@@ -26,6 +26,7 @@ static int StructMeta_traverse(PyObject * self, visitproc visit, void * arg);
 static int StructMeta_clear(PyObject * self);
 static void StructMeta_dealloc(PyObject * self);
 
+static bool inherits_mixin(PyObject * bases);
 static StructType * find_struct_base(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
 static struct options base_options(StructType const * base);
@@ -161,6 +162,16 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
+	if (!inherits_mixin(bases)) {
+		PyErr_SetString(
+			PyExc_TypeError,
+			"a struct class inherits salix.Struct; StructMeta is the metaclass of "
+			"one, not a way to make one"
+		);
+
+		return NULL;
+	}
+
 	StructType const * const base = find_struct_base(bases);
 	struct options const inherited = base_options(base);
 	struct options_request const request =
@@ -220,6 +231,25 @@ PyObject * StructMeta_new(
 	field_plan_clear(&plan);
 
 	return (PyObject *) struct_class;
+}
+
+/*
+ * Everything a struct does comes from _StructMixin: the comparison and repr
+ * bindings, the hash, the setattr that makes frozen mean something. Without it
+ * in the MRO the class still builds, still constructs and still reports its
+ * fields, and is a struct in every visible way except behaviour -- so a bare
+ * `metaclass=StructMeta` is refused rather than answered with that.
+ */
+static bool inherits_mixin(PyObject * const bases) {
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+
+		if (PyType_Check(base) && PyType_IsSubtype((PyTypeObject *) base, &StructMixin_Type)) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /* Find the (single) struct base among ``bases``. A fieldless one still carries
@@ -471,7 +501,27 @@ static StructType * create_class(
 		return NULL;
 	}
 
-	return (StructType *) PyType_Type.tp_new(metatype, type_args, NULL);
+	PY_MOVABLE(created, PyType_Type.tp_new(metatype, type_args, NULL));
+
+	if (created == NULL) {
+		return NULL;
+	}
+
+	/* type_new hands off to the winning metatype's tp_new when that is not the
+	 * one it was given, so a StructMeta subclass overriding __new__ decides what
+	 * comes back here -- and install_fields writes StructType storage into it. */
+	if (!is_struct_class(created)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"%.200s.__new__ returned %.200s, which is not a struct class",
+			metatype->tp_name,
+			Py_TYPE(created)->tp_name
+		);
+
+		return NULL;
+	}
+
+	return (StructType *) py_move(&created);
 }
 
 /* The type exists but is not yet a struct; this is what makes it one. */

--- a/src/meta.c
+++ b/src/meta.c
@@ -163,7 +163,13 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
-	if (!inherits_mixin(bases)) {
+	StructType const * const base = find_struct_base(bases);
+
+	/* A struct base is a mixin subtype already -- Struct is built on the mixin
+	 * and every struct descends from it -- so the scan below is only for the
+	 * classes that have no struct base at all, Struct's own creation among
+	 * them. */
+	if (base == NULL && !inherits_mixin(bases)) {
 		PyErr_SetString(
 			PyExc_TypeError,
 			"a struct class inherits salix.Struct; StructMeta is the metaclass of "
@@ -173,7 +179,6 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
-	StructType const * const base = find_struct_base(bases);
 	struct options const inherited = base_options(base);
 	struct options_request const request =
 		options_read(keywords, inherited, base != NULL && base->struct_field_count > 0);

--- a/src/meta.c
+++ b/src/meta.c
@@ -214,8 +214,14 @@ PyObject * StructMeta_new(
 		NULL
 	);
 
+	/* Already installed means type.__new__ delegated to a more derived metatype,
+	 * which re-entered here and built the class in full -- or a metaclass __new__
+	 * handed back a struct class it did not just make. Installing over either one
+	 * overwrites a field table without releasing it, and the plan that produced
+	 * it came from this same name, bases and namespace anyway. */
 	if (
 		struct_class != NULL &&
+		struct_class->struct_field_names == NULL &&
 		install_fields(
 				struct_class,
 				base,

--- a/src/meta.c
+++ b/src/meta.c
@@ -544,11 +544,11 @@ static StructType * create_class(
  * _PyType_CalculateMetaclass, which is not in the public API, so it is written
  * out here rather than called.
  *
- * Only the winner is wanted, and only to decide who builds. Metatypes unrelated
- * to each other are a conflict rather than a winner, and returning the
- * requested one for that case hands type_new an argument it will reject with
- * the metaclass-conflict error it has always raised -- the one message a caller
- * already knows.
+ * Only the winner is wanted, and only to decide who builds, so a conflict needs
+ * no answer here -- whatever this returns, type_new recomputes the winner and
+ * raises the metaclass-conflict error it has always raised. For unrelated
+ * metatypes that is the first one this locked onto rather than the requested
+ * one, which is why the loop can stay this simple.
  */
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;

--- a/src/meta.h
+++ b/src/meta.h
@@ -6,5 +6,9 @@
  * same reason StructMixin_Type is not. */
 extern PyTypeObject StructMeta_Type;
 
-/* Also called directly at module init to build the public ``Struct`` base. */
 PyObject * StructMeta_new(PyTypeObject * metatype, PyObject * args, PyObject * keywords);
+
+/* The public ``Struct`` base, built once at module init. It is the one class
+ * with no struct base among its own, which is exactly what StructMeta_new
+ * refuses -- so it is built here instead of through a metaclass call. */
+PyObject * struct_create_root(PyObject * name, PyObject * bases, PyObject * namespace);

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -10,6 +10,7 @@
 static int Struct_set_attribute(PyObject * self, PyObject * name, PyObject * value);
 static PyObject * Struct_get_field_names(PyObject * self, void * closure);
 static PyObject * Struct_get_defaults(PyObject * self, void * closure);
+static PyObject * not_a_struct(PyObject * self, char const * name);
 static PyGetSetDef Struct_getset[];
 
 PyTypeObject StructMixin_Type = {
@@ -38,6 +39,26 @@ static PyGetSetDef Struct_getset[] = {
 	{.name = NULL},
 };
 
+/*
+ * Everything below asks whether it is looking at a struct, because the mixin is
+ * a permitted base and a subclass of it need not be one. Where there is no
+ * struct the mixin has nothing to contribute, so the object gets what it would
+ * have had without it -- raising out of repr or hash would turn an object that
+ * is merely useless into one a debugger cannot print. The two getsets are the
+ * exception: they report struct metadata and nothing else, so there is no
+ * behaviour to fall back to.
+ */
+static PyObject * not_a_struct(PyObject * const self, char const * const name) {
+	PyErr_Format(
+		PyExc_TypeError,
+		"%s is defined on structs, and %.200s is not one",
+		name,
+		Py_TYPE(self)->tp_name
+	);
+
+	return NULL;
+}
+
 /* Structs are frozen, so every write fails.  A NULL value is how CPython
  * spells `del`, which is the only thing the two messages differ over. */
 static int Struct_set_attribute(
@@ -45,6 +66,10 @@ static int Struct_set_attribute(
 	PyObject * const name,
 	PyObject * const value
 ) {
+	if (!is_struct(self)) {
+		return PyObject_GenericSetAttr(self, name, value);
+	}
+
 	PyErr_Format(
 		PyExc_TypeError,
 		"%.200s object does not support attribute %s",
@@ -56,9 +81,15 @@ static int Struct_set_attribute(
 }
 
 static PyObject * Struct_get_field_names(PyObject * const self, void * const closure) {
-	return struct_tuple_or_empty(struct_type_of(self)->struct_field_names);
+	return (
+		is_struct(self) ? struct_tuple_or_empty(struct_type_of(self)->struct_field_names) :
+		not_a_struct(self, "__struct_fields__")
+	);
 }
 
 static PyObject * Struct_get_defaults(PyObject * const self, void * const closure) {
-	return struct_tuple_or_empty(struct_type_of(self)->struct_defaults);
+	return (
+		is_struct(self) ? struct_tuple_or_empty(struct_type_of(self)->struct_defaults) :
+		not_a_struct(self, "__struct_defaults__")
+	);
 }

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -10,7 +10,7 @@
 static int Struct_set_attribute(PyObject * self, PyObject * name, PyObject * value);
 static PyObject * Struct_get_field_names(PyObject * self, void * closure);
 static PyObject * Struct_get_defaults(PyObject * self, void * closure);
-static PyObject * not_a_struct(PyObject * self, char const * name);
+static PyObject * metadata_of(PyObject * self, enum struct_metadata which, char const * name);
 static PyGetSetDef Struct_getset[];
 
 PyTypeObject StructMixin_Type = {
@@ -53,11 +53,22 @@ static PyGetSetDef Struct_getset[] = {
  * private class.
  *
  * The two getsets are the exception either way: they report struct metadata and
- * nothing else, so there is nothing to fall back to and they raise.
+ * nothing else, so there is nothing to fall back to and they raise. An
+ * AttributeError rather than a TypeError, because "this object does not have
+ * that attribute" is what happened and it is what `hasattr` and `getattr`'s
+ * default are written to catch.
  */
-static PyObject * not_a_struct(PyObject * const self, char const * const name) {
+static PyObject * metadata_of(
+	PyObject * const self,
+	enum struct_metadata const which,
+	char const * const name
+) {
+	if (is_struct(self)) {
+		return struct_metadata(struct_type_of(self), which);
+	}
+
 	PyErr_Format(
-		PyExc_TypeError,
+		PyExc_AttributeError,
 		"%s is defined on structs, and %.200s is not one",
 		name,
 		Py_TYPE(self)->tp_name
@@ -87,16 +98,11 @@ static int Struct_set_attribute(
 	return RESULT_ERROR;
 }
 
+/* Two entry points because the getset table needs two; the answer is one. */
 static PyObject * Struct_get_field_names(PyObject * const self, void * const closure) {
-	return (
-		is_struct(self) ? struct_tuple_or_empty(struct_type_of(self)->struct_field_names) :
-		not_a_struct(self, "__struct_fields__")
-	);
+	return metadata_of(self, STRUCT_FIELD_NAMES, "__struct_fields__");
 }
 
 static PyObject * Struct_get_defaults(PyObject * const self, void * const closure) {
-	return (
-		is_struct(self) ? struct_tuple_or_empty(struct_type_of(self)->struct_defaults) :
-		not_a_struct(self, "__struct_defaults__")
-	);
+	return metadata_of(self, STRUCT_DEFAULTS, "__struct_defaults__");
 }

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -42,15 +42,18 @@ static PyGetSetDef Struct_getset[] = {
 /*
  * Everything below asks whether it is looking at a struct, because the mixin is
  * a permitted base and a subclass of it need not be one. Where there is no
- * struct, repr and hash fall back to object's rather than raising -- raising
- * out of either would turn an object that is merely useless into one a debugger
- * cannot print.
+ * struct, repr falls back to object's rather than raising -- raising out of
+ * repr would turn an object that is merely useless into one a debugger cannot
+ * print.
  *
  * object's, specifically, and not the co-base's: an impostor over `list` is
- * given object's repr and hashes by pointer, where a plain list subclass is
- * unhashable. Deferring to whatever the co-base defines would mean walking the
- * MRO for something to borrow, on a path reachable only by subclassing a
- * private class.
+ * given object's repr, where a plain list subclass has its own. Deferring to
+ * whatever the co-base defines would mean walking the MRO for something to
+ * borrow, on a path reachable only by subclassing a private class.
+ *
+ * Hash is the exception, and #66 is why: it cannot be a local decision, because
+ * hashing and equality have to agree and equality here is the co-base's. It
+ * refuses instead. See src/hash.c.
  *
  * The two getsets are the exception either way: they report struct metadata and
  * nothing else, so there is nothing to fall back to and they raise. An

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -55,6 +55,22 @@ static PyGetSetDef Struct_getset[] = {
  * hashing and equality have to agree and equality here is the co-base's. It
  * refuses instead. See src/hash.c.
  *
+ * Setattr takes object's too, and that one is worth saying out loud because it
+ * *overrides* rather than falls back: a co-base with its own `__setattr__`
+ * never sees the write. Measured, over a `list` subclass that records every
+ * name set on it -- the co-base alone records `['z']`, the impostor records
+ * nothing and the value lands anyway. Same reason as repr: honouring it means
+ * walking the MRO for a setter to borrow, on a path reachable only by
+ * subclassing a private class.
+ *
+ * Equality is left intransitive by all of this, and #66's fix does not change
+ * it. `rich_compare` answers NotImplemented for a non-struct, so two
+ * content-equal impostors fall back to identity and compare unequal, while each
+ * compares equal to the plain value they wrap through the co-base's reflected
+ * `__eq__`. Pinned in tests/test_struct_identity.py rather than left to be
+ * discovered, because it is a consequence of the fallback policy and not a
+ * separate decision.
+ *
  * The two getsets are the exception either way: they report struct metadata and
  * nothing else, so there is nothing to fall back to and they raise. An
  * AttributeError rather than a TypeError, because "this object does not have

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -42,11 +42,18 @@ static PyGetSetDef Struct_getset[] = {
 /*
  * Everything below asks whether it is looking at a struct, because the mixin is
  * a permitted base and a subclass of it need not be one. Where there is no
- * struct the mixin has nothing to contribute, so the object gets what it would
- * have had without it -- raising out of repr or hash would turn an object that
- * is merely useless into one a debugger cannot print. The two getsets are the
- * exception: they report struct metadata and nothing else, so there is no
- * behaviour to fall back to.
+ * struct, repr and hash fall back to object's rather than raising -- raising
+ * out of either would turn an object that is merely useless into one a debugger
+ * cannot print.
+ *
+ * object's, specifically, and not the co-base's: an impostor over `list` is
+ * given object's repr and hashes by pointer, where a plain list subclass is
+ * unhashable. Deferring to whatever the co-base defines would mean walking the
+ * MRO for something to borrow, on a path reachable only by subclassing a
+ * private class.
+ *
+ * The two getsets are the exception either way: they report struct metadata and
+ * nothing else, so there is nothing to fall back to and they raise.
  */
 static PyObject * not_a_struct(PyObject * const self, char const * const name) {
 	PyErr_Format(

--- a/src/options.h
+++ b/src/options.h
@@ -22,6 +22,20 @@ struct options {
 	bool weakref;
 };
 
+/* Field by field, because a struct of bools has padding and memcmp would read
+ * it. Adding an option to the struct without adding it here is the one way to
+ * get this wrong, which is why they are spelled rather than counted. */
+static inline bool options_agree(struct options const left, struct options const right) {
+	return (
+		left.frozen == right.frozen &&
+		left.eq == right.eq &&
+		left.order == right.order &&
+		left.repr == right.repr &&
+		left.match_args == right.match_args &&
+		left.weakref == right.weakref
+	);
+}
+
 /* Whether the class body's keywords were accepted, and what they resolved to. */
 struct options_request {
 	enum { OPTIONS_RESOLVED, OPTIONS_REJECTED } tag;

--- a/src/repr.c
+++ b/src/repr.c
@@ -12,6 +12,10 @@ static PyObject * field_repr(StructType const * type, PyObject * self, Py_ssize_
  * that contains itself renders as `...` instead of recursing forever.
  */
 PyObject * Struct_repr(PyObject * const self) {
+	if (!is_struct(self)) {
+		return PyBaseObject_Type.tp_repr(self);
+	}
+
 	int const recursive = Py_ReprEnter(self);
 
 	if (recursive != 0) {

--- a/src/salix.c
+++ b/src/salix.c
@@ -8,9 +8,11 @@
  * The design is a deliberately stripped-down clone of msgspec's ``Struct``
  * machinery (see msgspec's src/msgspec/_core.c):
  *
- *   - ``StructMeta``  : a C metaclass whose ``tp_new`` builds the struct type
+ *   - ``_StructMeta`` : a C metaclass whose ``tp_new`` builds the struct type
  *                       at class-creation time, entirely in C (no ``exec``, no
  *                       ``inspect``).  This is what makes type creation fast.
+ *                       Not exported: `type(Struct)` is the only way to it, and
+ *                       there is nothing to do with it that `Struct` does not.
  *   - ``Struct``      : the public base class.  Subclasses declare fields with
  *                       class-body annotations (``a: int``), exactly like
  *                       NamedTuple/dataclass/msgspec.
@@ -85,11 +87,7 @@ static int struct_exec(PyObject * const module) {
 		return RESULT_ERROR;
 	}
 
-	if (add_struct_base(module) != RESULT_OK) {
-		return RESULT_ERROR;
-	}
-
-	return PyModule_AddObjectRef(module, "StructMeta", (PyObject *) &StructMeta_Type);
+	return add_struct_base(module);
 }
 
 static enum result add_struct_base(PyObject * const module) {

--- a/src/salix.c
+++ b/src/salix.c
@@ -121,11 +121,5 @@ static PyObject * create_struct_base(void) {
 		return NULL;
 	}
 
-	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
-
-	if (args == NULL) {
-		return NULL;
-	}
-
-	return StructMeta_new(&StructMeta_Type, args, NULL);
+	return struct_create_root(name, bases, namespace);
 }

--- a/src/testing.c
+++ b/src/testing.c
@@ -70,7 +70,7 @@ PyObject * testing_evaluate(char const * const source) {
 	}
 
 	PyObject * const prelude = PyRun_String(
-		"import salix\nfrom salix import Struct, StructMeta\n",
+		"import salix\nfrom salix import Struct\n",
 		Py_file_input,
 		globals,
 		globals

--- a/src/types.h
+++ b/src/types.h
@@ -125,9 +125,16 @@ static inline PyObject * struct_metadata(
 	StructType const * const type,
 	enum struct_metadata const which
 ) {
-	return struct_tuple_or_empty(
-		which == STRUCT_DEFAULTS ? type->struct_defaults : type->struct_field_names
-	);
+	/* Matched rather than tested, so that a third kind of metadata is a
+	 * compiler error here instead of whatever the false arm happened to be. */
+	switch (which) {
+		case STRUCT_FIELD_NAMES:
+			return struct_tuple_or_empty(type->struct_field_names);
+		case STRUCT_DEFAULTS:
+			return struct_tuple_or_empty(type->struct_defaults);
+	}
+
+	Py_UNREACHABLE();
 }
 
 /* Access the PyMemberDef array that floats behind a heap type. Mirrors

--- a/src/types.h
+++ b/src/types.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Python.h>
+#include <stdbool.h>
 
+#include "meta.h"
 #include "options.h"
 
 /* PyMemberDef only became visible through Python.h in 3.12, and the member
@@ -47,6 +49,21 @@ typedef struct {
 	 * rule put it there. */
 	bool struct_resolves_body_eq;
 } StructType;
+
+/*
+ * Only an instance of StructMeta has the storage declared above; every other
+ * type stops at PyHeapTypeObject, and reading a field off one is a read past
+ * the end of its allocation. _StructMixin is a permitted base and Struct.__mro__
+ * hands it out, so a subclass of it whose metaclass is plain `type` reaches
+ * every slot the mixin installs while being no such thing.
+ */
+static inline bool is_struct_class(PyObject * const object) {
+	return PyObject_TypeCheck(object, &StructMeta_Type);
+}
+
+static inline bool is_struct(PyObject * const self) {
+	return is_struct_class((PyObject *) Py_TYPE(self));
+}
 
 static inline StructType * struct_type_of(PyObject * const self) {
 	return (StructType *) Py_TYPE(self);

--- a/src/types.h
+++ b/src/types.h
@@ -113,6 +113,23 @@ static inline PyObject * struct_tuple_or_empty(PyObject * const tuple) {
 	return tuple != NULL ? Py_NewRef(tuple) : PyTuple_New(0);
 }
 
+/* Which of the two metadata tuples is being asked for. The class answers
+ * through the metaclass and the instance through the mixin, so without this the
+ * same read is written out four times. */
+enum struct_metadata : int {
+	STRUCT_FIELD_NAMES,
+	STRUCT_DEFAULTS,
+};
+
+static inline PyObject * struct_metadata(
+	StructType const * const type,
+	enum struct_metadata const which
+) {
+	return struct_tuple_or_empty(
+		which == STRUCT_DEFAULTS ? type->struct_defaults : type->struct_field_names
+	);
+}
+
 /* Access the PyMemberDef array that floats behind a heap type. Mirrors
  * msgspec's MS_PyHeapType_GET_MEMBERS: the members live just past the type
  * object, which (for a custom metaclass) is sized by the metaclass basicsize. */

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -247,3 +247,34 @@ def test_a_refused_set_field_takes_nothing():
         set_field(pair, "absent", value)
 
     assert sys.getrefcount(value) == before
+
+
+def test_a_delegating_metatype_installs_the_field_table_once():
+    """`type.__new__` hands off to the most derived metatype, which re-enters
+    StructMeta.__new__ and builds the class in full. The outer call used to
+    install a second field table over the first, releasing nothing -- one leaked
+    __post_init__, defaults tuple and slot-offset array per class.
+    """
+
+    import salix
+
+    class Derived(salix.StructMeta):
+        pass
+
+    def post_init(self):
+        pass
+
+    class Base(Struct, metaclass=Derived):
+        x: int
+        __post_init__ = post_init
+
+    namespace = {"__annotations__": {"y": int}, "__post_init__": post_init}
+    before = sys.getrefcount(post_init)
+    built = salix.StructMeta("Built", (Base,), namespace)
+
+    assert built.__struct_fields__ == ("x", "y")
+    assert built(1, 2).y == 2
+
+    # One for the namespace dict, one for the class that resolved it. A second
+    # install would take a third and never give it back.
+    assert sys.getrefcount(post_init) - before == 2

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -251,14 +251,12 @@ def test_a_refused_set_field_takes_nothing():
 
 def test_a_delegating_metatype_installs_the_field_table_once():
     """`type.__new__` hands off to the most derived metatype, which re-enters
-    StructMeta.__new__ and builds the class in full. The outer call used to
-    install a second field table over the first, releasing nothing -- one leaked
-    __post_init__, defaults tuple and slot-offset array per class.
+    the metaclass's `__new__` and builds the class in full. The outer call used
+    to install a second field table over the first, releasing nothing -- one
+    leaked __post_init__, defaults tuple and slot-offset array per class.
     """
 
-    import salix
-
-    class Derived(salix.StructMeta):
+    class Derived(type(Struct)):
         pass
 
     def post_init(self):
@@ -270,7 +268,7 @@ def test_a_delegating_metatype_installs_the_field_table_once():
 
     namespace = {"__annotations__": {"y": int}, "__post_init__": post_init}
     before = sys.getrefcount(post_init)
-    built = salix.StructMeta("Built", (Base,), namespace)
+    built = type(Struct)("Built", (Base,), namespace)
 
     assert built.__struct_fields__ == ("x", "y")
     assert built(1, 2).y == 2

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -275,6 +275,8 @@ def test_a_delegating_metatype_installs_the_field_table_once():
     assert built.__struct_fields__ == ("x", "y")
     assert built(1, 2).y == 2
 
-    # One for the namespace dict, one for the class that resolved it. A second
-    # install would take a third and never give it back.
+    # `before` already counts the namespace dict's reference. The two are the
+    # built class's own __post_init__ binding and the struct_post_init that
+    # install_post_init resolved. A second install would take a third and never
+    # give it back.
     assert sys.getrefcount(post_init) - before == 2

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -10,7 +10,6 @@ Run with `uv run camas test` (or `python -m pytest`).
 
 import pytest
 
-import salix
 from salix import Struct
 
 
@@ -147,11 +146,10 @@ def test_empty_struct():
 
 
 def test_metaclass_identity():
-    assert type(Point2D) is salix.StructMeta
+    assert type(Point2D) is type(Struct)
     assert isinstance(Point2D(1.0, 2.0), Struct)
 
 
 def test_module_of_the_exported_names():
     assert Struct.__module__ == "salix"
-    assert salix.StructMeta.__module__ == "salix"
     assert Point2D.__module__ == __name__

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -92,6 +92,63 @@ class TestTheMetaclassWithoutTheMixin:
         assert built(1, 2) == built(1, 2)
 
 
+class TestTheUninstalledClassCannotBeBuilt:
+    """`is_struct` asks the metaclass, so every StructMeta instance has to have
+    a field table. What guarantees it is CPython's own `tp_new_wrapper`: the
+    most derived non-heap base of the requested type is `StructMeta`, whose
+    `tp_new` is not `type`'s, so `type.__new__` refuses to build one.
+
+    That guard is load-bearing and it is CPython's, not salix's, so these pin it
+    on every supported version rather than trusting it. Without it, the class
+    would have NULL `struct_field_names` and `x == x` would reach
+    `PyObject_RichCompareBool(NULL, NULL, Py_EQ)`.
+    """
+
+    @staticmethod
+    def metaclass_subclass_that_builds_with_type_new():
+        class Substituting(salix.StructMeta):
+            def __new__(mcls, *args, **keywords):
+                return type.__new__(mcls, *args, **keywords)
+
+        return Substituting
+
+    def test_type_new_refuses_the_metaclass(self):
+        with pytest.raises(TypeError, match="is not safe"):
+            type.__new__(salix.StructMeta, "S", (Point,), {})
+
+    def test_type_new_refuses_a_metaclass_subclass(self):
+        class Inheriting(salix.StructMeta):
+            pass
+
+        with pytest.raises(TypeError, match="is not safe"):
+            type.__new__(Inheriting, "S", (Point,), {})
+
+    def test_a_metaclass_new_that_reaches_for_type_new_is_refused_too(self):
+        """The substitution route into the same hole: the refusal follows the
+        metatype rather than the call site.
+        """
+
+        Substituting = self.metaclass_subclass_that_builds_with_type_new()
+
+        with pytest.raises(TypeError, match="is not safe"):
+            type.__new__(Substituting, "S", (Point,), {})
+
+        with pytest.raises(TypeError, match="is not safe"):
+            Substituting("S", (Point,), {})
+
+    def test_the_supported_route_still_installs(self):
+        """types.new_class goes the long way round and comes out a real struct,
+        so the refusals above are not refusing everything.
+        """
+
+        import types
+
+        built = types.new_class("S", (Point,), {"metaclass": salix.StructMeta})
+
+        assert built.__struct_fields__ == ("x",)
+        assert built(1) == built(1)
+
+
 class TestAMetaclassSubclass:
     def test_one_that_delegates_produces_a_struct(self):
         class Delegating(salix.StructMeta):
@@ -118,6 +175,26 @@ class TestAMetaclassSubclass:
 
         assert built(1, 2) < built(1, 3)
         assert type(built) is Delegating
+
+    def test_two_unrelated_metatypes_still_raise_the_conflict(self):
+        """Picking the winner ourselves must not swallow the case that has no
+        winner: type_new is handed the requested metatype and says so.
+        """
+
+        class Left(salix.StructMeta):
+            pass
+
+        class Right(salix.StructMeta):
+            pass
+
+        class FromLeft(Struct, metaclass=Left):
+            x: int
+
+        class FromRight(Struct, metaclass=Right):
+            y: int
+
+        with pytest.raises(TypeError, match="metaclass conflict"):
+            salix.StructMeta("Both", (FromLeft, FromRight), {})
 
     def test_a_default_survives_the_handoff_to_a_derived_metatype(self):
         """The re-entered call read the namespace after drop_class_variables had

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -11,6 +11,8 @@ The crashes cannot be asserted directly -- a segfault takes pytest with it -- so
 each one is pinned by the guarded outcome it now produces.
 """
 
+import collections.abc
+
 import pytest
 
 import salix
@@ -62,6 +64,21 @@ class TestAMixinSubclass:
 
         with pytest.raises(TypeError, match="unhashable type: 'Impostor'"):
             hash(impostor)
+
+    def test_it_is_an_instance_of_Hashable_all_the_same(self, impostor):
+        """The ABC asks whether tp_hash is non-NULL rather than calling it, and
+        the mixin's is -- the slot every struct hashes through. So the operator
+        and `isinstance` disagree, which is what a writable memoryview does too.
+        """
+
+        assert isinstance(impostor, collections.abc.Hashable)
+
+        view = memoryview(bytearray(b"ab"))
+
+        assert isinstance(view, collections.abc.Hashable)
+
+        with pytest.raises(ValueError, match="cannot hash writable memoryview"):
+            hash(view)
 
     def test_equality_between_two_of_them_is_intransitive(self):
         """A consequence of the fallback policy rather than a decision of its
@@ -168,6 +185,28 @@ class TestTheMetaclassWithoutTheMixin:
 
         assert built.__struct_fields__ == ("x", "y")
         assert built(1, 2) == built(1, 2)
+
+    @pytest.mark.parametrize("attribute", ["__struct_fields__", "__struct_defaults__"])
+    def test_its_own_metadata_getters_are_never_handed_the_metaclass(self, attribute):
+        """They read fields that live past the end of a PyTypeObject, so what
+        they are handed has to be an instance of the metaclass -- sized by its
+        basicsize -- and never the metaclass itself, which is an instance of
+        `type` and shorter by the difference the third assertion names.
+
+        Two things keep it that way, and neither is salix's: `type(META)` is
+        `type`, so an attribute lookup on META finds the descriptor and returns
+        it unread, and the descriptor refuses any other object outright.
+        """
+
+        descriptor = META.__dict__[attribute]
+
+        assert type(META) is type
+        assert getattr(META, attribute) is descriptor
+        assert META.__basicsize__ > type.__basicsize__
+
+        for wrong in (META, type, int, object()):
+            with pytest.raises(TypeError, match="doesn't apply to"):
+                descriptor.__get__(wrong)
 
 
 def metaclass_subclass_that_builds_with_type_new():
@@ -296,6 +335,29 @@ class TestAMetaclassSubclass:
         built = META("Built", (Base,), namespace)
 
         assert built(1).y == 42
+
+    @pytest.mark.xfail(strict=True, reason="#55")
+    def test_both_survive_a_delegate_that_writes_its_own_new(self):
+        """What the two above do not cover. They pass because the winner's
+        tp_new is StructMeta_new, so create_class builds as the winner and the
+        keywords and the untransformed namespace are still in hand. A Python
+        __new__ -- even one that only forwards -- makes type_new hand the build
+        to it instead, with no keywords and a namespace drop_class_variables has
+        already taken the defaults out of.
+        """
+
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "y": 42}
+        built = META("Built", (Base,), namespace, order=True)
+
+        assert built(1).y == 42
+        assert built(1) < built(1, 43)
 
     @pytest.mark.parametrize("produced", ["not a type", bytearray(8192), 0])
     def test_one_that_returns_a_non_type_is_refused(self, produced):

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -63,6 +63,45 @@ class TestAMixinSubclass:
         with pytest.raises(TypeError, match="unhashable type: 'Impostor'"):
             hash(impostor)
 
+    def test_equality_between_two_of_them_is_intransitive(self):
+        """A consequence of the fallback policy rather than a decision of its
+        own, and #66's fix does not change it: `rich_compare` answers
+        NotImplemented for a non-struct, so two content-equal impostors fall
+        back to identity, while each compares equal to the plain value they
+        wrap through the co-base's reflected `__eq__`.
+        """
+
+        pair = type("Tupleish", (MIXIN, tuple), {"__slots__": ()})
+        left, right = pair((1, 2)), pair((1, 2))
+
+        assert left == (1, 2)
+        assert right == (1, 2)
+        assert left != right
+
+    def test_the_co_base_setter_is_overridden_rather_than_deferred_to(self):
+        """Setattr falls back to object's, which for a co-base that defines its
+        own `__setattr__` means overriding it rather than falling back: the
+        write lands and the co-base never sees it. Same trade as repr, stated
+        here because the comment in mixin.c is the only other place it exists.
+        """
+
+        seen = []
+
+        class Recording(list):
+            def __setattr__(self, name, value):
+                seen.append(name)
+                object.__setattr__(self, name, value)
+
+        impostor = type("Sub", (MIXIN, Recording), {"__slots__": ("z",)})()
+        impostor.z = 1
+
+        assert impostor.z == 1
+        assert seen == []
+
+        Recording().z = 1
+
+        assert seen == ["z"]
+
     def test_it_cannot_be_equal_to_something_it_hashes_differently_from(self):
         """The contract the fallback used to break, over a co-base that is
         itself a value type: `==` said yes and the dict said no.
@@ -131,6 +170,14 @@ class TestTheMetaclassWithoutTheMixin:
         assert built(1, 2) == built(1, 2)
 
 
+def metaclass_subclass_that_builds_with_type_new():
+    class Substituting(META):
+        def __new__(mcls, *args, **keywords):
+            return type.__new__(mcls, *args, **keywords)
+
+    return Substituting
+
+
 class TestTheUninstalledClassCannotBeBuilt:
     """`is_struct` asks the metaclass, so every instance of it has to have
     a field table. What guarantees it is CPython's own `tp_new_wrapper`: the
@@ -144,34 +191,31 @@ class TestTheUninstalledClassCannotBeBuilt:
     of those slots reads holds.
     """
 
-    @staticmethod
-    def metaclass_subclass_that_builds_with_type_new():
-        class Substituting(META):
-            def __new__(mcls, *args, **keywords):
-                return type.__new__(mcls, *args, **keywords)
-
-        return Substituting
-
-    def test_type_new_refuses_the_metaclass(self):
-        with pytest.raises(TypeError, match="is not safe"):
-            type.__new__(META, "S", (Point,), {})
-
-    def test_type_new_refuses_a_metaclass_subclass(self):
-        class Inheriting(META):
-            pass
-
-        with pytest.raises(TypeError, match="is not safe"):
-            type.__new__(Inheriting, "S", (Point,), {})
-
-    def test_a_metaclass_new_that_reaches_for_type_new_is_refused_too(self):
-        """The substitution route into the same hole: the refusal follows the
-        metatype rather than the call site.
+    @pytest.mark.parametrize(
+        "metatype",
+        [
+            pytest.param(lambda: META, id="the-metaclass"),
+            pytest.param(lambda: type("Inheriting", (META,), {}), id="a-plain-subclass"),
+            pytest.param(
+                metaclass_subclass_that_builds_with_type_new,
+                id="one-that-substitutes-type-new",
+            ),
+        ],
+    )
+    def test_type_new_refuses_every_route_to_the_metatype(self, metatype):
+        """One assertion, three ways in: the refusal follows the metatype rather
+        than the call site.
         """
 
-        Substituting = self.metaclass_subclass_that_builds_with_type_new()
-
         with pytest.raises(TypeError, match="is not safe"):
-            type.__new__(Substituting, "S", (Point,), {})
+            type.__new__(metatype(), "S", (Point,), {})
+
+    def test_the_substituting_new_is_refused_through_its_own_call_too(self):
+        """The route the parametrization above cannot express: not
+        `type.__new__` directly, but the metaclass call that reaches it.
+        """
+
+        Substituting = metaclass_subclass_that_builds_with_type_new()
 
         with pytest.raises(TypeError, match="is not safe"):
             Substituting("S", (Point,), {})

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1,10 +1,11 @@
 """What the struct machinery does when handed something that is not a struct.
 
-`_StructMixin` is a permitted base and `StructMeta` is exported, so both are
-reachable without `Struct` anywhere in the bases. Most of what is asserted here
-used to be a segfault or a class that reported its fields and behaved like
-`object`; `TestTheUninstalledClassCannotBeBuilt` is the exception, pinning a
-CPython guard that salix relies on and never crashed without.
+Neither the mixin nor the metaclass is exported, and both are one attribute
+lookup from `Struct`, so both are reachable without `Struct` anywhere in the
+bases. Most of what is asserted here used to be a segfault or a class that
+reported its fields and behaved like `object`;
+`TestTheUninstalledClassCannotBeBuilt` is the exception, pinning a CPython
+guard that salix relies on and never crashed without.
 
 The crashes cannot be asserted directly -- a segfault takes pytest with it -- so
 each one is pinned by the guarded outcome it now produces.
@@ -16,6 +17,7 @@ import salix
 from salix import Struct
 
 MIXIN = Struct.__mro__[1]
+META = type(Struct)
 
 
 class Point(Struct):
@@ -73,31 +75,39 @@ class TestAMixinSubclass:
 
 
 class TestTheMetaclassWithoutTheMixin:
+    def test_the_module_does_not_offer_it(self):
+        """#15: reaching the metaclass takes `type(Struct)`, which is what the
+        rest of this class does. What is gone is the invitation to.
+        """
+
+        assert not hasattr(salix, "StructMeta")
+        assert META.__name__ == "_StructMeta"
+
     def test_a_class_body_naming_it_is_refused(self):
         with pytest.raises(TypeError, match="a struct class inherits salix"):
 
-            class Bare(metaclass=salix.StructMeta):
+            class Bare(metaclass=META):
                 x: int
 
     def test_calling_it_with_no_bases_is_refused(self):
         with pytest.raises(TypeError, match="a struct class inherits salix"):
-            salix.StructMeta("Bare", (), {})
+            META("Bare", (), {})
 
     def test_a_co_base_that_is_not_a_struct_does_not_smuggle_one_through(self):
         with pytest.raises(TypeError, match="a struct class inherits salix"):
-            salix.StructMeta("Bare", (list,), {})
+            META("Bare", (list,), {})
 
     def test_calling_it_with_a_struct_base_still_works(self):
-        built = salix.StructMeta("Extended", (Point,), {"__annotations__": {"y": int}})
+        built = META("Extended", (Point,), {"__annotations__": {"y": int}})
 
         assert built.__struct_fields__ == ("x", "y")
         assert built(1, 2) == built(1, 2)
 
 
 class TestTheUninstalledClassCannotBeBuilt:
-    """`is_struct` asks the metaclass, so every StructMeta instance has to have
+    """`is_struct` asks the metaclass, so every instance of it has to have
     a field table. What guarantees it is CPython's own `tp_new_wrapper`: the
-    most derived non-heap base of the requested type is `StructMeta`, whose
+    most derived non-heap base of the requested type is the metaclass, whose
     `tp_new` is not `type`'s, so `type.__new__` refuses to build one.
 
     That guard is load-bearing and it is CPython's, not salix's, so these pin it
@@ -109,7 +119,7 @@ class TestTheUninstalledClassCannotBeBuilt:
 
     @staticmethod
     def metaclass_subclass_that_builds_with_type_new():
-        class Substituting(salix.StructMeta):
+        class Substituting(META):
             def __new__(mcls, *args, **keywords):
                 return type.__new__(mcls, *args, **keywords)
 
@@ -117,10 +127,10 @@ class TestTheUninstalledClassCannotBeBuilt:
 
     def test_type_new_refuses_the_metaclass(self):
         with pytest.raises(TypeError, match="is not safe"):
-            type.__new__(salix.StructMeta, "S", (Point,), {})
+            type.__new__(META, "S", (Point,), {})
 
     def test_type_new_refuses_a_metaclass_subclass(self):
-        class Inheriting(salix.StructMeta):
+        class Inheriting(META):
             pass
 
         with pytest.raises(TypeError, match="is not safe"):
@@ -146,7 +156,7 @@ class TestTheUninstalledClassCannotBeBuilt:
 
         import types
 
-        built = types.new_class("S", (Point,), {"metaclass": salix.StructMeta})
+        built = types.new_class("S", (Point,), {"metaclass": META})
 
         assert built.__struct_fields__ == ("x",)
         assert built(1) == built(1)
@@ -154,7 +164,7 @@ class TestTheUninstalledClassCannotBeBuilt:
 
 class TestAMetaclassSubclass:
     def test_one_that_delegates_produces_a_struct(self):
-        class Delegating(salix.StructMeta):
+        class Delegating(META):
             pass
 
         class Delegated(Struct, metaclass=Delegating):
@@ -168,13 +178,13 @@ class TestAMetaclassSubclass:
         here with no keywords at all and planned the class without them.
         """
 
-        class Delegating(salix.StructMeta):
+        class Delegating(META):
             pass
 
         class Base(Struct, metaclass=Delegating):
             x: int
 
-        built = salix.StructMeta("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
 
         assert built(1, 2) < built(1, 3)
         assert type(built) is Delegating
@@ -184,10 +194,10 @@ class TestAMetaclassSubclass:
         winner: type_new is handed the requested metatype and says so.
         """
 
-        class Left(salix.StructMeta):
+        class Left(META):
             pass
 
-        class Right(salix.StructMeta):
+        class Right(META):
             pass
 
         class FromLeft(Struct, metaclass=Left):
@@ -197,7 +207,7 @@ class TestAMetaclassSubclass:
             y: int
 
         with pytest.raises(TypeError, match="metaclass conflict"):
-            salix.StructMeta("Both", (FromLeft, FromRight), {})
+            META("Both", (FromLeft, FromRight), {})
 
     def test_a_default_survives_the_handoff_to_a_derived_metatype(self):
         """The re-entered call read the namespace after drop_class_variables had
@@ -205,14 +215,14 @@ class TestAMetaclassSubclass:
         was gone by the time it planned the fields.
         """
 
-        class Delegating(salix.StructMeta):
+        class Delegating(META):
             pass
 
         class Base(Struct, metaclass=Delegating):
             x: int
 
         namespace = {"__annotations__": {"y": int}, "y": 42}
-        built = salix.StructMeta("Built", (Base,), namespace)
+        built = META("Built", (Base,), namespace)
 
         assert built(1).y == 42
 
@@ -231,7 +241,7 @@ class TestAMetaclassSubclass:
 
         calls = []
 
-        class Wrong(salix.StructMeta):
+        class Wrong(META):
             def __new__(mcls, *args, **keywords):
                 calls.append(1)
 
@@ -244,4 +254,4 @@ class TestAMetaclassSubclass:
             a: int
 
         with pytest.raises(TypeError, match=r"Wrong\.__new__ returned .*is not a struct class"):
-            salix.StructMeta("Z", (Seeded,), {"__annotations__": {"b": int}})
+            META("Z", (Seeded,), {"__annotations__": {"b": int}})

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -61,13 +61,17 @@ class TestAMixinSubclass:
 
         assert impostor.z == 1
 
-    def test_it_has_no_field_names_to_report(self, impostor):
-        with pytest.raises(TypeError, match="__struct_fields__ is defined on structs"):
-            _ = impostor.__struct_fields__
+    @pytest.mark.parametrize("attribute", ["__struct_fields__", "__struct_defaults__"])
+    def test_it_has_no_metadata_to_report(self, impostor, attribute):
+        """An AttributeError rather than a TypeError, because that is what the
+        two facilities for asking whether an attribute is there catch.
+        """
 
-    def test_it_has_no_defaults_to_report(self, impostor):
-        with pytest.raises(TypeError, match="__struct_defaults__ is defined on structs"):
-            _ = impostor.__struct_defaults__
+        with pytest.raises(AttributeError, match=f"{attribute} is defined on structs"):
+            getattr(impostor, attribute)
+
+        assert not hasattr(impostor, attribute)
+        assert getattr(impostor, attribute, "absent") == "absent"
 
     def test_set_field_still_refuses_it(self, impostor):
         with pytest.raises(TypeError, match="expects a struct"):
@@ -78,10 +82,14 @@ class TestTheMetaclassWithoutTheMixin:
     def test_the_module_does_not_offer_it(self):
         """#15: reaching the metaclass takes `type(Struct)`, which is what the
         rest of this class does. What is gone is the invitation to.
+
+        The second assertion is the relationship rather than the spelling: the
+        name a repr shows is not a name the module answers to, whatever that
+        name is later changed to.
         """
 
         assert not hasattr(salix, "StructMeta")
-        assert META.__name__ == "_StructMeta"
+        assert not hasattr(salix, META.__name__)
 
     def test_a_class_body_naming_it_is_refused(self):
         with pytest.raises(TypeError, match="a struct class inherits salix"):

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -53,8 +53,27 @@ class TestAMixinSubclass:
     def test_it_reprs_as_the_object_it_is(self, impostor):
         assert "Impostor object at" in repr(impostor)
 
-    def test_it_hashes_by_identity(self, impostor):
-        assert hash(impostor) == object.__hash__(impostor)
+    def test_it_is_unhashable(self, impostor):
+        """#66: it is compared by its co-base, because rich_compare answers
+        NotImplemented and the reflected operation gets there. An identity hash
+        beside that made it equal to a value it could not be looked up beside,
+        so hashing refuses instead and the pair is consistent again.
+        """
+
+        with pytest.raises(TypeError, match="unhashable type: 'Impostor'"):
+            hash(impostor)
+
+    def test_it_cannot_be_equal_to_something_it_hashes_differently_from(self):
+        """The contract the fallback used to break, over a co-base that is
+        itself a value type: `==` said yes and the dict said no.
+        """
+
+        equal_to_a_tuple = type("Tupleish", (MIXIN, tuple), {"__slots__": ()})((1, 2))
+
+        assert equal_to_a_tuple == (1, 2)
+
+        with pytest.raises(TypeError, match="unhashable type"):
+            {(1, 2): "from the tuple"}[equal_to_a_tuple]
 
     def test_it_is_not_frozen(self, impostor):
         impostor.z = 1

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1,8 +1,10 @@
 """What the struct machinery does when handed something that is not a struct.
 
 `_StructMixin` is a permitted base and `StructMeta` is exported, so both are
-reachable without `Struct` anywhere in the bases. Everything asserted here used
-to be a segfault or a class that reported its fields and behaved like `object`.
+reachable without `Struct` anywhere in the bases. Most of what is asserted here
+used to be a segfault or a class that reported its fields and behaved like
+`object`; `TestTheUninstalledClassCannotBeBuilt` is the exception, pinning a
+CPython guard that salix relies on and never crashed without.
 
 The crashes cannot be asserted directly -- a segfault takes pytest with it -- so
 each one is pinned by the guarded outcome it now produces.
@@ -99,9 +101,10 @@ class TestTheUninstalledClassCannotBeBuilt:
     `tp_new` is not `type`'s, so `type.__new__` refuses to build one.
 
     That guard is load-bearing and it is CPython's, not salix's, so these pin it
-    on every supported version rather than trusting it. Without it, the class
-    would have NULL `struct_field_names` and `x == x` would reach
-    `PyObject_RichCompareBool(NULL, NULL, Py_EQ)`.
+    on every supported version rather than trusting it. What a class that got
+    past it would do to the guarded slots is not asserted here, because the
+    guard cannot be turned off to find out -- only that the invariant every one
+    of those slots reads holds.
     """
 
     @staticmethod

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -103,10 +103,50 @@ class TestAMetaclassSubclass:
         assert Delegated(1).__struct_fields__ == ("a",)
         assert type(Delegated) is Delegating
 
+    def test_a_keyword_option_survives_the_handoff_to_a_derived_metatype(self):
+        """type.__new__ would hand off to the derived metatype, which re-entered
+        here with no keywords at all and planned the class without them.
+        """
+
+        class Delegating(salix.StructMeta):
+            pass
+
+        class Base(Struct, metaclass=Delegating):
+            x: int
+
+        built = salix.StructMeta("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert built(1, 2) < built(1, 3)
+        assert type(built) is Delegating
+
+    def test_a_default_survives_the_handoff_to_a_derived_metatype(self):
+        """The re-entered call read the namespace after drop_class_variables had
+        taken the field names out of it, so every default declared in the body
+        was gone by the time it planned the fields.
+        """
+
+        class Delegating(salix.StructMeta):
+            pass
+
+        class Base(Struct, metaclass=Delegating):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "y": 42}
+        built = salix.StructMeta("Built", (Base,), namespace)
+
+        assert built(1).y == 42
+
     @pytest.mark.parametrize("produced", ["not a type", bytearray(8192), 0])
-    def test_one_that_returns_something_else_is_refused(self, produced):
+    def test_one_that_returns_a_non_type_is_refused(self, produced):
         """type.__new__ hands off to the winning metatype, so the object
         create_class gets back is whatever this __new__ chose to return.
+
+        A __new__ that builds its substitute with an inline `type(name, bases,
+        ns)` never gets here: the bases carry the same metaclass, so `type` re-
+        enters it and CPython raises RecursionError before anything is returned.
+        That is metaclass semantics rather than salix's -- the same __new__ on a
+        plain `type` subclass recurses identically -- so the refusal covers what
+        a __new__ returns, not every way one can fail to return.
         """
 
         calls = []
@@ -123,5 +163,5 @@ class TestAMetaclassSubclass:
         class Seeded(Struct, metaclass=Wrong):
             a: int
 
-        with pytest.raises(TypeError, match="is not a struct class"):
+        with pytest.raises(TypeError, match=r"Wrong\.__new__ returned .*is not a struct class"):
             salix.StructMeta("Z", (Seeded,), {"__annotations__": {"b": int}})

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -336,6 +336,48 @@ class TestAMetaclassSubclass:
 
         assert built(1).y == 42
 
+    def test_a_delegate_that_writes_its_own_new_is_refused_not_mis_planned(self):
+        """The half of #55 that is answerable here: the class the delegate hands
+        back is checked against what this call planned, and a mismatch is an
+        error rather than a class that quietly is not the one asked for.
+
+        The class statement is not affected, and the test below this one says
+        so: there the winner is the requested metatype, so nothing is handed
+        off and the keywords and the body's defaults are still in hand.
+        """
+
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "y": 42}
+
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), namespace, order=True)
+
+    def test_the_class_statement_reaches_none_of_that(self):
+        """The hand-off only happens for an explicit metaclass call over a base
+        whose metatype wins. Written out, because the refusal above would be a
+        serious regression if it reached the ordinary spelling.
+        """
+
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        class Statement(Base, order=True):
+            y: int = 42
+
+        assert Statement.__struct_fields__ == ("x", "y")
+        assert Statement(1).y == 42
+        assert Statement(1) < Statement(1, 43)
+
     @pytest.mark.xfail(strict=True, reason="#55")
     def test_both_survive_a_delegate_that_writes_its_own_new(self):
         """What the two above do not cover. They pass because the winner's
@@ -344,6 +386,9 @@ class TestAMetaclassSubclass:
         __new__ -- even one that only forwards -- makes type_new hand the build
         to it instead, with no keywords and a namespace drop_class_variables has
         already taken the defaults out of.
+
+        Refused rather than mis-planned since the guard above, which is not the
+        same as fixed: what #55 wants is for this call to work.
         """
 
         class Forwarding(META):

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1,0 +1,127 @@
+"""What the struct machinery does when handed something that is not a struct.
+
+`_StructMixin` is a permitted base and `StructMeta` is exported, so both are
+reachable without `Struct` anywhere in the bases. Everything asserted here used
+to be a segfault or a class that reported its fields and behaved like `object`.
+
+The crashes cannot be asserted directly -- a segfault takes pytest with it -- so
+each one is pinned by the guarded outcome it now produces.
+"""
+
+import pytest
+
+import salix
+from salix import Struct
+
+MIXIN = Struct.__mro__[1]
+
+
+class Point(Struct):
+    x: int
+
+
+class Ordered(Struct, order=True):
+    x: int
+
+
+@pytest.fixture
+def impostor():
+    """A mixin subclass. The co-base supplies the tp_new the mixin withholds,
+    which is what makes one of these constructible at all.
+    """
+
+    return type("Impostor", (MIXIN, list), {"__slots__": ("z",)})()
+
+
+class TestAMixinSubclass:
+    def test_a_struct_does_not_compare_equal_to_one(self, impostor):
+        assert Point(1) != impostor
+        assert impostor != Point(1)
+        assert (Point(1) == impostor) is False
+
+    def test_it_does_not_order_against_a_struct(self, impostor):
+        with pytest.raises(TypeError):
+            _ = Ordered(1) < impostor
+
+        with pytest.raises(TypeError):
+            _ = impostor < Ordered(1)
+
+    def test_it_reprs_as_the_object_it_is(self, impostor):
+        assert "Impostor object at" in repr(impostor)
+
+    def test_it_hashes_by_identity(self, impostor):
+        assert hash(impostor) == object.__hash__(impostor)
+
+    def test_it_is_not_frozen(self, impostor):
+        impostor.z = 1
+
+        assert impostor.z == 1
+
+    def test_it_has_no_field_names_to_report(self, impostor):
+        with pytest.raises(TypeError, match="__struct_fields__ is defined on structs"):
+            _ = impostor.__struct_fields__
+
+    def test_it_has_no_defaults_to_report(self, impostor):
+        with pytest.raises(TypeError, match="__struct_defaults__ is defined on structs"):
+            _ = impostor.__struct_defaults__
+
+    def test_set_field_still_refuses_it(self, impostor):
+        with pytest.raises(TypeError, match="expects a struct"):
+            salix.set_field(impostor, "z", 1)
+
+
+class TestTheMetaclassWithoutTheMixin:
+    def test_a_class_body_naming_it_is_refused(self):
+        with pytest.raises(TypeError, match="a struct class inherits salix"):
+
+            class Bare(metaclass=salix.StructMeta):
+                x: int
+
+    def test_calling_it_with_no_bases_is_refused(self):
+        with pytest.raises(TypeError, match="a struct class inherits salix"):
+            salix.StructMeta("Bare", (), {})
+
+    def test_a_co_base_that_is_not_a_struct_does_not_smuggle_one_through(self):
+        with pytest.raises(TypeError, match="a struct class inherits salix"):
+            salix.StructMeta("Bare", (list,), {})
+
+    def test_calling_it_with_a_struct_base_still_works(self):
+        built = salix.StructMeta("Extended", (Point,), {"__annotations__": {"y": int}})
+
+        assert built.__struct_fields__ == ("x", "y")
+        assert built(1, 2) == built(1, 2)
+
+
+class TestAMetaclassSubclass:
+    def test_one_that_delegates_produces_a_struct(self):
+        class Delegating(salix.StructMeta):
+            pass
+
+        class Delegated(Struct, metaclass=Delegating):
+            a: int
+
+        assert Delegated(1).__struct_fields__ == ("a",)
+        assert type(Delegated) is Delegating
+
+    @pytest.mark.parametrize("produced", ["not a type", bytearray(8192), 0])
+    def test_one_that_returns_something_else_is_refused(self, produced):
+        """type.__new__ hands off to the winning metatype, so the object
+        create_class gets back is whatever this __new__ chose to return.
+        """
+
+        calls = []
+
+        class Wrong(salix.StructMeta):
+            def __new__(mcls, *args, **keywords):
+                calls.append(1)
+
+                if len(calls) == 1:
+                    return super().__new__(mcls, *args, **keywords)
+
+                return produced
+
+        class Seeded(Struct, metaclass=Wrong):
+            a: int
+
+        with pytest.raises(TypeError, match="is not a struct class"):
+            salix.StructMeta("Z", (Seeded,), {"__annotations__": {"b": int}})

--- a/tests/typing/rejected.py
+++ b/tests/typing/rejected.py
@@ -69,9 +69,15 @@ def ordering_against_an_unrelated_struct_is_rejected() -> None:
 
 
 def an_unknown_class_keyword_is_rejected() -> None:
-    """pyright's and ty's; mypy does not check keywords against __init_subclass__."""
+    """All three, since the stub stopped naming a metaclass: a class keyword
+    goes to the metaclass when there is one, and mypy stops checking it against
+    __init_subclass__ there.
+    """
 
-    class Typo(Struct, frozn=False):  # pyright: ignore[reportGeneralTypeIssues, reportCallIssue]
+    class Typo(  # type: ignore[call-arg]
+        Struct,
+        frozn=False,  # pyright: ignore[reportCallIssue]
+    ):
         value: int
 
 


### PR DESCRIPTION
Closes #15. Closes #28. Closes #29. Three issues, one missing question.

`struct_type_of` reinterprets `Py_TYPE(self)` as a `StructType *`, and only an instance of `StructMeta` has that storage — every other type stops at `PyHeapTypeObject`, so the read runs off the end of the allocation. `is_struct` and `is_struct_class` in `types.h` are that question written once; `set_field` already asked it inline and now shares the name.

### #28 — a mixin subclass segfaults, and the crashing call is an ordinary struct's `__eq__`

```python
Mixin = salix.Struct.__mro__[1]
F = type("F", (Mixin, list), {"__slots__": ("zzzzz",)})
P(1) == F()                          # segfault
```

`_StructMixin` carries `Py_TPFLAGS_BASETYPE` and `Struct.__mro__` hands it out, so a subclass of it whose metaclass is plain `type` reaches all four slots and both getsets while being no such thing. The co-base is what makes it constructible — a bare subclass inherits the mixin's NULL `tp_new` — which is why an earlier look concluded the mixin was closed off.

Where there is no struct the mixin has nothing to contribute, so the object gets what it would have had without it: `object`'s repr and hash, generic setattr, `NotImplemented` from the comparison. Raising out of `repr` or `hash` would turn an object that is merely useless into one a debugger cannot print. The two getsets are the exception — they report struct metadata and nothing else — so they raise `TypeError`.

### #29 — `create_class` cast `type.__new__`'s result unchecked

`type_new` hands off to the winning metatype's `tp_new` when that differs from the one it was given, so a `StructMeta` subclass overriding `__new__` decides what comes back — and `install_fields` writes six fields at `StructType` offsets into it. Returning a `str` or a `bytearray(8192)` segfaults. Checked now, and the error names both the metaclass and what it produced.

### #15 — a bare `metaclass=StructMeta` built something that was not a struct

It reported its fields correctly and had identity equality, `object`'s repr, and a `frozen` that accepted assignment — because `apply_options` only acts on transitions and with no struct base there are none. `bind_hash` bound the mixin's `__hash__` into a class with no mixin in its MRO, so `hash(C(1))` raised about a `'_StructMixin'` object.

Refused now: everything a struct does comes from the mixin, so a class without it in the bases is not one.

<details>
<summary><b>One decision this takes, and one it leaves open</b></summary>

That is **option 1** of the three in #15. **Option 3** — dropping `StructMeta` from the module's exports, keeping it only in the stub where `Struct`'s `metaclass=` needs it — is a separate decision and still open. It has to be made before the first upload either way, and it also settles what #24 and #20 should do about the namespace.

</details>

Sixteen tests in `tests/test_struct_identity.py`, each pinning a guarded outcome rather than a crash: a segfault takes pytest with it.

Rebased onto `main` after #43 and #45 landed, which rewrote `apply_options`/`bind_hash` and `Struct_set_field` underneath this. All three reproductions re-verified after the rebase, along with the merged behaviour from both: `B.__hash__ is None` for an inherited body `__eq__`, and `set_field` still writing. `camas check` green at 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-5 on behalf of @JPHutchins. She asked for the pre-publish review's issues to be resolved in one-PR batches, simplest first, and iterated with the automated reviewer until it approves.

