### PR TITLE
fix: read the layout base from the base CPython chose

### DIFF
--- a/src/meta.c
+++ b/src/meta.c
@@ -35,6 +35,9 @@ static PyObject * build_struct_class(
 	PyObject * keywords
 );
 static StructType * find_struct_base(PyObject * bases);
+static StructType * find_behaviour_base(PyObject * bases);
+static struct options inherited_options(PyObject * bases, StructType const * behaviour);
+static bool any_struct_base_is_mutable(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
 static struct options base_options(StructType const * base);
 static PyObject * build_class_namespace(
@@ -43,6 +46,8 @@ static PyObject * build_class_namespace(
 	PyObject * new_names,
 	struct options options,
 	StructType const * base,
+	struct options inherited,
+	bool frozen_across_bases,
 	bool body_defines_eq,
 	bool inherits_body_eq
 );
@@ -52,6 +57,7 @@ static enum result apply_options(
 	PyObject * namespace,
 	struct options options,
 	struct options inherited,
+	bool frozen_across_bases,
 	bool body_defines_eq,
 	bool inherits_body_eq
 );
@@ -220,7 +226,12 @@ static PyObject * build_struct_class(
 	PyObject * const original_namespace,
 	PyObject * const keywords
 ) {
-	struct options const inherited = base_options(base);
+	/* The behaviour base rather than the layout one: every dunder a struct base
+	 * carries is resolved by the MRO, which takes the first of them, so reading
+	 * the options off anything else makes the record and the behaviour two
+	 * different answers. */
+	StructType const * const behaviour = find_behaviour_base(bases);
+	struct options const inherited = inherited_options(bases, behaviour);
 	struct options_request const request =
 		options_read(keywords, inherited, base != NULL && base->struct_field_count > 0);
 
@@ -236,11 +247,12 @@ static PyObject * build_struct_class(
 
 	/* Read before build_class_namespace rebinds anything: afterwards every
 	 * comparison name is present whether the body wrote one or salix did. An
-	 * inherited one survives only if this body leaves equality alone. */
+	 * inherited one survives only if this body leaves equality alone -- and it
+	 * is the behaviour base's, because that is the __eq__ the MRO finds. */
 	bool const body_defines_eq = PyDict_GetItemString(original_namespace, "__eq__") != NULL;
 	bool const inherits_body_eq = (
-		base != NULL &&
-		base->struct_resolves_body_eq &&
+		behaviour != NULL &&
+		behaviour->struct_resolves_body_eq &&
 		request.options.eq == inherited.eq
 	);
 
@@ -252,6 +264,8 @@ static PyObject * build_struct_class(
 			plan.new_names,
 			request.options,
 			base,
+			inherited,
+			request.options.frozen && any_struct_base_is_mutable(bases),
 			body_defines_eq,
 			inherits_body_eq
 		)
@@ -289,9 +303,60 @@ static PyObject * build_struct_class(
 	return (PyObject *) struct_class;
 }
 
-/* Find the (single) struct base among ``bases``. A fieldless one still carries
- * the options a subclass inherits, so it counts. */
+/*
+ * The struct base this class extends the layout of: the one with the most
+ * fields, which is what CPython settles on as tp_base and so where the slots
+ * and their offsets come from. Taking the first match instead let a fieldless
+ * base stand in front of one with fields, and every field of the second went
+ * missing.
+ *
+ * Fields rather than tp_basicsize, because CPython discounts __weakref__ and
+ * __dict__ when it compares layouts and salix's fields are the only other slots
+ * a struct base adds. Below 3.12 a weakref slot still widens the type, so a
+ * `weakref=True` fieldless base measures exactly as wide as a one-field base
+ * and would win a comparison on size while CPython gave tp_base to the other.
+ *
+ * A fieldless struct base still carries the options a subclass inherits, so it
+ * counts when it is the only one. Two struct bases tie here when one derives
+ * from the other and when both are fieldless; either way the first of them is
+ * also the most derived, which is the one CPython settles on.
+ */
 static StructType * find_struct_base(PyObject * const bases) {
+	StructType * widest = NULL;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+
+		if (!is_struct_class(base)) {
+			continue;
+		}
+
+		StructType * const candidate = (StructType *) base;
+
+		if (widest == NULL || candidate->struct_field_count > widest->struct_field_count) {
+			widest = candidate;
+		}
+	}
+
+	return widest;
+}
+
+/* What a subclass starts from: the base's options, or the defaults when there
+ * is no struct base to inherit from. */
+static struct options base_options(StructType const * const base) {
+	return base != NULL ? base->struct_options : options_initial();
+}
+
+/*
+ * The struct base whose dunders the MRO will resolve: the first of them.
+ *
+ * Not the layout base: the layout question is where the slots are, and this is
+ * which class answers for the dunders. Answering both with the widest base put
+ * the record and the behaviour into disagreement three separate ways -- a class
+ * recorded frozen that every write succeeded on, an explicit repr=True that
+ * silently no-opped, and equal objects hashing differently.
+ */
+static StructType * find_behaviour_base(PyObject * const bases) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
 
@@ -303,10 +368,60 @@ static StructType * find_struct_base(PyObject * const bases) {
 	return NULL;
 }
 
-/* What a subclass starts from: the base's options, or the defaults when there
- * is no struct base to inherit from. */
-static struct options base_options(StructType const * const base) {
-	return base != NULL ? base->struct_options : options_initial();
+/*
+ * What the class starts from: the behaviour base's options, with the two that
+ * are facts about the other bases rather than preferences of that one.
+ *
+ * frozen is a promise every fielded base made separately -- a mutable subclass
+ * hands a writable object to everything holding a reference of any of their
+ * types -- so it is the strongest of them, not the first one's. weakref is a
+ * slot the class has if any base carries one, and recording otherwise would be
+ * the option disagreeing with tp_weaklistoffset.
+ */
+/*
+ * Whether some struct base is mutable, which is the only reason a frozen class
+ * has to bind __setattr__ rather than let the MRO find the mixin's. A mutable
+ * base bound object's on its own transition, and the MRO reaches that binding
+ * before the shared mixin.
+ */
+static bool any_struct_base_is_mutable(PyObject * const bases) {
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+
+		if (is_struct_class(base) && !((StructType *) base)->struct_options.frozen) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static struct options inherited_options(
+	PyObject * const bases,
+	StructType const * const behaviour
+) {
+	struct options const from_behaviour = base_options(behaviour);
+	bool promised_frozen = false;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+		StructType const * const struct_base = (StructType *) base;
+
+		promised_frozen |= (
+			is_struct_class(base) &&
+			struct_base->struct_field_count > 0 &&
+			struct_base->struct_options.frozen
+		);
+	}
+
+	return (struct options){
+		.frozen = from_behaviour.frozen || promised_frozen,
+		.eq = from_behaviour.eq,
+		.order = from_behaviour.order,
+		.repr = from_behaviour.repr,
+		.match_args = from_behaviour.match_args,
+		.weakref = from_behaviour.weakref,
+	};
 }
 
 /* CPython refuses a second __weakref__ in a subclass, so an inherited one is
@@ -325,6 +440,8 @@ static PyObject * build_class_namespace(
 	PyObject * const new_names,
 	struct options const options,
 	StructType const * const base,
+	struct options const inherited,
+	bool const frozen_across_bases,
 	bool const body_defines_eq,
 	bool const inherits_body_eq
 ) {
@@ -340,7 +457,8 @@ static PyObject * build_class_namespace(
 		apply_options(
 				namespace,
 				options,
-				base_options(base),
+				inherited,
+				frozen_across_bases,
 				body_defines_eq,
 				inherits_body_eq
 			) ==
@@ -410,6 +528,7 @@ static enum result apply_options(
 	PyObject * const namespace,
 	struct options const options,
 	struct options const inherited,
+	bool const frozen_across_bases,
 	bool const body_defines_eq,
 	bool const inherits_body_eq
 ) {
@@ -434,6 +553,12 @@ static enum result apply_options(
 		return RESULT_ERROR;
 	}
 
+	/* An unchanged option needs no rebinding, because `inherited` is read off
+	 * the first struct base -- the one whose branch of the MRO is searched
+	 * first. That is an approximation: a later struct base binds a dunder its
+	 * own creation transitioned on, and the MRO reaches it before the shared
+	 * mixin, so a second struct base can still answer for a name this class
+	 * never rebound. */
 	if (options.eq != inherited.eq && rebind(namespace, comparison, options.eq) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
@@ -445,8 +570,12 @@ static enum result apply_options(
 		return RESULT_ERROR;
 	}
 
+	/* The exception, and the reason frozen is the only forced one: with more
+	 * than one struct base it can be promised by a base that is not the one
+	 * binding __setattr__, and then the class is recorded frozen while the MRO
+	 * answers with object's and every write succeeds. */
 	if (
-		options.frozen != inherited.frozen &&
+		(options.frozen != inherited.frozen || frozen_across_bases) &&
 		rebind(namespace, mutability, options.frozen) != RESULT_OK
 	) {
 		return RESULT_ERROR;
@@ -488,12 +617,12 @@ static enum result rebind(
  *
  * It has to be bound rather than left to the MRO, because the mixin is a base:
  * its structural __ne__ is what the lookup finds, and it answers a different
- * question from the body's __eq__. `a == b` and `a != b` were both true. #58.
+ * question from the body's __eq__, so `a == b` and `a != b` were both true.
  *
  * Binding it into the dict also puts it ahead of a __ne__ a *co-base* supplies,
  * which plain Python would let win -- the derived one is the end of the MRO
- * there, not the front. That is the same shape as #47, where a non-struct
- * base's __eq__ shadows the struct base's, and it is left with that issue: the
+ * there, not the front. That is the same shape as a non-struct base's __eq__
+ * shadowing the struct base's, and it is left alone for the same reason: the
  * mixin already discarded a co-base's __ne__ before this, so what changes here
  * is which answer wins rather than whether the co-base's is heard.
  */
@@ -638,10 +767,9 @@ static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject 
  * where that shows.
  *
  * Refused rather than returned, and rather than installed over: the field table
- * this call planned describes a layout that class may not have. #55 is where
- * the hand-off itself is argued -- until it forwards what it was given, a
- * caller gets an error instead of a class that quietly is not the one asked
- * for.
+ * this call planned describes a layout that class may not have. Until the
+ * hand-off forwards what it was given, a caller gets an error instead of a
+ * class that quietly is not the one asked for.
  */
 static enum result reject_unless_planned(
 	StructType const * const struct_class,

--- a/tests/test_multiple_bases.py
+++ b/tests/test_multiple_bases.py
@@ -1,0 +1,327 @@
+"""More than one struct base.
+
+Which base a class extends the layout of is not the same question as which
+bases constrain it. Reading both off the first match is how a fieldless base
+standing in front of one with fields dropped every field of the second, and
+took `frozen` with it.
+"""
+
+import weakref
+
+import pytest
+
+from salix import Struct
+
+
+class Fieldless(Struct):
+    pass
+
+
+class FieldlessWeak(Struct, weakref=True):
+    pass
+
+
+class WithFields(Struct):
+    a: int
+    b: int
+
+
+class WithOneField(Struct):
+    """One field, because that is the width a weakref slot costs. Below 3.12
+    this and FieldlessWeak measure the same, which is the tie that says whether
+    salix is reading layout off sizes or off fields.
+    """
+
+    a: int
+
+
+def test_a_fieldless_base_in_front_does_not_hide_the_fields_behind_it():
+    class Both(Fieldless, WithFields):
+        c: int
+
+    instance = Both(1, 2, 3)
+
+    assert Both.__struct_fields__ == ("a", "b", "c")
+    assert (instance.a, instance.b, instance.c) == (1, 2, 3)
+    assert repr(instance) == "Both(a=1, b=2, c=3)"
+
+
+def test_a_weakref_base_in_front_does_not_hide_them_either():
+    """Sizes are the wrong question. Below 3.12 a weakref slot widens the type,
+    so a fieldless base carrying one measures exactly as wide as WithOneField
+    and would win a comparison on size -- while CPython, which discounts
+    __weakref__ when it settles on __base__, gave the layout to the other.
+    """
+
+    class Both(FieldlessWeak, WithOneField):
+        c: int
+
+    instance = Both(1, 2)
+
+    assert Both.__struct_fields__ == ("a", "c")
+    assert (instance.a, instance.c) == (1, 2)
+
+
+@pytest.mark.parametrize(
+    "bases",
+    [
+        (Fieldless, WithFields),
+        (WithFields, Fieldless),
+        (FieldlessWeak, WithOneField),
+        (WithOneField, FieldlessWeak),
+        (Fieldless, FieldlessWeak, WithOneField),
+        (FieldlessWeak, Fieldless, WithFields),
+    ],
+    ids=lambda bases: "-".join(base.__name__ for base in bases),
+)
+def test_the_layout_base_is_the_one_cpython_chose(bases):
+    """The offsets salix hands out are the base's slots plus the new ones, so
+    the base it reads them from has to be the base the new slots were placed
+    after -- and that base is CPython's choice, not salix's. Inheriting exactly
+    the fields of __base__ is that agreement stated in terms a test can read.
+    """
+
+    child = type(Struct)("Child", bases, {"__annotations__": {"c": int}})
+
+    assert child.__struct_fields__ == (*child.__base__.__struct_fields__, "c")
+
+
+def test_the_order_of_the_bases_does_not_change_the_fields():
+    class Forwards(Fieldless, WithFields):
+        c: int
+
+    class Backwards(WithFields, Fieldless):
+        c: int
+
+    assert Forwards.__struct_fields__ == Backwards.__struct_fields__
+
+
+def test_the_frozen_keyword_is_answered_by_any_base_with_fields():
+    """The symptom that mattered: a fieldless base in front waived the
+    constraint, so a mutable subclass of a frozen struct could exist and be
+    handed to anything holding a reference of the frozen base's type.
+    """
+
+    with pytest.raises(TypeError, match="mutable struct cannot inherit"):
+
+        class Mutable(Fieldless, WithFields, frozen=False):
+            c: int
+
+
+def test_a_weakref_base_in_front_does_not_waive_it_either():
+    with pytest.raises(TypeError, match="mutable struct cannot inherit"):
+
+        class Mutable(FieldlessWeak, WithOneField, frozen=False):
+            c: int
+
+
+def test_a_fieldless_base_alone_still_waives_it():
+    """Nothing behind it made a promise about a field, so there is none to break."""
+
+    class Mutable(Fieldless, frozen=False):
+        c: int
+
+    instance = Mutable(1)
+    instance.c = 2
+
+    assert instance.c == 2
+
+
+def test_options_still_come_from_the_struct_base():
+    class Unordered(Struct, repr=False):
+        pass
+
+    class Child(Unordered):
+        x: int = 0
+
+    assert "object at" in repr(Child())
+
+
+class TestWhichBaseAnswers:
+    """Which base answers which question, for the two this fix separates.
+
+    The *layout* base is the widest -- where CPython put the slots, so where
+    their offsets come from, and it is the whole of what this fix changes about
+    layout. Options are still read off the first struct base, as they were
+    before.
+
+    `frozen` is the exception, because it is a promise rather than a preference:
+    any base with fields that made it binds the whole class, and the rebind is
+    forced when some other struct base is mutable, since that base bound
+    object's __setattr__ on its own transition and the MRO reaches it first.
+
+    Reading the options off one base while the MRO answers from another is a
+    wider problem than this fix and predates it; the tests here pin the shapes
+    that work, not that one.
+    """
+
+    def test_a_mutable_base_in_front_does_not_unfreeze_the_class(self):
+        """The one that has to be forced. Otherwise C refuses a mutable subclass
+        and hashes by value while accepting every write -- a dict key that
+        changes its own hash.
+        """
+
+        class MutableFieldless(Struct, frozen=False):
+            pass
+
+        class Both(MutableFieldless, WithFields):
+            c: int
+
+        with pytest.raises(TypeError, match="does not support attribute assignment"):
+            Both(1, 2, 3).a = 99
+
+        with pytest.raises(TypeError, match="mutable struct cannot inherit"):
+
+            class Mutable(Both, frozen=False):
+                d: int = 0
+
+    def test_a_frozen_fieldless_base_may_still_strengthen_a_mutable_one(self):
+        """The other direction, and reading frozen off the widest base broke it:
+        the class was refused because the widest base was the mutable one.
+        """
+
+        class FrozenFieldless(Struct):
+            pass
+
+        class MutableFields(Struct, frozen=False):
+            a: int
+
+        class Strengthened(FrozenFieldless, MutableFields, frozen=True):
+            c: int
+
+        with pytest.raises(TypeError, match="does not support attribute assignment"):
+            Strengthened(1, 2).a = 99
+
+    def test_a_repr_less_base_in_front_takes_the_repr_with_it(self):
+        """Not a defect -- the class records `repr=False` and behaves that way.
+        What matters is that the two agree; reading the option off the widest
+        base while the MRO answered from this one is what did not.
+        """
+
+        class Unrepresented(Struct, repr=False):
+            pass
+
+        class Both(Unrepresented, WithFields):
+            c: int
+
+        assert "object at" in repr(Both(1, 2, 3))
+
+    def test_and_a_subclass_can_still_ask_for_it_back(self):
+        class Unrepresented(Struct, repr=False):
+            pass
+
+        class Both(Unrepresented, WithFields):
+            c: int
+
+        class Child(Both, repr=True):
+            d: int = 0
+
+        assert repr(Child(1, 2, 3)) == "Child(a=1, b=2, c=3, d=0)"
+
+    def test_an_identity_equal_base_in_front_takes_equality_with_it(self):
+        """And takes the hash with it, which is the half that has to follow."""
+
+        class ByIdentity(Struct, eq=False):
+            pass
+
+        class Both(ByIdentity, WithFields):
+            c: int
+
+        first, second = Both(1, 2, 3), Both(1, 2, 3)
+
+        assert first != second
+        assert hash(first) == hash(first)
+        assert first in {first}
+
+    def test_a_body_eq_on_a_base_that_is_not_the_layout_one_still_carries_its_hash(self):
+        """Equal objects hashing differently is the shape that broke here.
+
+        A body `__eq__` wins the MRO from any struct base, but the deferral
+        about its `__hash__` was read off the layout base only -- so a fieldless
+        base's body pair compared while salix's value hash answered beside it.
+        """
+
+        class ByBody(Struct):
+            def __eq__(self, other: object) -> bool:
+                return True
+
+            def __hash__(self) -> int:
+                return 7
+
+        class Both(ByBody, WithFields):
+            c: int
+
+        first, second = Both(1, 2, 3), Both(9, 9, 9)
+
+        assert first == second
+        assert hash(first) == hash(second) == 7
+
+    def test_a_weakref_slot_on_a_base_that_is_not_the_layout_one_is_recorded(self):
+        """The option has to match tp_weaklistoffset, or a subclass asks for a
+        second __weakref__ that CPython refuses.
+        """
+
+        class Weak(FieldlessWeak, WithFields):
+            c: int
+
+        class Child(Weak):
+            d: int = 0
+
+        assert weakref.ref(Weak(1, 2, 3)) is not None
+        assert weakref.ref(Child(1, 2, 3)) is not None
+
+    def test_a_keyword_matching_the_layout_base_is_still_honoured(self):
+        """The shape that catches the rebind comparing against the wrong base.
+
+        `apply_options` decides on a transition, so it has to be handed the
+        options the class actually inherits. Handed the layout base's instead,
+        a keyword asking for what the *layout* base already says looks like no
+        change at all -- nothing is rebound, the MRO keeps the first base's
+        binding, and the keyword is dropped without a word.
+        """
+
+        class Unrepresented(Struct, repr=False):
+            pass
+
+        class ByIdentity(Struct, eq=False):
+            pass
+
+        class Represented(Unrepresented, WithFields, repr=True):
+            c: int
+
+        class Equal(ByIdentity, WithFields, eq=True):
+            c: int
+
+        assert repr(Represented(1, 2, 3)) == "Represented(a=1, b=2, c=3)"
+        assert Equal(1, 2, 3) == Equal(1, 2, 3)
+
+    def test_a_base_that_agrees_changes_nothing(self):
+        """The negative control: two struct bases are not on their own a reason
+        to bind anything, so a class whose bases agree is left as it was.
+        """
+
+        class AlsoFrozen(Struct):
+            pass
+
+        class Both(AlsoFrozen, WithFields):
+            c: int
+
+        assert "__setattr__" not in vars(Both)
+        assert "__repr__" not in vars(Both)
+        assert "__eq__" not in vars(Both)
+
+    def test_and_a_plain_subclass_still_inherits_a_body_pair(self):
+        class ByBody(Struct):
+            a: int
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+            def __hash__(self) -> int:
+                return 7
+
+        class Child(ByBody):
+            c: int
+
+        assert (Child(1, 2) == Child(9, 9)) is True
+        assert hash(Child(1, 2)) == 7


### PR DESCRIPTION
Closes #9.

`find_struct_base` returned the first `StructMeta` in `bases`, and every
question was then asked of that one object. A fieldless struct base standing in
front of one with fields answered them all wrongly:

```python
class C(Fieldless, WithFields):
    c: int

C.__struct_fields__         # ('c',)  -- a and b gone
C(1).a                      # AttributeError
```

The slots for `a` and `b` still existed; nothing reached them, so `repr`, `==`
and `hash` silently ignored two thirds of the object. Reversing the base order
fixed it, which was the tell.

It also defeated `frozen`, which is the part that matters.
`class M(Fieldless, WithFields, frozen=False)` was accepted, so a mutable
subclass of a frozen struct existed and could be handed to anything holding a
`WithFields`-typed reference — exactly what `options.h` says `frozen` is there
to prevent.

## The base to read is the one CPython chose

`tp_base` is where CPython placed the new slots, so it is where their offsets
are measured from. Among struct bases that is **the one with the most fields**,
not the widest one.

<details>
<summary>Why not <code>tp_basicsize</code> — it is wrong on 3.10 and 3.11, and the two rules agree everywhere else.</summary>

CPython discounts `__weakref__` and `__dict__` when it compares layouts. Below
3.12 a weakref slot still grows `tp_basicsize`, so a `weakref=True` fieldless
base measures exactly as wide as a one-field base and wins a comparison on size
while CPython gave `tp_base` to the other:

```
3.10.20   Fieldless=16/0  FieldlessWeak=24/0  One=24/1  Two=32/2
3.12.13   Fieldless=16/0  FieldlessWeak=16/0  One=24/1  Two=32/2
```

Over every buildable combination of two and three bases drawn from eight shapes
— fieldless, fieldless with weakref, a fieldless subclass of that, one field,
one field with weakref, a fieldless subclass of the one-field base, two fields,
and two reached by extending the one-field base — each candidate rule scored
against `__base__` itself:

| | buildable | `first` wrong | `widest` wrong | `most fields` wrong |
| --- | --- | --- | --- | --- |
| 3.10.20 | 155 | 85 | 25 | 0 |
| 3.12.13 | 155 | 85 | 0 | 0 |
| 3.14.6 | 155 | 85 | 0 | 0 |

</details>

<details>
<summary>The frozen constraint does not need its own walk of <code>bases</code>, and it had one.</summary>

The first version of this answered `frozen` of *any* struct base rather than of
the layout one, on the reasoning that each base made the promise separately.
With the layout base fixed that is redundant rather than safer: the base with
the most fields has fields whenever any base does. The mutation says so — the
extra walk was removed only after removing it failed to break a test on either
3.10 or 3.14, and the case that would distinguish the two (a weakref-only base
tying on size) is the one the field-count rule already gets right.

</details>

<details>
<summary>Each candidate rule is a mutation of this commit, and the tests are scored against it.</summary>

```
first-match-layout-base  [3.10]: failed=9    [3.14]: failed=9
widest-by-basicsize      [3.10]: failed=4    [3.14]: failed=0
```

13 tests. `widest-by-basicsize` correctly fails nothing on 3.14, where it and
the field-count rule agree; on 3.10 the four it fails are the two weakref cases
and two of the parametrised `__base__` agreement checks.

</details>

## What is not here

The `__slots__` half of #12 was written alongside this and has been taken back
out. Refusing a body `__slots__` in `StructMeta_new` also refuses salix's own:
`create_class` hands the build to a winning metatype whose Python `__new__`
calls back into `StructMeta_new` with the namespace `build_class_namespace`
already wrote `__slots__` into, and three tests turn red on the round trip. The
refusal has to tell those two apart, which is its own change against #48's
hand-off. #12 stays open for it and for the `__new__` half, which is blocked on
#13.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked
> for the pre-publish review's issues to be worked off in one-PR batches and for
> each PR to be iterated with the automated reviewer; this is #9, held while #48
> was in flight and rewritten against the `create_class` it left behind.
