### PR TITLE
fix: a body __eq__ carries the derived __ne__ with it

### DIFF
--- a/src/meta.c
+++ b/src/meta.c
@@ -56,6 +56,7 @@ static enum result apply_options(
 	bool inherits_body_eq
 );
 static enum result rebind(PyObject * namespace, char const * const * names, bool from_mixin);
+static enum result bind_not_equal(PyObject * namespace, bool body_defines_eq);
 static enum result bind_hash(
 	PyObject * namespace,
 	struct options options,
@@ -427,6 +428,12 @@ static enum result apply_options(
 	static char const * const representation[] = {"__repr__", NULL};
 	static char const * const mutability[] = {"__setattr__", "__delattr__", NULL};
 
+	/* Before the rebind below, which would otherwise put the mixin's __ne__ in
+	 * beside the body's __eq__ for a class that also changed the eq option. */
+	if (bind_not_equal(namespace, body_defines_eq) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
 	if (options.eq != inherited.eq && rebind(namespace, comparison, options.eq) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
@@ -472,6 +479,28 @@ static enum result rebind(
 	}
 
 	return RESULT_OK;
+}
+
+/*
+ * A body that defines __eq__ gets Python's derived __ne__ with it, the way
+ * every other construction does -- object.__ne__ calls __eq__ and inverts,
+ * unless the body wrote a __ne__ of its own, which rebind leaves alone.
+ *
+ * It has to be bound rather than left to the MRO, because the mixin is a base:
+ * its structural __ne__ is what the lookup finds, and it answers a different
+ * question from the body's __eq__. `a == b` and `a != b` were both true. #58.
+ *
+ * Binding it into the dict also puts it ahead of a __ne__ a *co-base* supplies,
+ * which plain Python would let win -- the derived one is the end of the MRO
+ * there, not the front. That is the same shape as #47, where a non-struct
+ * base's __eq__ shadows the struct base's, and it is left with that issue: the
+ * mixin already discarded a co-base's __ne__ before this, so what changes here
+ * is which answer wins rather than whether the co-base's is heard.
+ */
+static enum result bind_not_equal(PyObject * const namespace, bool const body_defines_eq) {
+	static char const * const not_equal[] = {"__ne__", NULL};
+
+	return body_defines_eq ? rebind(namespace, not_equal, false) : RESULT_OK;
 }
 
 /*

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -166,19 +166,122 @@ class TestMethods:
         assert hash(first) == hash(Loose(99)) == 0
         assert len({first, second}) == 1
 
-    @pytest.mark.xfail(strict=True, reason="#58: salix keeps the mixin's __ne__")
-    def test_a_body_eq_should_carry_ne_with_it(self):
-        """Asserted as it should be rather than as it is, so the assertion goes
-        green the moment #58 is fixed and strict=True makes that impossible to
-        miss.
+    def test_a_body_eq_carries_ne_with_it(self):
+        """The mixin is a base, so its structural __ne__ is what the lookup
+        found beside a body __eq__ that answered a different question, and
+        `a == b` and `a != b` were both true. #58.
         """
 
         Loose = self.loose_equality()
 
         assert (Loose(1) != Loose(2)) is False
 
+    def test_a_subclass_of_it_derives_ne_the_same_way(self):
+        """A subclass writing nothing about equality inherits both halves.
+
+        A regression guard rather than a proof of where the binding goes: the
+        assertion holds whether the derived __ne__ sits in Loose or in Child,
+        since either inverts the same inherited __eq__. What pins the location
+        is the class dict, asserted below.
+        """
+
+        class Child(self.loose_equality()):
+            y: int = 0
+
+        assert (Child(1) == Child(2), Child(1) != Child(2)) == (True, False)
+        assert "__ne__" in vars(self.loose_equality())
+        assert "__ne__" not in vars(Child)
+
+    def test_a_body_eq_carries_it_through_an_eq_option_change(self):
+        """The order the two rebinds run in, which nothing structural enforces.
+
+        `rebind` skips a name already in the namespace, so a comparison rebind
+        running first would put the mixin's structural __ne__ in beside the
+        body's __eq__ and bind_not_equal would then skip it -- #58 through the
+        other door. Only a class that changes the eq option reaches that rebind
+        at all, which is why the tests above cannot see the ordering.
+        """
+
+        class OptedOut(Struct, eq=False):
+            x: int
+
+            def __eq__(self, other: object) -> bool:
+                return isinstance(other, OptedOut)
+
+            def __hash__(self) -> int:
+                return 0
+
+        class OptedBackIn(OptedOut, eq=True):
+            y: int = 0
+
+            def __eq__(self, other: object) -> bool:
+                return isinstance(other, OptedBackIn)
+
+            def __hash__(self) -> int:
+                return 0
+
+        assert (OptedOut(1) == OptedOut(2), OptedOut(1) != OptedOut(2)) == (True, False)
+        assert (OptedBackIn(1) == OptedBackIn(2), OptedBackIn(1) != OptedBackIn(2)) == (True, False)
+
+    def test_a_body_ne_is_kept_over_the_derived_one(self):
+        """Deriving is what a body that says nothing about != asks for."""
+
+        class Both(Struct):
+            x: int
+
+            def __eq__(self, other: object) -> bool:
+                return isinstance(other, Both)
+
+            def __ne__(self, other: object) -> str:  # type: ignore[override]
+                return "the body's"
+
+            def __hash__(self) -> int:
+                return 0
+
+        assert (Both(1) != Both(2)) == "the body's"
+
+    def test_a_struct_that_leaves_equality_to_salix_is_unaffected(self):
+        """The dict is what says so, not the answers.
+
+        object.__ne__ re-dispatches through the mixin's own tp_richcompare, so
+        a structural struct answers identically whether the binding is there or
+        not -- an unconditional bind_not_equal passes every assertion below the
+        first. The gate is only observable in vars().
+        """
+
+        class Structural(Struct):
+            x: int
+
+        assert "__ne__" not in vars(Structural)
+        assert (Structural(1) != Structural(2), Structural(1) != Structural(1)) == (True, False)
+
+    def test_a_co_base_s_ne_is_shadowed_and_that_is_where_47_lives(self):
+        """Pinned as it is rather than as plain Python has it.
+
+        Binding into the dict puts the derived __ne__ ahead of a co-base's,
+        which plain Python would let win -- there the derived one is the end of
+        the MRO. The mixin's structural __ne__ already displaced a co-base's
+        before this, so what changed is which answer wins; #47 is the issue for
+        a non-struct base's comparison dunders being shadowed.
+        """
+
+        class Taggable:
+            def __ne__(self, other: object) -> str:  # type: ignore[override]
+                return "the co-base's"
+
+        class Mixed(Struct, Taggable):
+            x: int
+
+            def __eq__(self, other: object) -> bool:
+                return isinstance(other, Mixed)
+
+            def __hash__(self) -> int:
+                return 0
+
+        assert (Mixed(1) != Mixed(2)) is False
+
     def test_every_other_construction_derives_ne_from_eq(self):
-        """The parity claim the test above rests on, asserted rather than
+        """The parity claim the tests above rest on, asserted rather than
         described -- this file has been wrong about a sibling's behaviour more
         than once.
         """


### PR DESCRIPTION
Closes #58.

`object.__ne__` calls `__eq__` and inverts unless it returns `NotImplemented`,
so a class that defines only `__eq__` gets a consistent `!=` for free. salix did
not — the mixin is a base, so its **structural** `__ne__` is what the lookup
found beside a body `__eq__` answering a different question:

```python
class Loose(Struct):
    x: int

    def __eq__(self, other):
        return isinstance(other, Loose)

    def __hash__(self):
        return 0

Loose(1) == Loose(2)        # True
Loose(1) != Loose(2)        # True   <- both
```

| | `a == b` | `a != b` |
| --- | --- | --- |
| salix, before | True | **True** |
| salix, now | True | False |
| `dataclass(eq=False)` + body `__eq__` | True | False |
| a plain class + body `__eq__` | True | False |

`test_every_other_construction_derives_ne_from_eq` asserts the bottom two rather
than describing them, because this file has been wrong about a sibling's
behaviour more than once.

## The fix

`bind_not_equal` puts `object.__ne__` into the namespace when the body defines
`__eq__`. Binding is what the mixin being a *base* costs: leaving `__ne__` out of
the namespace does not reach `object.__ne__`, it reaches the mixin's. `rebind`'s
existing skip means a body that wrote its own `__ne__` keeps it.

<details>
<summary>Why it runs before the comparison rebind rather than after.</summary>

A class that also changed the `eq` option would otherwise have the mixin's
`__ne__` put in beside the body's `__eq__` by that rebind — the same bug through
the other door, since `rebind` skips `__eq__` (present in the body) but not
`__ne__` (absent). Running first means `__ne__` is present by the time the
comparison rebind looks, so it is skipped there too.

</details>

## Scoring

The `xfail` this replaces was `strict=True`, so the fix could not land quietly.
Both new tests fail on a build whose `bind_not_equal` returns without binding:

```
FAILED tests/test_methods.py::TestMethods::test_a_body_eq_carries_ne_with_it
FAILED tests/test_methods.py::TestMethods::test_a_subclass_of_it_derives_ne_the_same_way
```

Two more are negative controls that pass either way and would catch an
over-broad fix: a body that writes its own `__ne__` keeps it, and a struct that
leaves equality to salix is untouched.

`camas check` 25/25, `nix flake check` green including the Windows cross builds.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked
> for the pre-publish review's issues to be worked off in one-PR batches and for
> each PR to be iterated with the automated reviewer; #58 came out of #52's
> review round.
