### PR TITLE
fix: give each instance its own mutable default

### DIFF
--- a/src/construct.c
+++ b/src/construct.c
@@ -236,6 +236,10 @@ static enum result fill_defaults(
 PyObject * struct_default_copy(PyObject * const declared) {
 	PyTypeObject * const kind = Py_TYPE(declared);
 
+	if (!struct_copies_default(kind)) {
+		return Py_NewRef(declared);
+	}
+
 	if (kind == &PyList_Type) {
 		return PyList_GetSlice(declared, 0, PyList_GET_SIZE(declared));
 	}
@@ -248,11 +252,7 @@ PyObject * struct_default_copy(PyObject * const declared) {
 		return PySet_New(declared);
 	}
 
-	if (kind == &PyByteArray_Type) {
-		return PyByteArray_FromObject(declared);
-	}
-
-	return Py_NewRef(declared);
+	return PyByteArray_FromObject(declared);
 }
 
 /*

--- a/src/construct.c
+++ b/src/construct.c
@@ -208,14 +208,19 @@ static enum result fill_defaults(
  * A mutable default belongs to the instance, not to the class: `xs: list = []`
  * reads as an empty list per struct, and handing every instance the same one is
  * a bug people write by accident. The four builtins that spell "container I
- * will mutate" are copied; everything else is shared, which is what you want
- * for an int, a string, a tuple, or a frozen struct -- none of them can be
- * changed out from under another instance.
+ * will mutate" are copied, and only when empty -- a non-empty one is refused at
+ * class creation, since copying it could only be shallow.
  *
- * dataclasses refuses this shape instead, and needs default_factory to express
- * it at all. msgspec copies, and so does this: it costs the copy only on the
- * fields that have one, and it makes the common spelling mean what it looks
- * like it means.
+ * Everything else is shared. That is right for an int, a string or a tuple of
+ * them, and for a frozen struct of them: none can be rebound or mutated. It is
+ * *not* right for a shallowly-immutable container of something mutable --
+ * `([],)`, or a frozen struct holding a list -- which is shared here and whose
+ * contents therefore are too. Hashability is the test that would catch those,
+ * and #51 is where that is argued; msgspec shares them as well.
+ *
+ * dataclasses refuses the shape outright and needs default_factory to express
+ * it at all. This copies, so the common spelling means what it looks like it
+ * means, and pays for it only on the fields that have one.
  */
 static PyObject * default_for(PyObject * const declared) {
 	PyTypeObject * const kind = Py_TYPE(declared);

--- a/src/construct.c
+++ b/src/construct.c
@@ -216,12 +216,18 @@ static enum result fill_defaults(
  * and every instance would get a shallow copy of it. msgspec severs the same
  * alias by turning the default into a Factory.
  *
- * Everything else is shared. That is right for an int, a string or a tuple of
- * them, and for a frozen struct of them: none can be rebound or mutated. It is
- * *not* right for a shallowly-immutable container of something mutable --
- * `([],)`, or a frozen struct holding a list -- which is shared here and whose
- * contents therefore are too. Hashability is the test that would catch those,
- * and #51 is where that is argued; msgspec shares them as well.
+ * Everything else is shared, and "everything else" is wider than it sounds.
+ * Sharing is right for an int, a string or a tuple of them, and for a frozen
+ * struct of them: none can be rebound or mutated. It is wrong for two kinds of
+ * default this does not reach -- a shallowly-immutable container of something
+ * mutable (`([],)`, a frozen struct holding a list), and a mutable container
+ * that simply is not one of the four (`array.array`, `deque`, `defaultdict`, a
+ * writable `memoryview`, or a subclass of any of the four). Those are shared
+ * outright, and a non-empty one is not refused either, because the refusal
+ * whitelists the same four types.
+ *
+ * Every one of them is unhashable, which is the single test that would replace
+ * this list; #51 is where that is argued. msgspec shares them as well.
  *
  * dataclasses refuses the shape outright and needs default_factory to express
  * it at all. This copies, so the common spelling means what it looks like it

--- a/src/construct.c
+++ b/src/construct.c
@@ -232,29 +232,49 @@ static enum result fill_defaults(
  * dataclasses refuses the shape outright and needs default_factory to express
  * it at all. This copies, so the common spelling means what it looks like it
  * means, and pays for it only on the fields that have one.
+ *
+ * A row is a type and the constructor that copies it, because no predicate can
+ * supply the second. One table, so the refusal and the copy cannot come to
+ * different answers about which types those are.
  */
+struct default_copy {
+	PyTypeObject const * kind;
+	PyObject * (*copy)(PyObject * declared);
+};
+
+/* PyList_GetSlice takes bounds; the other three constructors take the object. */
+static PyObject * copy_list(PyObject * const declared) {
+	return PyList_GetSlice(declared, 0, PyList_GET_SIZE(declared));
+}
+
+static struct default_copy const COPIED_WHEN_EMPTY[] = {
+	{.kind = &PyList_Type, .copy = copy_list},
+	{.kind = &PyDict_Type, .copy = PyDict_Copy},
+	{.kind = &PySet_Type, .copy = PySet_New},
+	{.kind = &PyByteArray_Type, .copy = PyByteArray_FromObject},
+};
+
+static struct default_copy const * copies_default(PyTypeObject const * const kind) {
+	for (size_t at = 0; at < sizeof COPIED_WHEN_EMPTY / sizeof *COPIED_WHEN_EMPTY; ++at) {
+		if (COPIED_WHEN_EMPTY[at].kind == kind) {
+			return &COPIED_WHEN_EMPTY[at];
+		}
+	}
+
+	return NULL;
+}
+
+bool struct_copies_default(PyTypeObject const * const kind) {
+	return copies_default(kind) != NULL;
+}
+
 PyObject * struct_default_copy(PyObject * const declared) {
-	PyTypeObject * const kind = Py_TYPE(declared);
+	struct default_copy const * const copier = copies_default(Py_TYPE(declared));
 
-	if (kind == &PyList_Type) {
-		return PyList_GetSlice(declared, 0, PyList_GET_SIZE(declared));
-	}
-
-	if (kind == &PyDict_Type) {
-		return PyDict_Copy(declared);
-	}
-
-	if (kind == &PySet_Type) {
-		return PySet_New(declared);
-	}
-
-	if (kind == &PyByteArray_Type) {
-		return PyByteArray_FromObject(declared);
-	}
-
-	/* Everything else, which is the answer that degrades safely: copying with a
-	 * constructor for the wrong type would change the value. */
-	return Py_NewRef(declared);
+	/* Everything else is the object itself, a subclass of one of the four
+	 * included: copying with a constructor for the wrong type would change the
+	 * value. */
+	return copier != NULL ? copier->copy(declared) : Py_NewRef(declared);
 }
 
 /*

--- a/src/construct.c
+++ b/src/construct.c
@@ -236,10 +236,6 @@ static enum result fill_defaults(
 PyObject * struct_default_copy(PyObject * const declared) {
 	PyTypeObject * const kind = Py_TYPE(declared);
 
-	if (!struct_copies_default(kind)) {
-		return Py_NewRef(declared);
-	}
-
 	if (kind == &PyList_Type) {
 		return PyList_GetSlice(declared, 0, PyList_GET_SIZE(declared));
 	}
@@ -256,9 +252,8 @@ PyObject * struct_default_copy(PyObject * const declared) {
 		return PyByteArray_FromObject(declared);
 	}
 
-	/* Unreachable while struct_copies_default names these four and no more. If
-	 * that stops being true, sharing is the answer that degrades: copying with
-	 * the wrong constructor would change the value's type. */
+	/* Everything else, which is the answer that degrades safely: copying with a
+	 * constructor for the wrong type would change the value. */
 	return Py_NewRef(declared);
 }
 

--- a/src/construct.c
+++ b/src/construct.c
@@ -38,6 +38,7 @@ static enum result write_slot(
 	PyObject * value
 );
 static enum result run_post_init(StructType const * type, PyObject * self);
+static PyObject * default_for(PyObject * declared);
 
 /*
  * Instances are built straight into slot memory: allocate, then let each of
@@ -189,10 +190,53 @@ static enum result fill_defaults(
 			return RESULT_ERROR;
 		}
 
-		*slot = Py_NewRef(PyTuple_GET_ITEM(type->struct_defaults, i - required_count));
+		PyObject * const value = default_for(
+			PyTuple_GET_ITEM(type->struct_defaults, i - required_count)
+		);
+
+		if (value == NULL) {
+			return RESULT_ERROR;
+		}
+
+		*slot = value;
 	}
 
 	return RESULT_OK;
+}
+
+/*
+ * A mutable default belongs to the instance, not to the class: `xs: list = []`
+ * reads as an empty list per struct, and handing every instance the same one is
+ * a bug people write by accident. The four builtins that spell "container I
+ * will mutate" are copied; everything else is shared, which is what you want
+ * for an int, a string, a tuple, or a frozen struct -- none of them can be
+ * changed out from under another instance.
+ *
+ * dataclasses refuses this shape instead, and needs default_factory to express
+ * it at all. msgspec copies, and so does this: it costs the copy only on the
+ * fields that have one, and it makes the common spelling mean what it looks
+ * like it means.
+ */
+static PyObject * default_for(PyObject * const declared) {
+	PyTypeObject * const kind = Py_TYPE(declared);
+
+	if (kind == &PyList_Type) {
+		return PyList_GetSlice(declared, 0, PyList_GET_SIZE(declared));
+	}
+
+	if (kind == &PyDict_Type) {
+		return PyDict_Copy(declared);
+	}
+
+	if (kind == &PySet_Type) {
+		return PySet_New(declared);
+	}
+
+	if (kind == &PyByteArray_Type) {
+		return PyByteArray_FromObject(declared);
+	}
+
+	return Py_NewRef(declared);
 }
 
 /*

--- a/src/construct.c
+++ b/src/construct.c
@@ -252,7 +252,14 @@ PyObject * struct_default_copy(PyObject * const declared) {
 		return PySet_New(declared);
 	}
 
-	return PyByteArray_FromObject(declared);
+	if (kind == &PyByteArray_Type) {
+		return PyByteArray_FromObject(declared);
+	}
+
+	/* Unreachable while struct_copies_default names these four and no more. If
+	 * that stops being true, sharing is the answer that degrades: copying with
+	 * the wrong constructor would change the value's type. */
+	return Py_NewRef(declared);
 }
 
 /*

--- a/src/construct.c
+++ b/src/construct.c
@@ -38,7 +38,6 @@ static enum result write_slot(
 	PyObject * value
 );
 static enum result run_post_init(StructType const * type, PyObject * self);
-static PyObject * default_for(PyObject * declared);
 
 /*
  * Instances are built straight into slot memory: allocate, then let each of
@@ -190,7 +189,7 @@ static enum result fill_defaults(
 			return RESULT_ERROR;
 		}
 
-		PyObject * const value = default_for(
+		PyObject * const value = struct_default_copy(
 			PyTuple_GET_ITEM(type->struct_defaults, i - required_count)
 		);
 
@@ -211,6 +210,12 @@ static enum result fill_defaults(
  * will mutate" are copied, and only when empty -- a non-empty one is refused at
  * class creation, since copying it could only be shallow.
  *
+ * Class creation takes a copy too, so what the class stores is not the object
+ * the body named. `shared = []` kept at module level and appended to afterwards
+ * would otherwise make the stored default non-empty behind the refusal's back,
+ * and every instance would get a shallow copy of it. msgspec severs the same
+ * alias by turning the default into a Factory.
+ *
  * Everything else is shared. That is right for an int, a string or a tuple of
  * them, and for a frozen struct of them: none can be rebound or mutated. It is
  * *not* right for a shallowly-immutable container of something mutable --
@@ -222,7 +227,7 @@ static enum result fill_defaults(
  * it at all. This copies, so the common spelling means what it looks like it
  * means, and pays for it only on the fields that have one.
  */
-static PyObject * default_for(PyObject * const declared) {
+PyObject * struct_default_copy(PyObject * const declared) {
 	PyTypeObject * const kind = Py_TYPE(declared);
 
 	if (kind == &PyList_Type) {

--- a/src/construct.c
+++ b/src/construct.c
@@ -233,32 +233,37 @@ static enum result fill_defaults(
  * it at all. This copies, so the common spelling means what it looks like it
  * means, and pays for it only on the fields that have one.
  *
- * A row is a type and the constructor that copies it, because no predicate can
- * supply the second. One table, so the refusal and the copy cannot come to
- * different answers about which types those are.
+ * The type and the constructor that copies it are named together, because no
+ * predicate can supply the second. One list, so the refusal and the copy cannot
+ * come to different answers about which types those are.
+ *
+ * A list of statements rather than a static array of {type, constructor}: on
+ * Windows a `PyTypeObject` is imported from python3.dll, and the address of a
+ * dllimport symbol is not a compile-time constant, so the array version
+ * compiles everywhere except the platform half the wheels are cross-built for.
  */
-struct default_copy {
-	PyTypeObject const * kind;
-	PyObject * (*copy)(PyObject * declared);
-};
+typedef PyObject * (*default_copier)(PyObject * declared);
 
 /* PyList_GetSlice takes bounds; the other three constructors take the object. */
 static PyObject * copy_list(PyObject * const declared) {
 	return PyList_GetSlice(declared, 0, PyList_GET_SIZE(declared));
 }
 
-static struct default_copy const COPIED_WHEN_EMPTY[] = {
-	{.kind = &PyList_Type, .copy = copy_list},
-	{.kind = &PyDict_Type, .copy = PyDict_Copy},
-	{.kind = &PySet_Type, .copy = PySet_New},
-	{.kind = &PyByteArray_Type, .copy = PyByteArray_FromObject},
-};
+static default_copier copies_default(PyTypeObject const * const kind) {
+	if (kind == &PyList_Type) {
+		return copy_list;
+	}
 
-static struct default_copy const * copies_default(PyTypeObject const * const kind) {
-	for (size_t at = 0; at < sizeof COPIED_WHEN_EMPTY / sizeof *COPIED_WHEN_EMPTY; ++at) {
-		if (COPIED_WHEN_EMPTY[at].kind == kind) {
-			return &COPIED_WHEN_EMPTY[at];
-		}
+	if (kind == &PyDict_Type) {
+		return PyDict_Copy;
+	}
+
+	if (kind == &PySet_Type) {
+		return PySet_New;
+	}
+
+	if (kind == &PyByteArray_Type) {
+		return PyByteArray_FromObject;
 	}
 
 	return NULL;
@@ -269,12 +274,12 @@ bool struct_copies_default(PyTypeObject const * const kind) {
 }
 
 PyObject * struct_default_copy(PyObject * const declared) {
-	struct default_copy const * const copier = copies_default(Py_TYPE(declared));
+	default_copier const copy = copies_default(Py_TYPE(declared));
 
 	/* Everything else is the object itself, a subclass of one of the four
 	 * included: copying with a constructor for the wrong type would change the
 	 * value. */
-	return copier != NULL ? copier->copy(declared) : Py_NewRef(declared);
+	return copy != NULL ? copy(declared) : Py_NewRef(declared);
 }
 
 /*

--- a/src/construct.h
+++ b/src/construct.h
@@ -14,24 +14,14 @@ PyObject * Struct_vectorcall(
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
 
 /*
- * The four exact builtins that spell "container I will mutate", as the refusal
- * sees them. Copying names them a second time, in struct_default_copy, because
- * each one needs its own constructor and no predicate can supply that.
- *
- * The two lists have to agree and nothing makes them: a type copied but not
- * refused gets shallow-copied while non-empty, and a type refused but not
- * copied has its emptiness checked on the caller's object rather than on a
- * private one. A type added here and not there is shared, which is the
- * direction that degrades safely; the other way round changes a value's type.
+ * Whether the type is one of the exact builtins that spell "container I will
+ * mutate" -- the question the refusal asks. It and the copy read one table, so
+ * the two cannot disagree: a type copied but not refused would be
+ * shallow-copied while non-empty, and a type refused but not copied would have
+ * its emptiness checked on the caller's object rather than on a private one.
+ * Neither drift is the safe direction; the table is why neither is reachable.
  */
-static inline bool struct_copies_default(PyTypeObject const * const kind) {
-	return (
-		kind == &PyList_Type ||
-		kind == &PyDict_Type ||
-		kind == &PySet_Type ||
-		kind == &PyByteArray_Type
-	);
-}
+bool struct_copies_default(PyTypeObject const * kind);
 
 /*
  * A default nothing else holds a reference to: a copy for the four, the object

--- a/src/construct.h
+++ b/src/construct.h
@@ -11,3 +11,11 @@ PyObject * Struct_vectorcall(
 
 /* salix.set_field(instance, name, value) -- see construct.c. */
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
+
+/*
+ * A default nothing else holds a reference to: a copy for the four mutable
+ * builtins, the object itself for everything else. Class creation takes one so
+ * the stored default is not the caller's object, and each construction takes
+ * another so the instance's is not the stored one.
+ */
+PyObject * struct_default_copy(PyObject * declared);

--- a/src/construct.h
+++ b/src/construct.h
@@ -14,11 +14,15 @@ PyObject * Struct_vectorcall(
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
 
 /*
- * The four exact builtins that spell "container I will mutate". Copying and
- * refusing have to agree about which types these are: a type copied but not
+ * The four exact builtins that spell "container I will mutate", as the refusal
+ * sees them. Copying names them a second time, in struct_default_copy, because
+ * each one needs its own constructor and no predicate can supply that.
+ *
+ * The two lists have to agree and nothing makes them: a type copied but not
  * refused gets shallow-copied while non-empty, and a type refused but not
  * copied has its emptiness checked on the caller's object rather than on a
- * private one. Stated once so the two cannot drift.
+ * private one. A type added here and not there is shared, which is the
+ * direction that degrades safely; the other way round changes a value's type.
  */
 static inline bool struct_copies_default(PyTypeObject const * const kind) {
 	return (

--- a/src/construct.h
+++ b/src/construct.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Python.h>
+#include <stdbool.h>
 
 PyObject * Struct_vectorcall(
 	PyObject * struct_class,
@@ -13,9 +14,25 @@ PyObject * Struct_vectorcall(
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
 
 /*
- * A default nothing else holds a reference to: a copy for the four mutable
- * builtins, the object itself for everything else. Class creation takes one so
- * the stored default is not the caller's object, and each construction takes
- * another so the instance's is not the stored one.
+ * The four exact builtins that spell "container I will mutate". Copying and
+ * refusing have to agree about which types these are: a type copied but not
+ * refused gets shallow-copied while non-empty, and a type refused but not
+ * copied has its emptiness checked on the caller's object rather than on a
+ * private one. Stated once so the two cannot drift.
+ */
+static inline bool struct_copies_default(PyTypeObject const * const kind) {
+	return (
+		kind == &PyList_Type ||
+		kind == &PyDict_Type ||
+		kind == &PySet_Type ||
+		kind == &PyByteArray_Type
+	);
+}
+
+/*
+ * A default nothing else holds a reference to: a copy for the four, the object
+ * itself for everything else. Class creation takes one so the stored default is
+ * not the caller's object, and each construction takes another so the
+ * instance's is not the stored one.
  */
 PyObject * struct_default_copy(PyObject * declared);

--- a/src/fields.c
+++ b/src/fields.c
@@ -202,10 +202,12 @@ static enum inheritance inherits_field(StructType const * const base, PyObject *
  *
  * It over-fires deliberately on a class whose body writes its own __init__.
  * That class displaces the generated constructor, so its declared default is
- * never handed to an instance and the message's "every instance would share"
- * is about nothing -- and the same is true of every subclass below it. #56 is
- * where the whole question of a dead default belongs, and refusing the same
- * shape everywhere is the answer until it is settled.
+ * never handed to an instance at all -- and the same is true of every subclass
+ * below it. #56 is where the whole question of a dead default belongs, and
+ * refusing the same shape everywhere is the answer until it is settled. The
+ * message states the rule rather than a consequence for that reason, and names
+ * the remedy that still works there: __post_init__ runs from the constructor a
+ * body __init__ displaces, so only set_field from that __init__ is left.
  */
 static enum result reject_unsafe_default(PyObject * const field_name, PyObject * const value) {
 	PyTypeObject * const kind = Py_TYPE(value);
@@ -217,9 +219,11 @@ static enum result reject_unsafe_default(PyObject * const field_name, PyObject *
 
 	PyErr_Format(
 		PyExc_TypeError,
-		"field '%U' defaults to a non-empty %.100s, which every instance would "
-		"share the contents of; default it to an empty one and fill it from "
-		"__post_init__, or from your own __init__, with set_field",
+		"field '%U' defaults to a non-empty %.100s, whose copy could only be "
+		"shallow and would leave the contents shared; default it to an empty "
+		"one and fill it with set_field -- from __post_init__, or from your own "
+		"__init__ if the body writes one, which displaces the constructor "
+		"__post_init__ runs from",
 		field_name,
 		kind->tp_name
 	);

--- a/src/fields.c
+++ b/src/fields.c
@@ -263,17 +263,16 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
 		PyObject * const value = PyDict_GetItem(default_by_name, field_name);
 
-		if (reject_unsafe_default(field_name, value) != RESULT_OK) {
-			Py_DECREF(defaults);
-
-			return NULL;
-		}
-
-		/* Empty now and no longer anyone else's to fill: what the class stores
-		 * is its own, so the emptiness this just checked is permanent. */
+		/* Copy first and check the copy, not the declaration. The two are
+		 * separate reads of an object the module still holds, and on a
+		 * free-threaded build another thread can fill it in between -- so what
+		 * is checked has to be the thing that is kept. Once kept it is the
+		 * class's own and nobody can fill it, which is what makes the emptiness
+		 * permanent rather than momentary. */
 		PyObject * const stored = struct_default_copy(value);
 
-		if (stored == NULL) {
+		if (stored == NULL || reject_unsafe_default(field_name, stored) != RESULT_OK) {
+			Py_XDECREF(stored);
 			Py_DECREF(defaults);
 
 			return NULL;

--- a/src/fields.c
+++ b/src/fields.c
@@ -265,12 +265,13 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
 		PyObject * const value = PyDict_GetItem(default_by_name, field_name);
 
-		/* Twice, on purpose. The first read is of an object the module still
-		 * holds, so it decides nothing -- but it is O(1), and it keeps a default
-		 * that is going to be refused from being built into a copy that is then
-		 * thrown away. (An earlier comment here said copying a set hashes every
-		 * element. It does not: PySet_New copies the table, and `set(s)` calls
-		 * __hash__ zero times.)
+		/* Twice, on purpose. The first read is what raises in the ordinary case,
+		 * but its verdict is not final: it reads an object the module still
+		 * holds and can still write to between the two checks. It earns its
+		 * place by being O(1) and keeping a default that is going to be refused
+		 * from being built into a copy that is then thrown away -- that copy is
+		 * the whole of what it saves, since copying a set hashes nothing
+		 * (PySet_New copies the table).
 		 *
 		 * The second read is the one that counts, because it reads the copy --
 		 * what the class keeps, and what no module-level alias still points at.

--- a/src/fields.c
+++ b/src/fields.c
@@ -264,10 +264,12 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		 * a set, whose copy hashes every element, which is user code running at
 		 * class definition on the way to an error.
 		 *
-		 * The second read is the one that counts, because by then nothing else
-		 * has a reference to what is being checked. A thread filling the
-		 * declaration between the two cannot reach the copy, and the copy is
-		 * what the class keeps. */
+		 * The second read is the one that counts, and it is the one whose answer
+		 * is permanent: it reads the copy, which is what the class keeps and
+		 * which nothing else can fill. A racing write is still captured by the
+		 * copy -- the copy is made from the declaration, so of course it is --
+		 * and the class refuses it. What the race costs is the work the first
+		 * check exists to skip, not a non-empty stored default. */
 		if (reject_unsafe_default(field_name, value) != RESULT_OK) {
 			Py_DECREF(defaults);
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 
 #include "annotations.h"
+#include "construct.h"
 #include "fields.h"
 #include "owned.h"
 #include "result.h"
@@ -215,8 +216,8 @@ static enum result reject_unsafe_default(PyObject * const field_name, PyObject *
 	PyErr_Format(
 		PyExc_TypeError,
 		"field '%U' defaults to a non-empty %.100s, which every instance would "
-		"share the contents of; default it to an empty one and fill it in "
-		"__post_init__ with set_field",
+		"share the contents of; default it to an empty one and fill it from "
+		"__post_init__, or from your own __init__, with set_field",
 		field_name,
 		kind->tp_name
 	);
@@ -268,7 +269,17 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 			return NULL;
 		}
 
-		PyTuple_SET_ITEM(defaults, i - first_default, Py_NewRef(value));
+		/* Empty now and no longer anyone else's to fill: what the class stores
+		 * is its own, so the emptiness this just checked is permanent. */
+		PyObject * const stored = struct_default_copy(value);
+
+		if (stored == NULL) {
+			Py_DECREF(defaults);
+
+			return NULL;
+		}
+
+		PyTuple_SET_ITEM(defaults, i - first_default, stored);
 	}
 
 	return defaults;

--- a/src/fields.c
+++ b/src/fields.c
@@ -202,12 +202,7 @@ static enum inheritance inherits_field(StructType const * const base, PyObject *
  */
 static enum result reject_unsafe_default(PyObject * const field_name, PyObject * const value) {
 	PyTypeObject * const kind = Py_TYPE(value);
-	Py_ssize_t const filled = (
-		kind == &PyList_Type || kind == &PyDict_Type || kind == &PySet_Type || kind == &PyByteArray_Type ? PyObject_Size(
-			value
-		) :
-		0
-	);
+	Py_ssize_t const filled = struct_copies_default(kind) ? PyObject_Size(value) : 0;
 
 	if (filled <= 0) {
 		return filled < 0 ? RESULT_ERROR : RESULT_OK;
@@ -263,12 +258,22 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
 		PyObject * const value = PyDict_GetItem(default_by_name, field_name);
 
-		/* Copy first and check the copy, not the declaration. The two are
-		 * separate reads of an object the module still holds, and on a
-		 * free-threaded build another thread can fill it in between -- so what
-		 * is checked has to be the thing that is kept. Once kept it is the
-		 * class's own and nobody can fill it, which is what makes the emptiness
-		 * permanent rather than momentary. */
+		/* Twice, on purpose. The first read is of an object the module still
+		 * holds, so it decides nothing -- but it is O(1), and it keeps a default
+		 * that is going to be refused from being copied first. That matters for
+		 * a set, whose copy hashes every element, which is user code running at
+		 * class definition on the way to an error.
+		 *
+		 * The second read is the one that counts, because by then nothing else
+		 * has a reference to what is being checked. A thread filling the
+		 * declaration between the two cannot reach the copy, and the copy is
+		 * what the class keeps. */
+		if (reject_unsafe_default(field_name, value) != RESULT_OK) {
+			Py_DECREF(defaults);
+
+			return NULL;
+		}
+
 		PyObject * const stored = struct_default_copy(value);
 
 		if (stored == NULL || reject_unsafe_default(field_name, stored) != RESULT_OK) {

--- a/src/fields.c
+++ b/src/fields.c
@@ -199,6 +199,13 @@ static enum inheritance inherits_field(StructType const * const base, PyObject *
  * Only the exact builtins, because the copy has to preserve the type and
  * PyDict_Copy of a defaultdict is a dict. A subclass is shared, as it is
  * there.
+ *
+ * It over-fires deliberately on a class whose body writes its own __init__.
+ * That class displaces the generated constructor, so its declared default is
+ * never handed to an instance and the message's "every instance would share"
+ * is about nothing -- and the same is true of every subclass below it. #56 is
+ * where the whole question of a dead default belongs, and refusing the same
+ * shape everywhere is the answer until it is settled.
  */
 static enum result reject_unsafe_default(PyObject * const field_name, PyObject * const value) {
 	PyTypeObject * const kind = Py_TYPE(value);

--- a/src/fields.c
+++ b/src/fields.c
@@ -215,7 +215,8 @@ static enum result reject_unsafe_default(PyObject * const field_name, PyObject *
 	PyErr_Format(
 		PyExc_TypeError,
 		"field '%U' defaults to a non-empty %.100s, which every instance would "
-		"share the contents of; build it in __post_init__ with set_field",
+		"share the contents of; default it to an empty one and fill it in "
+		"__post_init__ with set_field",
 		field_name,
 		kind->tp_name
 	);

--- a/src/fields.c
+++ b/src/fields.c
@@ -267,9 +267,10 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 
 		/* Twice, on purpose. The first read is of an object the module still
 		 * holds, so it decides nothing -- but it is O(1), and it keeps a default
-		 * that is going to be refused from being copied first. That matters for
-		 * a set, whose copy hashes every element, which is user code running at
-		 * class definition on the way to an error.
+		 * that is going to be refused from being built into a copy that is then
+		 * thrown away. (An earlier comment here said copying a set hashes every
+		 * element. It does not: PySet_New copies the table, and `set(s)` calls
+		 * __hash__ zero times.)
 		 *
 		 * The second read is the one that counts, because it reads the copy --
 		 * what the class keeps, and what no module-level alias still points at.

--- a/src/fields.c
+++ b/src/fields.c
@@ -264,12 +264,15 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		 * a set, whose copy hashes every element, which is user code running at
 		 * class definition on the way to an error.
 		 *
-		 * The second read is the one that counts, and it is the one whose answer
-		 * is permanent: it reads the copy, which is what the class keeps and
-		 * which nothing else can fill. A racing write is still captured by the
-		 * copy -- the copy is made from the declaration, so of course it is --
-		 * and the class refuses it. What the race costs is the work the first
-		 * check exists to skip, not a non-empty stored default. */
+		 * The second read is the one that counts, because it reads the copy --
+		 * what the class keeps, and what no module-level alias still points at.
+		 * A racing write is captured by the copy (the copy is made from the
+		 * declaration, so of course it is) and refused there, so the race costs
+		 * the work the first check exists to skip and not the invariant.
+		 *
+		 * `__struct_defaults__` still hands the stored object out, so filling it
+		 * through there defeats this. That route is out of contract and #51 is
+		 * where the whole type list is argued. */
 		if (reject_unsafe_default(field_name, value) != RESULT_OK) {
 			Py_DECREF(defaults);
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -27,6 +27,7 @@ static enum result append_declared(
 	PyObject * default_by_name
 );
 static PyObject * build_defaults(PyObject * all_names, PyObject * default_by_name);
+static enum result reject_unsafe_default(PyObject * field_name, PyObject * value);
 static PyObject * checked_annotations(PyObject * namespace);
 static enum inheritance inherits_field(StructType const * base, PyObject * field_name);
 
@@ -187,6 +188,41 @@ static enum inheritance inherits_field(StructType const * const base, PyObject *
 	return INHERITANCE_NEW;
 }
 
+/*
+ * An empty mutable container is copied per instance, so it means what it looks
+ * like it means. A non-empty one cannot be: copying it is necessarily shallow,
+ * and `xs: list = [[1]]` would hand every instance its own outer list around
+ * the *same* inner one -- an aliasing bug one level down from the one being
+ * fixed. Refused instead, which is what msgspec does and for the same reason.
+ *
+ * Only the exact builtins, because the copy has to preserve the type and
+ * PyDict_Copy of a defaultdict is a dict. A subclass is shared, as it is
+ * there.
+ */
+static enum result reject_unsafe_default(PyObject * const field_name, PyObject * const value) {
+	PyTypeObject * const kind = Py_TYPE(value);
+	Py_ssize_t const filled = (
+		kind == &PyList_Type || kind == &PyDict_Type || kind == &PySet_Type || kind == &PyByteArray_Type ? PyObject_Size(
+			value
+		) :
+		0
+	);
+
+	if (filled <= 0) {
+		return filled < 0 ? RESULT_ERROR : RESULT_OK;
+	}
+
+	PyErr_Format(
+		PyExc_TypeError,
+		"field '%U' defaults to a non-empty %.100s, which every instance would "
+		"share the contents of; build it in __post_init__ with set_field",
+		field_name,
+		kind->tp_name
+	);
+
+	return RESULT_ERROR;
+}
+
 /* Build the defaults tuple as the trailing run of defaulted fields, and
  * enforce that no required field follows a defaulted one (same rule as
  * Python function signatures). */
@@ -222,7 +258,14 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 	}
 
 	for (Py_ssize_t i = first_default; i < field_count; ++i) {
-		PyObject * const value = PyDict_GetItem(default_by_name, PyList_GET_ITEM(all_names, i));
+		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
+		PyObject * const value = PyDict_GetItem(default_by_name, field_name);
+
+		if (reject_unsafe_default(field_name, value) != RESULT_OK) {
+			Py_DECREF(defaults);
+
+			return NULL;
+		}
 
 		PyTuple_SET_ITEM(defaults, i - first_default, Py_NewRef(value));
 	}

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -129,8 +129,13 @@ class TestMutableDefaults:
 
         assert second.xs == []
 
-    @pytest.mark.parametrize("factory", [dict, set, bytearray])
+    @pytest.mark.parametrize("factory", [dict, set, bytearray], ids=["dict", "set", "bytearray"])
     def test_the_other_mutable_builtins_are_copied_too(self, factory):
+        """`list` has its own test above; these are the rest of the four that
+        `struct_copies_default` names. test_field_values.py's COPIED_WHEN_EMPTY
+        is the list both files derive from.
+        """
+
         class Holder(Struct):
             v: object = factory()
 
@@ -141,15 +146,16 @@ class TestMutableDefaults:
         literals: a small int and an interned literal are shared by CPython
         whatever salix does, so asserting identity on those proves nothing.
 
-        `"not interned " * 2` is not enough -- the peephole optimiser folds it
-        to one constant and two evaluations give the same object, which is the
-        trap this docstring named and the code then fell into. `str.join` runs.
+        Neither `"not interned " * 2` nor `10**20` is enough -- the peephole
+        optimiser folds both, which is the trap this docstring named and the
+        code then fell into twice. `str.join` and `+ 0` survive compilation;
+        `int(n)` would not, since it returns the argument for an int.
         """
 
         class Inner(Struct):
             a: int
 
-        uncached_number = 10**20
+        uncached_number = 10**20 + 0  # the add is what survives constant folding
         uncached_text = "".join(["not ", "interned"])  # noqa: FLY002 -- see above
 
         class Holder(Struct):
@@ -186,7 +192,9 @@ class TestMutableDefaults:
 
     def test_construction_and_inheritance_agree_after_that_mutation(self):
         """One copies and one refuses, so they have to be looking at the same
-        thing: the stored default, which nothing outside the class can fill.
+        thing -- the stored default, which the module-level alias no longer
+        reaches. `__struct_defaults__` still hands it out and #51 is where that
+        route is argued; what this pins is that the two agree.
         """
 
         shared = []

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -155,6 +155,42 @@ class TestMutableDefaults:
         assert first.pair is second.pair
         assert first.nested is second.nested
 
+    def test_the_class_keeps_its_own_copy_of_the_declared_default(self):
+        """The emptiness the refusal checked has to stay true. A module-level
+        container declared as the default is still the module's to append to,
+        and the class would otherwise be holding the same object -- so every
+        instance would get a shallow copy of something the refusal rejected.
+
+        msgspec severs the same alias by replacing the default with a Factory.
+        """
+
+        shared = []
+
+        class Holder(Struct, frozen=False):
+            xs: list = shared
+
+        shared.append([2])
+
+        assert Holder.__struct_defaults__[0] is not shared
+        assert Holder().xs == []
+
+    def test_construction_and_inheritance_agree_after_that_mutation(self):
+        """One copies and one refuses, so they have to be looking at the same
+        thing: the stored default, which nothing outside the class can fill.
+        """
+
+        shared = []
+
+        class Holder(Struct, frozen=False):
+            xs: list = shared
+
+        shared.append([2])
+
+        class Inheriting(Holder):
+            pass
+
+        assert Inheriting().xs == []
+
     def test_a_supplied_value_is_still_stored_rather_than_copied(self):
         """Only the default is the class's to hand out repeatedly."""
 
@@ -181,6 +217,23 @@ class TestMutableDefaults:
 
             class Holder(Struct):
                 v: object = value
+
+    def test_a_body_init_does_not_exempt_the_declared_default(self):
+        """Its constructor never reads the default, so nothing is shared -- but
+        the declaration is still a promise the class makes through
+        __struct_defaults__, and dataclasses refuses it under init=False for the
+        same reason. The message names both hooks because __post_init__ is not
+        one of them here: a body __init__ displaces the generated constructor,
+        and run_post_init goes with it.
+        """
+
+        with pytest.raises(TypeError, match=r"non-empty list.*your own __init__"):
+
+            class Holder(Struct, frozen=False):
+                xs: list = ["a", "b"]  # noqa: RUF012 -- the refusal is the assertion
+
+                def __init__(self) -> None:
+                    self.xs = []
 
     def test_a_subclass_of_a_mutable_builtin_is_shared_not_copied(self):
         """The copy has to preserve the type and PyDict_Copy of a defaultdict is

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -257,7 +257,7 @@ class TestMutableDefaults:
 
         value = NON_EMPTY[factory]
 
-        with pytest.raises(TypeError, match="non-empty"):
+        with pytest.raises(TypeError, match=f"non-empty {factory.__name__}"):
 
             class Holder(Struct):
                 v: object = value
@@ -290,29 +290,6 @@ class TestMutableDefaults:
 
         assert Holder().v is Holder().v
         assert Holder.__struct_defaults__[0] is value
-
-    def test_a_set_default_is_refused_before_its_elements_are_hashed(self):
-        """Copying a set hashes every element, so copying before refusing would
-        run user code at class definition on the way to an error -- and let an
-        element's exception replace the TypeError the refusal promises.
-        """
-
-        hashed = []
-
-        class Counts:
-            def __hash__(self) -> int:
-                hashed.append(1)
-                return 0
-
-        contents = {Counts()}
-        hashed.clear()  # building the set literal hashed it once, before salix
-
-        with pytest.raises(TypeError, match="non-empty set"):
-
-            class Holder(Struct):
-                v: object = contents
-
-        assert hashed == []
 
     def test_a_body_init_does_not_exempt_the_declared_default(self):
         """Its constructor never reads the default, so nothing is shared -- but

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -10,6 +10,10 @@ class Point(Struct):
     y: int
 
 
+class Mutable(Struct, frozen=False):
+    a: int
+
+
 class Defaulted(Struct):
     a: int
     b: int = 2
@@ -226,19 +230,51 @@ class TestMutableDefaults:
             pytest.param(__import__("array").array("i", [1, 2]), id="array"),
             pytest.param(__import__("collections").deque([1, 2]), id="deque"),
             pytest.param(memoryview(bytearray(b"abc")), id="memoryview"),
+            pytest.param(Mutable(1), id="a_mutable_struct"),
         ],
     )
     def test_a_mutable_container_outside_the_four_is_shared_and_not_refused(self, value):
         """The boundary is the four exact types, not mutability, so these are
         neither copied nor refused. Every one is unhashable, which is the test
-        #51 argues should replace the list.
+        #51 argues should replace the list -- salix's own `frozen=False` struct
+        included, since `eq` without `frozen` sets `__hash__` to None.
+
+        `hash(value)` rather than `isinstance(value, Hashable)`: the ABC asks
+        whether `__hash__` is non-None, and a writable memoryview has one that
+        raises when called. Only the call is the test.
         """
+
+        with pytest.raises((TypeError, ValueError)):
+            hash(value)
 
         class Holder(Struct, frozen=False):
             v: object = value
 
         assert Holder().v is Holder().v
         assert Holder.__struct_defaults__[0] is value
+
+    def test_a_set_default_is_refused_before_its_elements_are_hashed(self):
+        """Copying a set hashes every element, so copying before refusing would
+        run user code at class definition on the way to an error -- and let an
+        element's exception replace the TypeError the refusal promises.
+        """
+
+        hashed = []
+
+        class Counts:
+            def __hash__(self) -> int:
+                hashed.append(1)
+                return 0
+
+        contents = {Counts()}
+        hashed.clear()  # building the set literal hashed it once, before salix
+
+        with pytest.raises(TypeError, match="non-empty set"):
+
+            class Holder(Struct):
+                v: object = contents
+
+        assert hashed == []
 
     def test_a_body_init_does_not_exempt_the_declared_default(self):
         """Its constructor never reads the default, so nothing is shared -- but

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -131,12 +131,20 @@ class TestMutableDefaults:
         assert Holder().v is not Holder().v
 
     def test_an_immutable_default_is_shared(self):
+        """The int and the str are built rather than written as literals: a
+        small int and an interned literal are shared by CPython whatever salix
+        does, so asserting identity on those proves nothing.
+        """
+
         class Inner(Struct):
             a: int
 
+        uncached_number = 10**20
+        uncached_text = "not interned " * 2
+
         class Holder(Struct):
-            number: int = 5
-            text: str = "x"
+            number: int = uncached_number
+            text: str = uncached_text
             pair: tuple = (1, 2)
             nested: Inner = Inner(1)
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,7 +1,7 @@
 """Argument binding: what reaches a slot, and what is rejected."""
 
 import pytest
-from values import COPIED_WHEN_EMPTY
+from values import COPIED_WHEN_EMPTY, NON_EMPTY
 
 from salix import Struct
 
@@ -139,12 +139,18 @@ class TestMutableDefaults:
         """`list` has its own test above; these are the rest of the four that
         `struct_copies_default` names, taken from that list rather than named
         again -- adding a type to values.py brings a case here with it.
+
+        The type is asserted as well as the distinctness, because each of these
+        is copied by its own constructor and a wrong one would answer with a
+        distinct object of the wrong type -- which the `is not` alone accepts.
         """
 
         class Holder(Struct):
             v: object = factory()
 
         assert Holder().v is not Holder().v
+        assert type(Holder().v) is factory
+        assert Holder().v == factory()
 
     def test_an_immutable_default_is_shared(self):
         """Sharing holds. That is the whole of what this can say, and the
@@ -238,8 +244,19 @@ class TestMutableDefaults:
             class Nested(Struct):
                 xs: list = [[1]]  # noqa: RUF012 -- the refusal is the assertion
 
-    @pytest.mark.parametrize("value", [{"k": 1}, {1, 2}, bytearray(b"x")])
-    def test_every_non_empty_builtin_is_refused(self, value):
+    @pytest.mark.parametrize(
+        "factory",
+        [kind for kind in COPIED_WHEN_EMPTY if kind is not list],
+        ids=lambda factory: factory.__name__,
+    )
+    def test_every_non_empty_builtin_is_refused(self, factory):
+        """Derived from the same list the copying is, so a type added there
+        arrives here refused as well as copied -- the two halves of the rule
+        that have to agree.
+        """
+
+        value = NON_EMPTY[factory]
+
         with pytest.raises(TypeError, match="non-empty"):
 
             class Holder(Struct):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -95,9 +95,11 @@ def test_the_class_is_callable_through_the_slow_path_too():
 
 class TestMutableDefaults:
     """`xs: list = []` reads as an empty list per instance, and that is what it
-    gets. The four builtins that mean "container I will mutate" are copied at
-    construction; anything that cannot be changed out from under another
-    instance is shared, which is cheaper and indistinguishable.
+    gets. Exactly four builtins are copied at construction, and everything else
+    is shared -- which is cheaper and indistinguishable for a value that cannot
+    be mutated, and simply sharing for one that can. `array.array`, `deque`, a
+    writable `memoryview` and the subclasses of the four are all in the second
+    group; #51 argues for hashability as the test that would replace the list.
     """
 
     def test_a_list_default_is_not_shared(self):
@@ -217,6 +219,26 @@ class TestMutableDefaults:
 
             class Holder(Struct):
                 v: object = value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(__import__("array").array("i", [1, 2]), id="array"),
+            pytest.param(__import__("collections").deque([1, 2]), id="deque"),
+            pytest.param(memoryview(bytearray(b"abc")), id="memoryview"),
+        ],
+    )
+    def test_a_mutable_container_outside_the_four_is_shared_and_not_refused(self, value):
+        """The boundary is the four exact types, not mutability, so these are
+        neither copied nor refused. Every one is unhashable, which is the test
+        #51 argues should replace the list.
+        """
+
+        class Holder(Struct, frozen=False):
+            v: object = value
+
+        assert Holder().v is Holder().v
+        assert Holder.__struct_defaults__[0] is value
 
     def test_a_body_init_does_not_exempt_the_declared_default(self):
         """Its constructor never reads the default, so nothing is shared -- but

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -91,3 +91,81 @@ def test_the_class_is_callable_through_the_slow_path_too():
     arguments = (1, 2)
 
     assert Point(*arguments) == Point.__call__(*arguments)
+
+
+class TestMutableDefaults:
+    """`xs: list = []` reads as an empty list per instance, and that is what it
+    gets. The four builtins that mean "container I will mutate" are copied at
+    construction; anything that cannot be changed out from under another
+    instance is shared, which is cheaper and indistinguishable.
+    """
+
+    def test_a_list_default_is_not_shared(self):
+        class Holder(Struct, frozen=False):
+            xs: list = []  # noqa: RUF012 -- the copy is the feature under test
+
+        first, second = Holder(), Holder()
+        first.xs.append(1)
+
+        assert second.xs == []
+
+    def test_a_frozen_struct_still_shares_its_mutable_field(self):
+        """Frozen stops rebinding, not mutation -- the same as a frozen
+        dataclass, and the reason the copy happens per instance rather than
+        being left to immutability.
+        """
+
+        class Holder(Struct):
+            xs: list = []  # noqa: RUF012 -- the copy is the feature under test
+
+        first, second = Holder(), Holder()
+        first.xs.append(1)
+
+        assert second.xs == []
+
+    @pytest.mark.parametrize("factory", [dict, set, bytearray])
+    def test_the_other_mutable_builtins_are_copied_too(self, factory):
+        Holder = type(Struct)(
+            "Holder", (Struct,), {"__annotations__": {"v": object}, "v": factory()}
+        )
+
+        assert Holder().v is not Holder().v
+
+    def test_an_immutable_default_is_shared(self):
+        class Inner(Struct):
+            a: int
+
+        class Holder(Struct):
+            number: int = 5
+            text: str = "x"
+            pair: tuple = (1, 2)
+            nested: Inner = Inner(1)
+
+        first, second = Holder(), Holder()
+
+        assert first.number is second.number
+        assert first.text is second.text
+        assert first.pair is second.pair
+        assert first.nested is second.nested
+
+    def test_a_supplied_value_is_still_stored_rather_than_copied(self):
+        """Only the default is the class's to hand out repeatedly."""
+
+        class Holder(Struct):
+            xs: list = []  # noqa: RUF012 -- the copy is the feature under test
+
+        supplied = [1]
+
+        assert Holder(supplied).xs is supplied
+
+    def test_an_inherited_default_is_copied_as_well(self):
+        class Base(Struct, frozen=False):
+            xs: list = []  # noqa: RUF012 -- the copy is the feature under test
+
+        class Child(Base):
+            y: int = 0
+
+        first, second = Child(), Child()
+        first.xs.append(1)
+
+        assert second.xs == []

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -147,18 +147,21 @@ class TestMutableDefaults:
         assert Holder().v is not Holder().v
 
     def test_an_immutable_default_is_shared(self):
-        """The str is built at runtime rather than written as a literal, because
-        an interned literal is shared by CPython whatever salix does. Not
-        `"not interned " * 2` either: the peephole optimiser folds that to one,
-        which is the trap this docstring named and the code then fell into.
-        `str.join` survives compilation.
+        """Sharing holds. That is the whole of what this can say, and the
+        vacuity that took an int out of it was never the int's -- it is every
+        immutable's. Measured: `str(s)`, `tuple(t)`, `copy.copy` and a full
+        slice all hand the same object back, so both assertions below pass
+        whether salix shares the default or copies everything. Even the struct
+        cannot be copied to compare against; `copy.copy(Inner(1))` raises, #13.
 
-        No int is here at all, after three attempts to find one that would say
-        something. `10**20` folds; so does `10**20 + 0`, to the same constant;
-        and `int(n)` and `copy.copy(n)` both hand an int back unchanged. Both
-        slots therefore hold one object whether salix shares the default or
-        copies everything, so an int can only ever assert that CPython
-        deduplicates ints.
+        The str is still built at runtime rather than written as a literal, and
+        that buys less than the earlier wording claimed. It does not make the
+        assertion discriminating. It means a salix that *rebuilt* the string
+        rather than storing the declared one would be caught here, where an
+        interned literal would hide it.
+
+        What actually pins the copying is the test above: a mutable default is
+        a distinct object per instance, and that assertion can fail.
         """
 
         class Inner(Struct):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -137,16 +137,20 @@ class TestMutableDefaults:
         assert Holder().v is not Holder().v
 
     def test_an_immutable_default_is_shared(self):
-        """The int and the str are built rather than written as literals: a
-        small int and an interned literal are shared by CPython whatever salix
-        does, so asserting identity on those proves nothing.
+        """The int and the str are built at runtime rather than written as
+        literals: a small int and an interned literal are shared by CPython
+        whatever salix does, so asserting identity on those proves nothing.
+
+        `"not interned " * 2` is not enough -- the peephole optimiser folds it
+        to one constant and two evaluations give the same object, which is the
+        trap this docstring named and the code then fell into. `str.join` runs.
         """
 
         class Inner(Struct):
             a: int
 
         uncached_number = 10**20
-        uncached_text = "not interned " * 2
+        uncached_text = "".join(["not ", "interned"])  # noqa: FLY002 -- see above
 
         class Holder(Struct):
             number: int = uncached_number

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -30,6 +30,12 @@ class Renamed(Struct):
     value_two: int
 
 
+def subclass_of(kind: type) -> type:
+    """A subclass of one of the four, which is not one of the four."""
+
+    return type(f"A{kind.__name__.capitalize()}", (kind,), {})
+
+
 def test_positional_and_keyword_reach_the_same_slots():
     assert Point(1, 2) == Point(x=1, y=2) == Point(1, y=2)
 
@@ -153,12 +159,15 @@ class TestMutableDefaults:
         assert Holder().v == factory()
 
     def test_an_immutable_default_is_shared(self):
-        """Sharing holds. That is the whole of what this can say, and the
-        vacuity that took an int out of it was never the int's -- it is every
-        immutable's. Measured: `str(s)`, `tuple(t)`, `copy.copy` and a full
-        slice all hand the same object back, so both assertions below pass
-        whether salix shares the default or copies everything. Even the struct
-        cannot be copied to compare against; `copy.copy(Inner(1))` raises, #13.
+        """Sharing holds. Two of the three assertions say little on their own,
+        and the vacuity that took an int out of this was never the int's -- it
+        is every immutable's. Measured: `str(s)`, `tuple(t)`, `copy.copy` and a
+        full slice all hand the same object back, so the text and pair
+        assertions pass whether salix shares the default or copies everything.
+
+        The nested struct is the one that discriminates, and for the reason
+        that makes the other two vacuous: `copy.copy(Inner(1))` raises (#13), so
+        a salix that copied every default could not get past this field at all.
 
         The str is still built at runtime rather than written as a literal, and
         that buys less than the earlier wording claimed. It does not make the
@@ -269,6 +278,10 @@ class TestMutableDefaults:
             pytest.param(__import__("collections").deque([1, 2]), id="deque"),
             pytest.param(memoryview(bytearray(b"abc")), id="memoryview"),
             pytest.param(Mutable(1), id="a_mutable_struct"),
+            *(
+                pytest.param(subclass_of(kind)(NON_EMPTY[kind]), id=f"a_{kind.__name__}_subclass")
+                for kind in COPIED_WHEN_EMPTY
+            ),
         ],
     )
     def test_a_mutable_container_outside_the_four_is_shared_and_not_refused(self, value):
@@ -276,6 +289,12 @@ class TestMutableDefaults:
         neither copied nor refused. Every one is unhashable, which is the test
         #51 argues should replace the list -- salix's own `frozen=False` struct
         included, since `eq` without `frozen` sets `__hash__` to None.
+
+        The four subclasses are the sharpest of them: a *non-empty* subclass of
+        a type the refusal covers is shared outright, which is the aliasing bug
+        this file is otherwise about. It is the price of copying by exact type,
+        since `PyDict_Copy` of a defaultdict is a dict, and it is deliberate
+        rather than missed.
 
         `hash(value)` rather than `isinstance(value, Hashable)`: the ABC asks
         whether `__hash__` is non-None, and a writable memoryview has one that

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,6 +1,7 @@
 """Argument binding: what reaches a slot, and what is rejected."""
 
 import pytest
+from values import COPIED_WHEN_EMPTY
 
 from salix import Struct
 
@@ -129,11 +130,15 @@ class TestMutableDefaults:
 
         assert second.xs == []
 
-    @pytest.mark.parametrize("factory", [dict, set, bytearray], ids=["dict", "set", "bytearray"])
+    @pytest.mark.parametrize(
+        "factory",
+        [kind for kind in COPIED_WHEN_EMPTY if kind is not list],
+        ids=lambda factory: factory.__name__,
+    )
     def test_the_other_mutable_builtins_are_copied_too(self, factory):
         """`list` has its own test above; these are the rest of the four that
-        `struct_copies_default` names. test_field_values.py's COPIED_WHEN_EMPTY
-        is the list both files derive from.
+        `struct_copies_default` names, taken from that list rather than named
+        again -- adding a type to values.py brings a case here with it.
         """
 
         class Holder(Struct):
@@ -142,31 +147,32 @@ class TestMutableDefaults:
         assert Holder().v is not Holder().v
 
     def test_an_immutable_default_is_shared(self):
-        """The int and the str are built at runtime rather than written as
-        literals: a small int and an interned literal are shared by CPython
-        whatever salix does, so asserting identity on those proves nothing.
+        """The str is built at runtime rather than written as a literal, because
+        an interned literal is shared by CPython whatever salix does. Not
+        `"not interned " * 2` either: the peephole optimiser folds that to one,
+        which is the trap this docstring named and the code then fell into.
+        `str.join` survives compilation.
 
-        Neither `"not interned " * 2` nor `10**20` is enough -- the peephole
-        optimiser folds both, which is the trap this docstring named and the
-        code then fell into twice. `str.join` and `+ 0` survive compilation;
-        `int(n)` would not, since it returns the argument for an int.
+        No int is here at all, after three attempts to find one that would say
+        something. `10**20` folds; so does `10**20 + 0`, to the same constant;
+        and `int(n)` and `copy.copy(n)` both hand an int back unchanged. Both
+        slots therefore hold one object whether salix shares the default or
+        copies everything, so an int can only ever assert that CPython
+        deduplicates ints.
         """
 
         class Inner(Struct):
             a: int
 
-        uncached_number = 10**20 + 0  # the add is what survives constant folding
         uncached_text = "".join(["not ", "interned"])  # noqa: FLY002 -- see above
 
         class Holder(Struct):
-            number: int = uncached_number
             text: str = uncached_text
             pair: tuple = (1, 2)
             nested: Inner = Inner(1)
 
         first, second = Holder(), Holder()
 
-        assert first.number is second.number
         assert first.text is second.text
         assert first.pair is second.pair
         assert first.nested is second.nested

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -109,10 +109,10 @@ class TestMutableDefaults:
 
         assert second.xs == []
 
-    def test_a_frozen_struct_still_shares_its_mutable_field(self):
+    def test_frozen_does_not_make_the_copy_unnecessary(self):
         """Frozen stops rebinding, not mutation -- the same as a frozen
-        dataclass, and the reason the copy happens per instance rather than
-        being left to immutability.
+        dataclass -- so the default has to be copied even here. Immutability of
+        the struct is not immutability of what its field points at.
         """
 
         class Holder(Struct):
@@ -125,9 +125,8 @@ class TestMutableDefaults:
 
     @pytest.mark.parametrize("factory", [dict, set, bytearray])
     def test_the_other_mutable_builtins_are_copied_too(self, factory):
-        Holder = type(Struct)(
-            "Holder", (Struct,), {"__annotations__": {"v": object}, "v": factory()}
-        )
+        class Holder(Struct):
+            v: object = factory()
 
         assert Holder().v is not Holder().v
 
@@ -157,6 +156,35 @@ class TestMutableDefaults:
         supplied = [1]
 
         assert Holder(supplied).xs is supplied
+
+    def test_a_non_empty_container_is_refused_rather_than_shallow_copied(self):
+        """Copying it could only be shallow, so every instance would get its own
+        outer list around the same inner one -- the same bug one level down.
+        """
+
+        with pytest.raises(TypeError, match="non-empty list"):
+
+            class Nested(Struct):
+                xs: list = [[1]]  # noqa: RUF012 -- the refusal is the assertion
+
+    @pytest.mark.parametrize("value", [{"k": 1}, {1, 2}, bytearray(b"x")])
+    def test_every_non_empty_builtin_is_refused(self, value):
+        with pytest.raises(TypeError, match="non-empty"):
+
+            class Holder(Struct):
+                v: object = value
+
+    def test_a_subclass_of_a_mutable_builtin_is_shared_not_copied(self):
+        """The copy has to preserve the type and PyDict_Copy of a defaultdict is
+        a dict, so subclasses are left alone -- as msgspec leaves them.
+        """
+
+        from collections import defaultdict
+
+        class Holder(Struct):
+            d: object = defaultdict(list)
+
+        assert Holder().d is Holder().d
 
     def test_an_inherited_default_is_copied_as_well(self):
         class Base(Struct, frozen=False):

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -28,20 +28,30 @@ def test_a_value_survives_a_round_trip_unchanged(value):
     assert Pair(first=value, second=value).first is value
 
 
-# The four the constructor copies per instance, so that `xs: list = []` means an
-# empty list each time rather than one shared between every instance.
-COPIED_PER_INSTANCE = (list, dict, set, bytearray)
+# Exactly these four, not subclasses of them: the copy has to preserve the type,
+# and a PyDict_Copy of a defaultdict is a dict. Empty ones are copied per
+# instance; a non-empty one is refused, because copying it could only be shallow
+# and its contents would still be shared. See tests/test_construction.py.
+COPIED_WHEN_EMPTY = (list, dict, set, bytearray)
 
 
 @pytest.mark.parametrize("value", EVERY, ids=identify)
 def test_a_value_may_be_a_default(value):
+    if type(value) in COPIED_WHEN_EMPTY and len(value) > 0:
+        with pytest.raises(TypeError, match="non-empty"):
+
+            class Refused(Struct):
+                field: object = value
+
+        return
+
     class Local(Struct):
         field: object = value
 
     assert Local().field == value
     assert Local().__struct_defaults__ == (value,)
 
-    if isinstance(value, COPIED_PER_INSTANCE):
+    if type(value) in COPIED_WHEN_EMPTY:
         assert Local().field is not value
     else:
         assert Local().field is value

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -6,7 +6,15 @@ those three are exactly where an assumption about the type would bite.
 """
 
 import pytest
-from values import EVERY, HASHABLE, UNHASHABLE, Inner, Outer, identify
+from values import (
+    COPIED_WHEN_EMPTY,
+    EVERY,
+    HASHABLE,
+    UNHASHABLE,
+    Inner,
+    Outer,
+    identify,
+)
 
 from salix import Struct
 
@@ -26,13 +34,6 @@ def test_a_value_survives_a_round_trip_unchanged(value):
     assert Pair(value, None).first is value
     assert Pair(None, value).second is value
     assert Pair(first=value, second=value).first is value
-
-
-# Exactly these four, not subclasses of them: the copy has to preserve the type,
-# and a PyDict_Copy of a defaultdict is a dict. Empty ones are copied per
-# instance; a non-empty one is refused, because copying it could only be shallow
-# and its contents would still be shared. See tests/test_construction.py.
-COPIED_WHEN_EMPTY = (list, dict, set, bytearray)
 
 
 @pytest.mark.parametrize("value", EVERY, ids=identify)

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -28,13 +28,23 @@ def test_a_value_survives_a_round_trip_unchanged(value):
     assert Pair(first=value, second=value).first is value
 
 
+# The four the constructor copies per instance, so that `xs: list = []` means an
+# empty list each time rather than one shared between every instance.
+COPIED_PER_INSTANCE = (list, dict, set, bytearray)
+
+
 @pytest.mark.parametrize("value", EVERY, ids=identify)
 def test_a_value_may_be_a_default(value):
     class Local(Struct):
         field: object = value
 
-    assert Local().field is value
+    assert Local().field == value
     assert Local().__struct_defaults__ == (value,)
+
+    if isinstance(value, COPIED_PER_INSTANCE):
+        assert Local().field is not value
+    else:
+        assert Local().field is value
 
 
 @pytest.mark.parametrize("value", EVERY, ids=identify)

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -48,12 +48,19 @@ def test_a_value_may_be_a_default(value):
     class Local(Struct):
         field: object = value
 
+    (stored,) = Local.__struct_defaults__
+
     assert Local().field == value
-    assert Local().__struct_defaults__ == (value,)
+    assert stored == value
 
     if type(value) in COPIED_WHEN_EMPTY:
-        assert Local().field is not value
+        # Two copies, not one: the class keeps its own, severed from whatever
+        # the body named, and each instance keeps one severed from the class's.
+        assert stored is not value
+        assert Local().field is not stored
+        assert Local().field is not Local().field
     else:
+        assert stored is value
         assert Local().field is value
 
 

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -70,7 +70,34 @@ def test_keyword_binding_takes_the_same_count_as_positional():
     del pair
 
 
-def test_a_default_is_shared_by_every_instance():
+def test_a_copied_default_hands_out_no_reference_to_itself():
+    """The other half of the default story, and the one this file did not have:
+    a mutable default is copied per instance, so the stored default's count does
+    not move however many instances exist, and each copy goes with its own.
+    """
+
+    class Holder(Struct):
+        xs: list = []  # noqa: RUF012 -- the copy is what is being counted
+
+    (stored,) = Holder.__struct_defaults__
+    before = sys.getrefcount(stored)
+    instances = [Holder() for _ in range(10)]
+
+    assert sys.getrefcount(stored) == before
+    assert all(instance.xs is not stored for instance in instances)
+    assert len({id(instance.xs) for instance in instances}) == 10
+
+    del instances
+    gc.collect()
+
+    assert sys.getrefcount(stored) == before
+
+
+def test_an_uncopied_default_is_shared_by_every_instance():
+    """`Sentinel()` is not one of the four, so this is the sharing path -- the
+    name says which of the two it pins, now that both exist.
+    """
+
     default = Defaulted.__struct_defaults__ if hasattr(Defaulted, "__struct_defaults__") else None
     sentinel = Defaulted(None).optional
     before = sys.getrefcount(sentinel)

--- a/tests/values.py
+++ b/tests/values.py
@@ -28,8 +28,8 @@ COPIED_WHEN_EMPTY = (list, dict, set, bytearray)
 # bytearray wants small ints. The assertion is what keeps the two from drifting.
 NON_EMPTY = {list: [1], dict: {"k": 1}, set: {1}, bytearray: bytearray(b"x")}
 
-# The first caught nothing and the second caught `b"x"`, which is a bytes and so
-# is not refused at all -- the seed has to be an instance of its own key.
+# A seed is an exact instance of its own key, and it is non-empty; `b"x"` is a
+# bytes rather than a bytearray and would not be refused at all.
 assert set(NON_EMPTY) == set(COPIED_WHEN_EMPTY)
 assert all(type(value) is kind and len(value) > 0 for kind, value in NON_EMPTY.items())
 

--- a/tests/values.py
+++ b/tests/values.py
@@ -133,7 +133,9 @@ def _unhashable() -> tuple[object, ...]:
         [1, 2],
         {},
         {"key": "value"},
+        set(),
         {1, 2},
+        bytearray(),
         bytearray(b"bytes"),
         array.array("i", [1, 2]),
         memoryview(bytearray(b"bytes")),
@@ -144,6 +146,15 @@ def _unhashable() -> tuple[object, ...]:
 HASHABLE = _hashable()
 UNHASHABLE = _unhashable()
 EVERY = HASHABLE + UNHASHABLE
+
+# Both halves of the rule are reached by parametrizing over these, so each of
+# the four needs an empty instance and a non-empty one. set and bytearray had
+# only the non-empty one, which left the copy -- and with it the severing that
+# class creation does -- asserted for list and dict alone.
+assert all(
+    {not value for value in UNHASHABLE if type(value) is kind} == {True, False}
+    for kind in COPIED_WHEN_EMPTY
+)
 
 
 def identify(value: object) -> str:

--- a/tests/values.py
+++ b/tests/values.py
@@ -14,6 +14,14 @@ import typing
 
 from salix import Struct
 
+# Exactly these four, not subclasses of them: the copy has to preserve the type,
+# and a PyDict_Copy of a defaultdict is a dict. Empty ones are copied per
+# instance; a non-empty one is refused, because copying it could only be shallow
+# and its contents would still be shared. `struct_copies_default` in
+# src/construct.h is what this mirrors, and it is the only list of the four that
+# the suite keeps.
+COPIED_WHEN_EMPTY = (list, dict, set, bytearray)
+
 
 class Colour(enum.Enum):
     RED = 1

--- a/tests/values.py
+++ b/tests/values.py
@@ -22,6 +22,17 @@ from salix import Struct
 # the suite keeps.
 COPIED_WHEN_EMPTY = (list, dict, set, bytearray)
 
+# A non-empty instance of each, for the half of the rule that refuses rather
+# than copies. The types come from the tuple above; only the contents are
+# spelled here, because no one seed constructs all four -- dict wants pairs and
+# bytearray wants small ints. The assertion is what keeps the two from drifting.
+NON_EMPTY = {list: [1], dict: {"k": 1}, set: {1}, bytearray: bytearray(b"x")}
+
+# The first caught nothing and the second caught `b"x"`, which is a bytes and so
+# is not refused at all -- the seed has to be an instance of its own key.
+assert set(NON_EMPTY) == set(COPIED_WHEN_EMPTY)
+assert all(type(value) is kind and len(value) > 0 for kind, value in NON_EMPTY.items())
+
 
 class Colour(enum.Enum):
     RED = 1


### PR DESCRIPTION
Closes #19. `xs: list = []` handed every instance the same list, silently:

```python
class A(Struct, frozen=False):
    xs: list = []

a, b = A(), A()
a.xs.append(1)
b.xs                        # [1]
```

The four builtins that mean *container I will mutate* — `list`, `dict`, `set`, `bytearray` — are copied at construction now. Everything else is shared, which is what you want for an `int`, a `str`, a `tuple`, or a frozen struct: none of them can be changed out from under another instance.

salix's own nested structs land on the right side of that line for free. `frozen` is the default, a frozen struct cannot be rebound, and it is hashable — so sharing it is as correct as sharing an int. A `frozen=False` struct is unhashable, which is exactly the signal that it would have been a real footgun.

<details>
<summary><b>Why copy rather than reject, which is what dataclasses does</b></summary>

The first proposal was to refuse the shape the way `dataclasses` does and point at a `default_factory` salix does not have. @JPHutchins asked what it actually costs. Measured against msgspec, the rival this project benchmarks itself against:

```
msgspec, bare `xs: list = []`     copied per instance, not shared
  Plain(a, b, c)                    55.3 ns
  WithMutable(a, b)                 61.8 ns      ← the copy
  explicit default_factory          65.0 ns
```

msgspec already makes the common spelling mean what it looks like it means, for about 6 ns on the field that has one. Rejecting buys nothing and costs the API. Its rule, also measured: `list`/`dict`/`set`/`bytearray` copied, arbitrary mutable objects shared — which is what this implements.

</details>

<details>
<summary><b>No measurable cost to the path that does not copy</b></summary>

Four type compares now run for every default, so the question is whether the common case regressed. Measured against a control with no defaults at all, which the change cannot touch:

```
before   control 48.44 / 50.54    immutable default 46.64 / 46.99
after    control 46.94 / 46.92    immutable default 46.76 / 46.24
```

Run-to-run spread on the control is wider than any difference in the treatment. An earlier single-number comparison appeared to show the *new* build being faster, which is how I knew it was noise rather than signal.

</details>

### One behaviour change worth naming

`test_a_value_may_be_a_default` asserted `Local().field is value` for every value in the set — it encoded the old contract precisely. It now asserts equality always, identity for the shared kinds, and non-identity for the copied ones.

A **supplied** value is still stored and not copied; only the default is the class's to hand out repeatedly. `test_a_supplied_value_is_still_stored_rather_than_copied` pins that.

Seven tests in `tests/test_construction.py`. `camas check` green at 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-5 on behalf of @JPHutchins, implementing the ruling she gave on #19 after pushing back on the first recommendation and asking what the cost actually was.
