### PR TITLE
test: say what these three assertions actually pin

### DIFF
--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -207,6 +207,14 @@ def test_a_shared_ordered_struct_is_safe_to_compare_while_another_thread_writes_
     often enough. So this pins that ordering keeps working under concurrent
     writes rather than that it would crash without the lock; the crash is pinned
     by the test above, through the helper both paths share.
+
+    `ordered is True` is constant by design and cannot fail in the race
+    direction: floor is below every tuple the writer stores, so a reader that
+    returns a stale but still-above-floor value answers True exactly as a live
+    one does. What it does catch is a read path that raises, or that returns
+    anything other than True. Making the writer straddle floor would not buy the
+    stale case either -- the reader then cannot know which value is current, so
+    it could assert nothing about the result at all.
     """
 
     class Ranked(Struct, frozen=False, order=True):

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -185,11 +185,13 @@ class TestMethods:
         is the class dict, asserted below.
         """
 
-        class Child(self.loose_equality()):
+        Loose = self.loose_equality()
+
+        class Child(Loose):
             y: int = 0
 
         assert (Child(1) == Child(2), Child(1) != Child(2)) == (True, False)
-        assert "__ne__" in vars(self.loose_equality())
+        assert "__ne__" in vars(Loose)
         assert "__ne__" not in vars(Child)
 
     def test_a_body_eq_carries_it_through_an_eq_option_change(self):
@@ -200,6 +202,16 @@ class TestMethods:
         body's __eq__ and bind_not_equal would then skip it -- #58 through the
         other door. Only a class that changes the eq option reaches that rebind
         at all, which is why the tests above cannot see the ordering.
+
+        The two halves are not equal witnesses. OptedBackIn is the one that
+        observes the order; OptedOut answers correctly whichever way round the
+        two run, because `rebind(..., false)` installs object's __ne__ for
+        eq=False anyway. It is here to cover the eq=False direction at all.
+
+        Its answer assertion is what pins that direction -- without the binding
+        the MRO reaches the mixin's structural __ne__ and returns True. The
+        `vars()` assertions below add only *where* the binding sits, which the
+        answers cannot show.
         """
 
         class OptedOut(Struct, eq=False):
@@ -222,6 +234,8 @@ class TestMethods:
 
         assert (OptedOut(1) == OptedOut(2), OptedOut(1) != OptedOut(2)) == (True, False)
         assert (OptedBackIn(1) == OptedBackIn(2), OptedBackIn(1) != OptedBackIn(2)) == (True, False)
+        assert "__ne__" in vars(OptedOut)
+        assert "__ne__" in vars(OptedBackIn)
 
     def test_a_body_ne_is_kept_over_the_derived_one(self):
         """Deriving is what a body that says nothing about != asks for."""


### PR DESCRIPTION
Test-only. No source change; every behaviour these cover is unchanged.

**Four review rounds running produced the same finding against tests I had just
written** — the docstring claimed something the assertion could not observe.
Once is a slip, four times is a habit, so these land together rather than one
per PR.

| where | the claim | what the assertion could see |
| --- | --- | --- |
| `test_a_subclass_of_it_derives_ne_the_same_way` | "what pins the location is the class dict" | `vars(self.loose_equality())` builds a **third** `Loose` — not the class `Child` was defined over |
| `test_a_body_eq_carries_it_through_an_eq_option_change` | both halves guard the rebind order | only `OptedBackIn` does; `OptedOut` answers correctly either way, because `rebind(..., false)` installs `object.__ne__` for `eq=False` regardless |
| `test_a_shared_ordered_struct_is_safe_to_compare...` | reads as though it guards the race | `ordered is True` is constant — `floor` is below every tuple the writer stores |

<details>
<summary>The third one is a decline, and the reason matters.</summary>

The recommendation on #70 was to make the writer straddle `floor` so a stale or
torn pair read could be observed. That removes what the assertion is for: with a
straddling writer the reader cannot know which value is current, so it can
assert nothing about the result at all.

The constant assertion is the device the sibling test names in its own
docstring — *"the value assertions are there so that a reader which quietly
stopped reading would fail rather than pass"*. It was never a check on the race,
and the docstring now says that rather than leaving a reader to work it out.
The race on that path is not observable at any density I could reach: reverting
just `ordering_result` to a borrowed read survives 3/3, and 3/3 again at five
times the rounds, which is the same result `hash` gave before #46's fix.

</details>

Two `"__ne__" in vars(...)` assertions are new, on `OptedOut` and `OptedBackIn`,
because the dict is the only place the `eq=False` direction of the binding is
visible at all.

`camas check` 25/25.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. Three
> findings across #70's and #73's review rounds said a test could not observe
> what it claimed; both merged on the convergence signal with these recorded as
> follow-ups, and this is that follow-up.
