### PR TITLE
fix: write the declared defaults before a body __init__ runs

### DIFF
--- a/src/construct.c
+++ b/src/construct.c
@@ -86,6 +86,51 @@ PyObject * Struct_vectorcall(
 }
 
 /*
+ * What a class whose body writes __init__ allocates with. That class declined
+ * the generated constructor, and fill_defaults went with it: a declared default
+ * was never written, for the class and for every subclass, so
+ * __struct_defaults__ advertised a value no instance would ever carry (#56).
+ * Writing them here means the __init__ runs over a struct that already holds
+ * them and overwrites whatever it means to -- which is where a dataclass leaves
+ * them too, on the class, readable.
+ *
+ * Fields with no default are left NULL. Supplying those is what the body's
+ * __init__ is for, and reading one it did not write raises AttributeError as
+ * it did before. __post_init__ is not run here for the same reason: it is the
+ * generated constructor's last step, and this class does not have one.
+ *
+ * The arguments go unread, exactly as PyType_GenericNew left them: they are the
+ * __init__'s to interpret. Which is also what this costs an __init__ that
+ * overwrites every default from its own arguments: the copy is written and
+ * thrown away, because nothing here can know that. fill_defaults can, since the
+ * vectorcall sees which slots the caller filled. Measured on 3.14, a two-field
+ * class whose __init__ assigns both: 115.1ns against 99.9 for
+ * PyType_GenericNew, and a class declaring no defaults pays nothing.
+ */
+PyObject * Struct_new(
+	PyTypeObject * const struct_class,
+	PyObject * const arguments,
+	PyObject * const keywords
+) {
+	PY_MOVABLE(self, struct_class->tp_alloc(struct_class, 0));
+
+	if (self == NULL) {
+		return NULL;
+	}
+
+	StructType const * const type = (StructType *) struct_class;
+
+	/* fill_defaults with nothing supplied, which is what this is: every slot of
+	 * a fresh instance is NULL so its skip never fires, and starting at
+	 * required_count makes its missing-argument branch unreachable. Calling it
+	 * rather than repeating it keeps one copy of what a default costs. */
+	return (
+		fill_defaults(type, self, struct_required_count(type)) == RESULT_OK ? py_move(&self) :
+		NULL
+	);
+}
+
+/*
  * The last thing the constructor does, so what it validates is a struct with
  * every field already written. Frozen means it cannot assign one back --
  * set_field below is the deliberate way through, and the only one, since a

--- a/src/construct.h
+++ b/src/construct.h
@@ -10,6 +10,12 @@ PyObject * Struct_vectorcall(
 	PyObject * keyword_names
 );
 
+/*
+ * What a class whose body writes __init__ allocates with, in place of
+ * PyType_GenericNew -- see construct.c.
+ */
+PyObject * Struct_new(PyTypeObject * struct_class, PyObject * arguments, PyObject * keywords);
+
 /* salix.set_field(instance, name, value) -- see construct.c. */
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -670,14 +670,15 @@ static PyObject * module_attribute(char const * const module_name, char const * 
  * PyDict_Copy of a defaultdict is a dict. A subclass is shared, as it is
  * there.
  *
- * It over-fires deliberately on a class whose body writes its own __init__.
- * That class displaces the generated constructor, so its declared default is
- * never handed to an instance at all -- and the same is true of every subclass
- * below it. #56 is where the whole question of a dead default belongs, and
- * refusing the same shape everywhere is the answer until it is settled. The
- * message states the rule rather than a consequence for that reason, and names
- * the remedy that still works there: __post_init__ runs from the constructor a
- * body __init__ displaces, so only set_field from that __init__ is left.
+ * It reaches a class whose body writes its own __init__ on the same terms as
+ * every other: Struct_new writes that class's declared defaults before the
+ * __init__ runs, so a non-empty one would be copied per instance and is
+ * shallow there for the same reason. It used to over-fire on a declaration
+ * nothing would ever hand out, which is what #56 was; the message states the
+ * rule rather than a consequence because that reads the same either way, and
+ * names the remedy that still works there: __post_init__ runs from the
+ * constructor a body __init__ displaces, so only set_field from that __init__
+ * is left.
  */
 static enum result reject_unsafe_default(PyObject * const field_name, PyObject * const value) {
 	PyTypeObject * const kind = Py_TYPE(value);

--- a/src/meta.c
+++ b/src/meta.c
@@ -682,12 +682,14 @@ static enum result install_fields(
 	struct_class->struct_resolves_body_eq = resolves_body_eq;
 
 	/* The mixin has no tp_new, because nothing ever needed one: the vectorcall
-	 * allocates. A class that declined it needs the generic one to get as far
-	 * as its own __init__ -- and only such a class, so the mixin itself stays
+	 * allocates. A class that declined it needs one to get as far as its own
+	 * __init__ -- and only such a class, so the mixin itself stays
 	 * uninstantiable and nothing can hold a struct's dunders over an object
-	 * that has no field table. */
+	 * that has no field table. Struct_new rather than PyType_GenericNew,
+	 * because the generic one leaves every slot NULL and the declared defaults
+	 * were then never written by anything. */
 	if (defines_own_init(struct_class)) {
-		struct_class->heap_type.ht_type.tp_new = PyType_GenericNew;
+		struct_class->heap_type.ht_type.tp_new = Struct_new;
 	} else {
 		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
 	}

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -3,10 +3,13 @@
 The generated constructor is a vectorcall on the type, and a vectorcall answers
 before `tp_call` ever reaches `__init__` -- so a body that defined one used to
 have it discarded without a word. A class that defines one now declines the
-vectorcall instead, which also means it declines everything the vectorcall does:
-defaults and `__post_init__` included.
+vectorcall instead, which also means it declines what the vectorcall does that
+belongs to the signature it is replacing: `__post_init__`, and the refusal of a
+missing required argument. Declared defaults are not part of that -- they are
+written by `tp_new` before the body's `__init__` runs.
 """
 
+import pickle
 import sys
 
 import pytest
@@ -57,6 +60,33 @@ def test_an_inherited_init_is_honoured_too():
     assert Child(3) == Handwritten(3)
 
 
+def test_a_body_init_under_a_generated_base_declines_the_vectorcall_too():
+    """The other direction: the base keeps the generated constructor and the
+    subclass writes its own __init__, so the subclass is where tp_new arrives.
+
+    The base must be unaffected -- it still has the vectorcall, and its own
+    defaults still come from fill_defaults rather than from tp_new.
+    """
+
+    class Generated2(Struct, frozen=False):
+        x: int
+        y: int = 5
+
+    class Handwritten2(Generated2):
+        z: int = 9
+
+        def __init__(self) -> None:
+            self.x = 1
+
+    built = Handwritten2()
+
+    assert (built.x, built.y, built.z) == (1, 5, 9)
+    assert (Generated2(2).x, Generated2(2).y) == (2, 5)
+
+    with pytest.raises(TypeError, match="takes at most 2 positional"):
+        Generated2(1, 2, 3)
+
+
 def test_a_child_may_go_back_to_the_generated_one():
     """__init__ is a name like any other; object's is what un-defines it."""
 
@@ -67,8 +97,14 @@ def test_a_child_may_go_back_to_the_generated_one():
     assert Child(1).y == 0
 
 
-def test_defaults_are_not_filled_for_a_body_init():
-    """The vectorcall is what fills them, and this class declined it."""
+def test_defaults_are_written_before_a_body_init_runs():
+    """What the class declared, the instance carries.
+
+    The declaration used to be inert: the vectorcall filled defaults and this
+    class declined it, so `__struct_defaults__` advertised a value no instance
+    would ever have. tp_new writes them now, which is where a dataclass leaves
+    them readable too.
+    """
 
     class Partial(Struct, frozen=False):
         x: int
@@ -77,8 +113,85 @@ def test_defaults_are_not_filled_for_a_body_init():
         def __init__(self) -> None:
             self.x = 1
 
+    assert Partial().y == 99
+    assert repr(Partial()) == "Partial(x=1, y=99)"
+
+
+def test_a_body_init_can_read_the_default_and_overwrite_it():
+    """Written before it runs, so it is a starting point rather than a fact."""
+
+    class Doubling(Struct, frozen=False):
+        y: int = 99
+
+        def __init__(self) -> None:
+            self.y = self.y * 2
+
+    assert Doubling().y == 198
+
+
+def test_a_field_with_no_default_is_left_unset():
+    """Supplying those is what the body's __init__ is for."""
+
+    class Required(Struct, frozen=False):
+        x: int
+        y: int = 99
+
+        def __init__(self) -> None:
+            pass
+
     with pytest.raises(AttributeError):
-        _ = Partial().y
+        _ = Required().x
+
+    assert Required().y == 99
+
+
+def test_a_subclass_that_writes_no_init_gets_its_defaults_too():
+    """The case that made this a bug rather than a consequence. `defines_own_init`
+    reads tp_init, which an inherited __init__ satisfies -- so a subclass that
+    says nothing about construction lost its own declared default as well as the
+    base's, and had no way to ask for it back.
+    """
+
+    class Base(Struct, frozen=False):
+        x: int = 7
+
+        def __init__(self) -> None:
+            pass
+
+    class Child(Base):
+        y: int = 5
+
+    assert (Child().x, Child().y) == (7, 5)
+
+
+def test_a_frozen_class_with_a_body_init_still_gets_them():
+    """It cannot write a field, so before this the instance had none at all."""
+
+    class Frozen(Struct):
+        x: int = 7
+
+        def __init__(self) -> None:
+            pass
+
+    assert Frozen().x == 7
+
+
+def test_each_instance_gets_its_own_mutable_default():
+    """tp_new takes the same copy the vectorcall does, so the rule that a
+    mutable default belongs to the instance holds on both paths.
+    """
+
+    class Mutable(Struct, frozen=False):
+        xs: list = []  # noqa: RUF012 -- the copy is the feature under test
+
+        def __init__(self) -> None:
+            pass
+
+    first = Mutable()
+    first.xs.append(1)
+
+    assert Mutable().xs == []
+    assert first.xs is not Mutable().xs
 
 
 def test_post_init_does_not_run_for_a_body_init():
@@ -134,6 +247,63 @@ def test_a_frozen_body_init_can_use_object_setattr_where_the_interpreter_allows_
             object.__setattr__(self, "x", 1)
 
     assert Frozen().x == 1
+
+
+class PicklableFrozen(Struct):
+    """Module level, because pickle looks a class up by qualified name."""
+
+    x: int = 7
+
+    def __init__(self) -> None:
+        pass
+
+
+class PicklableMutable(Struct, frozen=False):
+    x: int = 7
+
+    def __init__(self) -> None:
+        pass
+
+
+def test_a_mutable_body_init_struct_now_pickles_what_it_holds():
+    """Writing the defaults is what makes the state worth restoring.
+
+    Before this, the state was empty and the round trip returned an instance
+    with every field unset -- not a failure, which is what made it easy to miss.
+
+    The written value is a non-default one on purpose: tp_new writes `7` during
+    `loads` whatever the pickle said, so asserting the default back would pass
+    just as well on a round trip that restored nothing at all.
+    """
+
+    instance = PicklableMutable()
+    instance.x = 99
+
+    assert pickle.loads(pickle.dumps(instance)).x == 99
+    assert PicklableMutable().x == 7
+
+
+@pytest.mark.xfail(strict=True, reason="#13: a frozen struct has no __setstate__ that can write")
+def test_a_frozen_body_init_struct_should_pickle_too():
+    """The frozen half of the same, and the one this cost something.
+
+    The default reducer restores state through setattr, which a frozen struct
+    refuses, so `pickle.loads` now raises where it used to return an instance
+    with every field unset. That is a real change and not a lost round trip:
+    nothing was ever restored. #13 is the issue -- a __getstate__/__setstate__
+    pair that writes slots the way set_field does -- and this goes green when it
+    lands.
+
+    Written through set_field to a non-default value first, for the same reason
+    the mutable test does it: tp_new writes `7` during loads whatever the pickle
+    said, so asserting the default back would let #13 land with a broken restore
+    and still flip this green.
+    """
+
+    instance = PicklableFrozen()
+    set_field(instance, "x", 99)
+
+    assert pickle.loads(pickle.dumps(instance)).x == 99
 
 
 def test_the_mixin_stays_uninstantiable():

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -110,6 +110,76 @@ def test_an_uncopied_default_is_shared_by_every_instance():
     assert sys.getrefcount(sentinel) == before
 
 
+def test_a_body_init_shares_an_uncopied_default_the_same_way():
+    """tp_new writes the defaults for a class that declined the vectorcall, so
+    the two paths are counted separately -- one taking a reference per instance
+    is not evidence about the other.
+    """
+
+    class Declining(Struct, frozen=False):
+        optional: object = Sentinel()
+
+        def __init__(self) -> None:
+            pass
+
+    (sentinel,) = Declining.__struct_defaults__
+    before = sys.getrefcount(sentinel)
+    instances = [Declining() for _ in range(10)]
+
+    assert sys.getrefcount(sentinel) == before + 10
+
+    del instances
+
+    assert sys.getrefcount(sentinel) == before
+
+
+def test_a_body_init_copies_a_mutable_default_without_retaining_it():
+    class Declining(Struct, frozen=False):
+        xs: list = []  # noqa: RUF012 -- the copy is what is being counted
+
+        def __init__(self) -> None:
+            pass
+
+    (stored,) = Declining.__struct_defaults__
+    before = sys.getrefcount(stored)
+    instances = [Declining() for _ in range(10)]
+
+    assert sys.getrefcount(stored) == before
+    assert len({id(instance.xs) for instance in instances}) == 10
+
+    del instances
+    gc.collect()
+
+    assert sys.getrefcount(stored) == before
+
+
+def test_a_body_init_that_raises_releases_the_defaults_tp_new_wrote():
+    class Failing(Struct, frozen=False):
+        optional: object = Sentinel()
+
+        def __init__(self) -> None:
+            raise ValueError
+
+    (sentinel,) = Failing.__struct_defaults__
+    before = sys.getrefcount(sentinel)
+
+    for _ in range(10):
+        with pytest.raises(ValueError):
+            Failing()
+
+    assert sys.getrefcount(sentinel) == before
+
+    # Without this the test is vacuously green on a build whose tp_new writes
+    # nothing: no reference taken is no reference to leak.
+    class Writing(Struct, frozen=False):
+        optional: object = Sentinel()
+
+        def __init__(self) -> None:
+            pass
+
+    assert Writing().optional is Writing.__struct_defaults__[0]
+
+
 def test_reading_a_field_does_not_accumulate():
     sentinel = Sentinel()
     pair = Pair(sentinel, None)


### PR DESCRIPTION
Closes #56. Option 1, as ruled.

A class whose body writes `__init__` declines the generated constructor, and
`fill_defaults` went with it — so a declared default was never written, and
`__struct_defaults__` advertised a value no instance would ever carry.

```python
class R(Struct, frozen=False):
    x: int = 7

    def __init__(self):
        pass

class T(R):
    y: int = 5

T().x                   # AttributeError -- and T never said anything about __init__
T().y                   # AttributeError -- its own declared default
T.__struct_defaults__   # (7, 5)
```

`Struct_new` replaces `PyType_GenericNew` for exactly those classes. It
allocates the same way and then writes each field that has a default, taking the
same `struct_default_copy` the vectorcall takes — so a mutable default still
belongs to the instance on both paths. The body's `__init__` then runs over a
struct that already holds them and overwrites what it means to.

## What stays the same

- **Fields with no default stay NULL.** Supplying those is what the body's
  `__init__` is for, and reading one it did not write raises `AttributeError` as
  before.
- **`__post_init__` still does not run.** It is the generated constructor's last
  step, and this class does not have one.
- **The arguments go unread**, exactly as `PyType_GenericNew` left them. They are
  the `__init__`'s to interpret.

<details>
<summary>The subtree is what makes this a bug rather than a consequence.</summary>

`defines_own_init` reads `tp_init`, which an *inherited* `__init__` satisfies —
so `T` above, which says nothing about construction, lost its own declared
default as well as the base's, and had no way to ask for it back:
`__init__ = None` only makes the class uncallable.

A dataclass leaves the same shape readable, because its default stays on the
class. A salix field is a `member_descriptor` and the value lives only in
`__struct_defaults__`, so nothing hands it out unless something writes the slot.

</details>

<details>
<summary>Six new tests, each scored against a build with <code>tp_new</code> put back.</summary>

```
FAILED test_defaults_are_written_before_a_body_init_runs
FAILED test_a_body_init_can_read_the_default_and_overwrite_it
FAILED test_a_field_with_no_default_is_left_unset
FAILED test_a_subclass_that_writes_no_init_gets_its_defaults_too
FAILED test_a_frozen_class_with_a_body_init_still_gets_them
FAILED test_each_instance_gets_its_own_mutable_default
6 failed, 11 passed
```

`test_defaults_are_not_filled_for_a_body_init` documented the old behaviour and
is the first of these, rewritten. The frozen case is new coverage rather than a
changed expectation: a frozen class with a body `__init__` cannot write a field
at all, so before this its instances carried none.

</details>

This also settles the argument the issue came out of: #49's refusal of a
non-empty mutable default fires on classes with a body `__init__`, and it was
arguable that it over-fired on a declaration that could never take effect. Under
this change the declaration always takes effect, so the refusal is plainly
right.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She ruled
> option 1 on #56 and asked for the pre-publish review's issues to be worked off
> in one-PR batches, each iterated with the automated reviewer.
