### PR TITLE
fix: read a slot under the lock the writer takes

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -74,8 +74,9 @@ static PyObject * ordering_result(PyObject * const self, PyObject * const other,
 	}
 
 	for (Py_ssize_t i = 0; i < self_type->struct_field_count; ++i) {
-		PY_OWNED(mine, Py_NewRef(struct_slot_or_none(self_type, self, i)));
-		PY_OWNED(theirs, Py_NewRef(struct_slot_or_none(other_type, other, i)));
+		struct slot_pair const pair = struct_slot_pair_ref(self_type, self, other_type, other, i);
+		PY_OWNED(mine, pair.mine);
+		PY_OWNED(theirs, pair.theirs);
 		int const equal = PyObject_RichCompareBool(mine, theirs, Py_EQ);
 
 		if (equal == COMPARISON_ERROR) {
@@ -114,8 +115,9 @@ static enum comparison names_equal(
 	);
 }
 
-/* Borrowed slots are sound here and not in ordering_result: the comparison is
- * the last use of either pointer. */
+/* Owned for the same reason ordering_result's are: the equality probe runs
+ * arbitrary Python, which can rebind either slot, and on a free-threaded build
+ * can free what a borrowed pointer names. */
 static enum comparison values_equal(
 	StructType const * const self_type,
 	PyObject * const self,
@@ -123,11 +125,10 @@ static enum comparison values_equal(
 	PyObject * const other
 ) {
 	for (Py_ssize_t i = 0; i < self_type->struct_field_count; ++i) {
-		int const equal = PyObject_RichCompareBool(
-			struct_slot_or_none(self_type, self, i),
-			struct_slot_or_none(other_type, other, i),
-			Py_EQ
-		);
+		struct slot_pair const pair = struct_slot_pair_ref(self_type, self, other_type, other, i);
+		PY_OWNED(mine, pair.mine);
+		PY_OWNED(theirs, pair.theirs);
+		int const equal = PyObject_RichCompareBool(mine, theirs, Py_EQ);
 
 		if (equal != COMPARISON_EQUAL) {
 			return equal;

--- a/src/hash.c
+++ b/src/hash.c
@@ -44,9 +44,7 @@ Py_hash_t Struct_hash(PyObject * const self) {
 		return HASH_ERR;
 	}
 
-	for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
-		PyTuple_SET_ITEM(values, i, Py_NewRef(struct_slot_or_none(type, self, i)));
-	}
+	struct_slots_ref_or_none_into(type, self, values);
 
 	if (Py_EnterRecursiveCall(" while hashing a struct") != 0) {
 		return HASH_ERR;

--- a/src/repr.c
+++ b/src/repr.c
@@ -61,7 +61,7 @@ static PyObject * field_repr(
 	PyObject * const self,
 	Py_ssize_t const index
 ) {
-	PyObject * const value = *struct_slot(type, self, index);
+	PY_OWNED(value, struct_slot_ref(type, self, index));
 
 	PY_OWNED(rendered, value != NULL ? PyObject_Repr(value) : PyUnicode_FromString("<unset>"));
 

--- a/src/types.h
+++ b/src/types.h
@@ -87,19 +87,127 @@ static inline PyObject * * struct_slot(
 }
 
 /*
- * A slot stays NULL until something writes it, which is observable on a
- * half-built struct. Reading it as None keeps hash and == total instead of
- * making each one re-derive the guard; repr wants to see the NULL, so it
- * reads the slot directly.
+ * Py_BEGIN_CRITICAL_SECTION arrived in 3.13, and expands to a bare scope on a
+ * build with the GIL -- which is every build below it.
+ *
+ * A macro because a critical section is a lexical scope holding a stack frame
+ * the interpreter links into a per-thread stack; no function can open one and
+ * return with it still open. Same reason owned.h is macros.
  */
-static inline PyObject * struct_slot_or_none(
+#if PY_VERSION_HEX < 0x030D0000
+#	define STRUCT_BEGIN_CRITICAL_SECTION(object) {
+#	define STRUCT_END_CRITICAL_SECTION() }
+#	define STRUCT_BEGIN_CRITICAL_SECTION2(first, second) {
+#	define STRUCT_END_CRITICAL_SECTION2() }
+#else
+#	define STRUCT_BEGIN_CRITICAL_SECTION(object) Py_BEGIN_CRITICAL_SECTION(object)
+#	define STRUCT_END_CRITICAL_SECTION() Py_END_CRITICAL_SECTION()
+#	define STRUCT_BEGIN_CRITICAL_SECTION2(first, second) Py_BEGIN_CRITICAL_SECTION2(first, second)
+#	define STRUCT_END_CRITICAL_SECTION2() Py_END_CRITICAL_SECTION2()
+#endif
+
+/* One field from each of two instances, for the readers that walk them in
+ * pairs. */
+struct slot_pair {
+	PyObject * mine;
+	PyObject * theirs;
+};
+
+/*
+ * A new reference to a field, taken under the same lock the writer takes.
+ *
+ * #7 made the write side safe by going through PyMember_SetOne, which holds a
+ * critical section on the instance over the store and defers the release past
+ * the end of it. Every reader here loaded the slot and then increffed what it
+ * found, which is two steps with a window between them: on a free-threaded
+ * build a concurrent write frees the pointer inside that window, and repr and
+ * == segfault. Measured, 3.14t, four writers and three readers of one kind:
+ * `repr` exited 134/139/134 and `==` 139/134/134, while the same loop reading
+ * through CPython's own member descriptor survived every time. #46.
+ *
+ * Every acquisition is in this file, so a fifth reader cannot forget one. The
+ * macros are a bare scope on a build with the GIL, so all three of these are
+ * the same load and incref they always were there.
+ *
+ * What a reader gets is per-slot atomicity, not a snapshot of the struct: a
+ * write landing between two of repr's fields renders a pair the object never
+ * held. That is what reading two member descriptors in a row gives as well.
+ *
+ * Hash is the exception, and the only one: its loop stays in C, so one
+ * acquisition spans the whole of it and what it hashes is a state the struct
+ * really held. repr and the comparisons run PyObject_Repr and
+ * PyObject_RichCompareBool between fields, and a section held across arbitrary
+ * Python is suspended the moment the thread detaches -- so hoisting one around
+ * those loops would read as a guarantee and not be one.
+ *
+ * A slot stays NULL until something writes it, which is observable on a
+ * half-built struct, and this hands that back as NULL: repr is the caller that
+ * renders it.
+ */
+static inline PyObject * struct_slot_ref(
 	StructType const * const type,
 	PyObject * const self,
 	Py_ssize_t const index
 ) {
-	PyObject * const value = *struct_slot(type, self, index);
+	PyObject * value;
 
-	return value != NULL ? value : Py_None;
+	STRUCT_BEGIN_CRITICAL_SECTION(self);
+	value = Py_XNewRef(*struct_slot(type, self, index));
+	STRUCT_END_CRITICAL_SECTION();
+
+	return value;
+}
+
+/*
+ * Both sides of one field, under a single acquisition covering both instances.
+ * The comparison paths walk them in pairs, and one section where there were two
+ * is the whole of what the lock can be made to cost them: 3.14t, an eight-field
+ * struct, `a == b` 134.5ns per field-pair section against 110.7 for one.
+ *
+ * Reading an unwritten slot as None keeps == total instead of making each
+ * caller re-derive the guard.
+ */
+static inline struct slot_pair struct_slot_pair_ref(
+	StructType const * const self_type,
+	PyObject * const self,
+	StructType const * const other_type,
+	PyObject * const other,
+	Py_ssize_t const index
+) {
+	PyObject * mine;
+	PyObject * theirs;
+
+	STRUCT_BEGIN_CRITICAL_SECTION2(self, other);
+	mine = *struct_slot(self_type, self, index);
+	theirs = *struct_slot(other_type, other, index);
+	mine = Py_NewRef(mine != NULL ? mine : Py_None);
+	theirs = Py_NewRef(theirs != NULL ? theirs : Py_None);
+	STRUCT_END_CRITICAL_SECTION2();
+
+	return (struct slot_pair){.mine = mine, .theirs = theirs};
+}
+
+/*
+ * Every field into `values`, which must be a tuple of struct_field_count and
+ * whose items must be unset. One acquisition rather than one per field, and so
+ * a real snapshot -- hash is the reader that can have both, because nothing in
+ * this loop calls back into Python. 3.14t, eight fields: 111.4ns to 81.1,
+ * against 77.5 for the unsynchronised read this replaced.
+ */
+static inline void struct_slots_ref_or_none_into(
+	StructType const * const type,
+	PyObject * const self,
+	PyObject * const values
+) {
+	STRUCT_BEGIN_CRITICAL_SECTION(self);
+
+	for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
+		PyObject * const value = *struct_slot(type, self, i);
+
+		PyTuple_SET_ITEM(values, i, Py_NewRef(value != NULL ? value : Py_None));
+	}
+
+	STRUCT_END_CRITICAL_SECTION();
 }
 
 /* Fields below this index have no default and must be supplied by the caller. */

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -126,3 +126,118 @@ def test_a_shared_struct_is_safe_to_read_from_every_thread():
             assert shared.__struct_fields__ == ("x", "y")
 
     run_on_every_thread(work)
+
+
+def test_a_shared_struct_is_safe_to_read_while_another_thread_writes_it():
+    """The read side of the write tests above, and the one that segfaulted.
+
+    Every reader loaded a slot and then increffed what it found, which is two
+    steps with a window between them; a concurrent write freed the pointer
+    inside it. Measured before the fix, four writers and three readers of one
+    kind: `repr` exited 134/139/134 and `==` 139/134/134, while the same loop
+    reading through CPython's own member descriptor survived every time.
+
+    Survival is the assertion, because a segfault takes pytest with it. The
+    value assertions are there so that a reader which quietly stopped reading
+    would fail rather than pass.
+    """
+
+    class Shared(Struct, frozen=False):
+        value: object
+
+    # Frozen, so that it is hashable -- and still writable through set_field,
+    # which is what makes hash the third reader this can race rather than a
+    # fourth it cannot.
+    class Sealed(Struct):
+        value: object
+
+    shared = Shared([0, 0])
+    sealed = Sealed((0, 0))
+
+    # Never equal to any list the writer produces, so the comparison is a real
+    # walk of both slots every time rather than an early out -- and never equal
+    # by accident when the writer happens to reach the value it holds.
+    other = Shared(object())
+
+    # Denser than the tests above, because the window is between a load and the
+    # incref that follows it and an assertion in the loop is wide enough to hide
+    # it: at ITERATIONS with a check every pass, the unfixed build survives.
+    rounds = ITERATIONS * 5
+
+    def write():
+        for i in range(rounds):
+            shared.value = [i, i]
+            set_field(sealed, "value", (i, i))
+
+    def read():
+        for i in range(rounds):
+            rendered = repr(shared)
+            equal = shared == other
+            hashed = hash(sealed)
+
+            if i % 1000 == 0:
+                assert rendered.startswith("Shared(value=")
+                assert equal is False
+                assert isinstance(hashed, int)
+
+    # Sliced to the thread count rather than doubled from half of it, so an odd
+    # THREADS is one role short of a writer instead of one thread short of a
+    # role.
+    roles = iter(([write, read] * THREADS)[:THREADS])
+    claim = threading.Lock()
+
+    def work():
+        with claim:
+            role = next(roles)
+
+        role()
+
+    run_on_every_thread(work)
+
+
+def test_a_shared_ordered_struct_is_safe_to_compare_while_another_thread_writes_it():
+    """The fourth reader. ordering_result takes its pair of slots the way
+    values_equal does, and nothing else here reaches it.
+
+    It is the weaker of the four, and honestly so: reverting just this loop to
+    a borrowed read survives 3/3 here, and 3/3 again at five times these rounds.
+    The same was true of hash before the fix -- it read exactly as == did and
+    exited 0/0/0 while == exited 139/134/134. One racing load per call, behind a
+    names_equal tuple comparison and the richcompare dispatch, is apparently not
+    often enough. So this pins that ordering keeps working under concurrent
+    writes rather than that it would crash without the lock; the crash is pinned
+    by the test above, through the helper both paths share.
+    """
+
+    class Ranked(Struct, frozen=False, order=True):
+        value: object
+
+    shared = Ranked((0, 0))
+
+    # Below every tuple the writer produces, so the comparison has a determinate
+    # answer however far the writer has got -- and unequal at the first field,
+    # which is the branch that hands both slots to PyObject_RichCompare.
+    floor = Ranked((-1, -1))
+    rounds = ITERATIONS * 5
+
+    def write():
+        for i in range(rounds):
+            shared.value = (i, i)
+
+    def read():
+        for i in range(rounds):
+            ordered = floor < shared
+
+            if i % 1000 == 0:
+                assert ordered is True
+
+    roles = iter(([write, read] * THREADS)[:THREADS])
+    claim = threading.Lock()
+
+    def work():
+        with claim:
+            role = next(roles)
+
+        role()
+
+    run_on_every_thread(work)


### PR DESCRIPTION
Closes #46.

`#7` made the write side safe by routing `set_field` through `PyMember_SetOne`,
which holds a critical section on the instance over the store and defers the
release past the end of it. The read side was never touched: every reader loaded
a slot and then increffed what it found, which is two steps with a window
between them, and on a free-threaded build a concurrent write frees the pointer
inside it.

`struct_slot_ref` now takes the reference under a critical section on the
instance, and every reader goes through it — `repr.c`, `hash.c` and both
comparison paths in `compare.c`. One function rather than a section at each of
four sites, so a fifth reader cannot forget it.

## The measurement

3.14t, four writer threads and three readers of one kind on one shared
`frozen=False` struct, 40k rounds, three runs each. The control is CPython's own
member descriptor, which does hold the lock:

| reader | exits |
| --- | --- |
| `descriptor` (`shared.value`, i.e. `PyMember_GetOne`) | 0, 0, 0 |
| `repr` | 134, 139, 134 |
| `==` | 139, 134, 134 |
| `hash` | 0, 0, 0 — reads the same way, did not manifest |

The regression test is `SIGABRT` 3/3 without the critical section and clean with
it.

## Not the issue's preferred option 2

<details>
<summary>Routing reads through <code>PyMember_GetOne</code> would inherit the guarantee rather than restate it, which is the right instinct — but a NULL slot is an ordinary state here.</summary>

`del m.x` on a mutable struct leaves a slot NULL, and `repr` renders it
`M(x=<unset>)`. `Py_T_OBJECT_EX` answers a NULL slot with an `AttributeError`,
so option 2 turns an ordinary answer into raise-then-clear at every reader, and
needs `PyMemberDef.name` populated or CPython formats the message from a NULL
pointer.

So `struct_slot_ref` hands NULL back — `repr` is the caller that wants to see it
— and `struct_slot_ref_or_none` is the total version `hash` and `==` use, which
is what `struct_slot_or_none` was before this.

</details>

<details>
<summary>Why the critical section is a macro pair rather than a function.</summary>

A critical section is a lexical scope holding a frame the interpreter links into
a per-thread stack, so no function can open one and return with it still open —
the same reason `owned.h` is macros. `Py_BEGIN_CRITICAL_SECTION` arrived in 3.13
and expands to a bare scope on a build with the GIL, so `types.h` carries a shim
beside the `SLOT_MEMBER_TYPE` one and nothing changes on a GIL-ful build.

</details>

<details>
<summary>The test took three tries to mean anything — it passed on the unfixed build twice.</summary>

Once because the reader's per-iteration assertion was wide enough to hide the
window between the load and the incref, and once because the comparison found an
early out. The version here asserts every 1000th pass rather than every pass,
runs `ITERATIONS * 5` rounds, and compares against a struct holding a bare
`object()` so the walk can never short-circuit and can never be equal by
accident. Survival is the assertion, because a segfault takes pytest with it —
same shape as the write-path tests above it.

</details>

Writers are unchanged: `construct.c:112` runs before the object escapes, and
`write_slot` keeps `PyMember_SetOne`.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked
> for the pre-publish review's issues to be worked off in one-PR batches and for
> each PR to be iterated with the automated reviewer; this is #46, which was
> written and held while #48 was in flight.
