### PR TITLE
test: sweep every combination of two and three struct bases

### DIFF
--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -411,9 +411,11 @@ def test_a_frozen_class_that_compares_by_value_hashes_by_value():
         if not (seen.frozen and seen.equality == "value"):
             continue
 
+        one, twin = instance(cls), instance(cls)
+
         if cls.__hash__ is None:
             violations.append(f"{named(bases)}: unhashable")
-        elif hash(instance(cls)) != hash(instance(cls)):
+        elif hash(one) != hash(twin):
             violations.append(f"{named(bases)}: equal instances hash differently")
 
     assert violations == []
@@ -550,13 +552,68 @@ def behaviour_differs_from_the_first_base_alone(
 
 
 def hash_disagreements(combinations: tuple[Combination, ...]) -> list[str]:
-    return [
-        named(bases)
-        for bases, cls in combinations
-        if cls.__hash__ is not None
-        and instance(cls) == instance(cls, 100)
-        and hash(instance(cls)) != hash(instance(cls, 100))
-    ]
+    """Both pairs, because either can be the equal one.
+
+    Two instances built from *differing* arguments are equal only where a body
+    __eq__ says everything is, and two built from the *same* arguments are
+    equal wherever equality reads the fields. Probing only the first left the
+    invariant firing on 111 of 672 sound combinations, and on 87 of those the
+    hash is a constant.
+
+    Both instances of a pair are held while they are compared: hashed one at a
+    time, the first is freed before the second is allocated and the allocator
+    hands back the same address, so an identity hash reads as a matching one.
+    """
+
+    disagreements = []
+
+    for bases, cls in combinations:
+        if cls.__hash__ is None:
+            continue
+
+        for left, right in ((instance(cls), instance(cls)), (instance(cls), instance(cls, 100))):
+            if left == right and hash(left) != hash(right):
+                disagreements.append(named(bases))
+                break
+
+    return disagreements
+
+
+def hashability_disagrees_with_equality(
+    combinations: tuple[Combination, ...],
+) -> list[str]:
+    """Whether a class can be hashed at all must follow the equality it
+    answers with -- identity equality is hashable, value equality is hashable
+    exactly when the value cannot move, and an equality a body supplied brings
+    its own rule.
+
+    The unhashable rule beside this one keys off *observed* value equality, so
+    it steps over a class that records eq=True, is made unhashable for it, and
+    then answers identity because a later base binds `__eq__`. That leaves an
+    identity-comparing class that cannot be put in a set, and nothing said so.
+    """
+
+    violations = []
+
+    for bases, cls in combinations:
+        seen = observe(cls)
+        hashable = cls.__hash__ is not None
+
+        if seen.equality == "identity" and not hashable:
+            violations.append(f"{named(bases)}: identity equality, unhashable")
+        elif seen.equality == "value" and hashable != seen.frozen:
+            violations.append(f"{named(bases)}: value equality, hashable={hashable}")
+
+    return violations
+
+
+def test_hashability_follows_the_equality_the_class_answers_with():
+    assert hashability_disagrees_with_equality(SOUND_EQ) == []
+
+
+@pytest.mark.xfail(strict=True, reason="#76: equality answered by a later base, hash settled from the record")
+def test_hashability_follows_equality_when_a_later_base_answers_it():
+    assert hashability_disagrees_with_equality(CONTESTED_EQ) == []
 
 
 def test_the_repr_is_the_first_struct_bases():

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -1,0 +1,481 @@
+"""Every buildable combination of two and three struct bases, and what has to
+be true of all of them.
+
+The tests beside this one in test_multiple_bases.py pin shapes: this base in
+front of that one answers so. Nine of those shapes arrived one review round at
+a time while #9 was being fixed, each the same mechanism wearing a different
+hat, because a handful of examples samples the space rather than covering it.
+
+So these say what must hold of *any* combination, and sweep the whole space
+looking for somewhere it does not. A shape nobody thought of is covered the day
+it becomes buildable.
+
+The rule the differential tests state is salix's own: options are inherited
+from the **first** struct base, whose branch of the MRO is searched first, and
+only `frozen` and `weakref` are facts about every base rather than preferences
+of that one. So a class with several struct bases must behave like the same
+class built on its first struct base alone.
+
+Where that fails today it fails for one reason, filed as #76: a struct base
+binds a dunder only where its own creation transitioned an option, so a later
+base can bind a name the first one left to the MRO, and then the record and the
+behaviour are two different answers. Those combinations are split off by asking
+`vars()` which bases bind the name -- a structural question, not a list of
+known-bad examples -- and the tests over them are strict xfails, so #76 turns
+them red the day it lands.
+"""
+
+import itertools
+import operator
+import weakref
+from typing import Any, NamedTuple
+
+import pytest
+
+from salix import Struct
+
+
+class Fieldless(Struct):
+    pass
+
+
+class MutableFieldless(Struct, frozen=False):
+    pass
+
+
+class Weak(Struct, weakref=True):
+    pass
+
+
+class Fields(Struct):
+    a: int
+    b: int
+
+
+class OneField(Struct):
+    a: int
+
+
+class MutableFields(Struct, frozen=False):
+    m: int
+
+
+class Unrepresented(Struct, repr=False):
+    pass
+
+
+class ByIdentity(Struct, eq=False):
+    pass
+
+
+class Ordered(Struct, order=True):
+    o: int
+
+
+class BodyEq(Struct):
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __hash__(self) -> int:
+        return 7
+
+
+class Derived(Fieldless):
+    pass
+
+
+SHAPES = (
+    Fieldless,
+    MutableFieldless,
+    Weak,
+    Fields,
+    OneField,
+    MutableFields,
+    Unrepresented,
+    ByIdentity,
+    Ordered,
+    BodyEq,
+    Derived,
+)
+
+ARRANGEMENTS = tuple(
+    arrangement
+    for width in (2, 3)
+    for arrangement in itertools.permutations(SHAPES, width)
+)
+
+_names = itertools.count()
+
+
+class Refused(NamedTuple):
+    """Salix declined the class."""
+
+    message: str
+
+
+class Impossible(NamedTuple):
+    """Python declined it, which is not this suite's business: an MRO or
+    lay-out conflict says these bases could never have been combined, whoever
+    was building them.
+    """
+
+    message: str
+
+
+Outcome = type | Refused | Impossible
+Combination = tuple[tuple[type, ...], type]
+
+PYTHONS_OWN = ("consistent method resolution", "lay-out conflict")
+NEW_FIELD = "z"
+
+
+def build(bases: tuple[type, ...], field: str = NEW_FIELD, **keywords: bool) -> Outcome:
+    try:
+        return type(Struct)(
+            f"Combination{next(_names)}",
+            bases,
+            {"__annotations__": {field: int}},
+            **keywords,
+        )
+    except TypeError as failure:
+        if any(reason in str(failure) for reason in PYTHONS_OWN):
+            return Impossible(str(failure))
+        return Refused(str(failure))
+
+
+def is_a_class(outcome: Outcome) -> bool:
+    return isinstance(outcome, type)
+
+
+def instance(cls: type, start: int = 0) -> Any:
+    return cls(*range(start, start + len(cls.__struct_fields__)))
+
+
+class Behaviour(NamedTuple):
+    """What a class does, as opposed to what it recorded. Only the second is
+    salix's to choose, and the whole of #76 is the two disagreeing.
+    """
+
+    repr: bool
+    equality: str
+    order: bool
+    frozen: bool
+    weakref: bool
+
+
+def observe(cls: type) -> Behaviour:
+    """`equality` is three-valued because equality has three possible sources.
+    A body `__eq__` that answers True to everything looks exactly like the
+    structural one until it is shown two instances that differ, which is the
+    shape #71's round-6 review found and four rounds before it did not.
+    """
+
+    one, twin, other = instance(cls), instance(cls), instance(cls, 100)
+
+    try:
+        operator.lt(one, twin)
+        orders = True
+    except TypeError:
+        orders = False
+
+    try:
+        weakref.ref(one)
+        weak = True
+    except TypeError:
+        weak = False
+
+    try:
+        setattr(instance(cls), cls.__struct_fields__[0], 99)
+        frozen = False
+    except TypeError:
+        frozen = True
+
+    return Behaviour(
+        repr=repr(one).startswith(f"{cls.__name__}("),
+        equality=(
+            "everything" if one == other else "value" if one == twin else "identity"
+        ),
+        order=orders,
+        frozen=frozen,
+        weakref=weak,
+    )
+
+
+def answered_by_a_later_base(bases: tuple[type, ...], name: str) -> bool:
+    """Whether the MRO finds this dunder somewhere other than where the options
+    were read from.
+
+    A struct base carries a dunder in its own dict exactly where its creation
+    transitioned an option away from what it inherited; everything else it
+    leaves to the mixin at the end of the MRO. So a later base binding a name
+    the first one did not is the whole of #76's mechanism, asked of the classes
+    themselves rather than assumed from a list.
+    """
+
+    return name not in vars(bases[0]) and any(name in vars(base) for base in bases[1:])
+
+
+def named(bases: tuple[type, ...]) -> str:
+    return " + ".join(base.__name__ for base in bases)
+
+
+ALL = tuple(
+    (bases, outcome) for bases in ARRANGEMENTS if is_a_class(outcome := build(bases))
+)
+
+
+def test_the_sweep_reaches_every_shape_at_both_widths():
+    """A guard on the sweep itself. A change that made some shape unbuildable
+    in every arrangement would stop testing it without a word, and every test
+    below would stay green over the space that was left.
+    """
+
+    assert {base for bases, _ in ALL for base in bases} == set(SHAPES)
+    assert {len(bases) for bases, _ in ALL} == {2, 3}
+
+
+def test_the_fields_are_the_layout_bases_followed_by_the_new_one():
+    """The offsets salix hands out are the base's slots plus the new ones, so
+    the base it reads them from has to be the one CPython placed them after.
+    """
+
+    violations = [
+        f"{named(bases)}: {cls.__struct_fields__} after {cls.__base__.__name__}"
+        f"{cls.__base__.__struct_fields__}"
+        for bases, cls in ALL
+        if cls.__struct_fields__ != (*cls.__base__.__struct_fields__, NEW_FIELD)
+    ]
+
+    assert violations == []
+
+
+def test_every_field_reads_back_what_it_was_given():
+    violations = [
+        named(bases)
+        for bases, cls in ALL
+        if [getattr(instance(cls), name) for name in cls.__struct_fields__]
+        != list(range(len(cls.__struct_fields__)))
+    ]
+
+    assert violations == []
+
+
+def test_match_args_is_the_fields():
+    violations = [
+        f"{named(bases)}: {cls.__match_args__} against {cls.__struct_fields__}"
+        for bases, cls in ALL
+        if getattr(cls, "__match_args__", None) != cls.__struct_fields__
+    ]
+
+    assert violations == []
+
+
+def test_a_write_and_a_delete_agree_about_whether_the_class_is_frozen():
+    """Two routes to the same promise. A class that refuses one and allows the
+    other is frozen against an assignment and not against a `del`.
+    """
+
+    def writes(cls: type) -> bool:
+        try:
+            setattr(instance(cls), cls.__struct_fields__[0], 99)
+            return True
+        except TypeError:
+            return False
+
+    def deletes(cls: type) -> bool:
+        try:
+            delattr(instance(cls), cls.__struct_fields__[0])
+            return True
+        except (TypeError, AttributeError):
+            return False
+
+    violations = [named(bases) for bases, cls in ALL if writes(cls) != deletes(cls)]
+
+    assert violations == []
+
+
+def test_a_value_that_compares_by_value_and_can_still_move_is_unhashable():
+    """Python's rule, and the reason `frozen` and `eq` between them settle the
+    hash: a key whose hash moves is not a key.
+    """
+
+    violations = [
+        named(bases)
+        for bases, cls in ALL
+        if observe(cls).equality == "value"
+        and not observe(cls).frozen
+        and cls.__hash__ is not None
+    ]
+
+    assert violations == []
+
+
+ORDERS_ALONE = {
+    shape: observe(alone).order
+    for shape in SHAPES
+    if is_a_class(alone := build((shape,)))
+}
+
+
+def contested(bases: tuple[type, ...], name: str) -> bool:
+    """Whether #76's mechanism can reach this name for these bases.
+
+    Split per name rather than once for all of them: a combination where a
+    later base binds `__repr__` says nothing about equality, and folding them
+    together would put hundreds of sound cases in a bucket that is expected to
+    fail, where a regression in one of them would change nothing.
+
+    `__lt__` needs the extra clause because ordering is answered by the
+    recorded option at comparison time, not by the binding -- so a later base's
+    `__lt__` only shadows an answer there was one of. That reads off the first
+    base alone, which is the side of the comparison being trusted, so it is a
+    property of the reference rather than of the class under test.
+    """
+
+    if not answered_by_a_later_base(bases, name):
+        return False
+
+    return ORDERS_ALONE.get(bases[0], False) if name == "__lt__" else True
+
+
+def halves(name: str) -> tuple[tuple[Combination, ...], tuple[Combination, ...]]:
+    return (
+        tuple((bases, cls) for bases, cls in ALL if not contested(bases, name)),
+        tuple((bases, cls) for bases, cls in ALL if contested(bases, name)),
+    )
+
+
+SOUND_REPR, CONTESTED_REPR = halves("__repr__")
+SOUND_EQ, CONTESTED_EQ = halves("__eq__")
+SOUND_ORDER, CONTESTED_ORDER = halves("__lt__")
+
+
+@pytest.mark.parametrize(
+    ("sound", "broken"),
+    [
+        (SOUND_REPR, CONTESTED_REPR),
+        (SOUND_EQ, CONTESTED_EQ),
+        (SOUND_ORDER, CONTESTED_ORDER),
+    ],
+    ids=["__repr__", "__eq__", "__lt__"],
+)
+def test_both_halves_of_the_split_are_reached(sound, broken):
+    """An empty sound half would make the test over it vacuous. An empty broken
+    half cannot hide: its test is a strict xfail, so it turns red instead.
+    """
+
+    assert sound != ()
+    assert broken != ()
+
+
+def behaviour_differs_from_the_first_base_alone(
+    combinations: tuple[Combination, ...],
+    field: str,
+) -> list[str]:
+    violations = []
+
+    for bases, multi in combinations:
+        alone = build((bases[0],))
+
+        if not is_a_class(alone):
+            continue
+
+        together, apart = getattr(observe(multi), field), getattr(observe(alone), field)
+
+        if together != apart:
+            violations.append(f"{named(bases)}: {together} against {apart} alone")
+
+    return violations
+
+
+def hash_disagreements(combinations: tuple[Combination, ...]) -> list[str]:
+    return [
+        named(bases)
+        for bases, cls in combinations
+        if cls.__hash__ is not None
+        and instance(cls) == instance(cls, 100)
+        and hash(instance(cls)) != hash(instance(cls, 100))
+    ]
+
+
+def test_the_repr_is_the_first_struct_bases():
+    assert behaviour_differs_from_the_first_base_alone(SOUND_REPR, "repr") == []
+
+
+def test_equality_is_the_first_struct_bases():
+    assert behaviour_differs_from_the_first_base_alone(SOUND_EQ, "equality") == []
+
+
+def test_ordering_is_the_first_struct_bases():
+    assert behaviour_differs_from_the_first_base_alone(SOUND_ORDER, "order") == []
+
+
+def test_equal_instances_hash_equal():
+    """The dict-key invariant, and the one worth the whole sweep: two objects
+    that compare equal and hash differently cannot find each other in a dict.
+    """
+
+    assert hash_disagreements(SOUND_EQ) == []
+
+
+@pytest.mark.xfail(strict=True, reason="#76: the record and the MRO disagree")
+def test_the_repr_is_the_first_struct_bases_when_a_later_one_binds_it():
+    assert behaviour_differs_from_the_first_base_alone(CONTESTED_REPR, "repr") == []
+
+
+@pytest.mark.xfail(strict=True, reason="#76: the record and the MRO disagree")
+def test_equality_is_the_first_struct_bases_when_a_later_one_binds_it():
+    assert behaviour_differs_from_the_first_base_alone(CONTESTED_EQ, "equality") == []
+
+
+@pytest.mark.xfail(strict=True, reason="#76: the record and the MRO disagree")
+def test_ordering_is_the_first_struct_bases_when_a_later_one_binds_it():
+    assert behaviour_differs_from_the_first_base_alone(CONTESTED_ORDER, "order") == []
+
+
+@pytest.mark.xfail(strict=True, reason="#76: a later base's __eq__ against salix's hash")
+def test_equal_instances_hash_equal_when_a_later_base_answers_equality():
+    assert hash_disagreements(CONTESTED_EQ) == []
+
+
+@pytest.mark.xfail(strict=True, reason="#77: the frozen pin is armed from one base and directed by another")
+def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
+    """Whether a class may be frozen is a question about which of its bases
+    made a promise, and no ordering of the same bases changes the answer.
+    """
+
+    violations = []
+
+    for bases in ARRANGEMENTS:
+        for wanted in (True, False):
+            forwards = build(bases, frozen=wanted)
+            backwards = build(tuple(reversed(bases)), frozen=wanted)
+
+            if isinstance(forwards, Impossible) or isinstance(backwards, Impossible):
+                continue
+
+            if isinstance(forwards, Refused) != isinstance(backwards, Refused):
+                violations.append(f"{named(bases)} frozen={wanted}")
+
+    assert violations == []
+
+
+@pytest.mark.xfail(strict=True, reason="#78: weakref is recorded from one base and slotted from another")
+def test_the_weakref_option_and_the_slot_agree():
+    """CPython cannot take an inherited `__weakref__` away, so `weakref=False`
+    over a base that has one is a request salix cannot honour -- and accepting
+    it silently leaves the class recording one answer and giving another.
+    """
+
+    violations = []
+
+    for bases, cls in ALL:
+        without = build((cls,), field="fresh", weakref=False)
+
+        if not is_a_class(without):
+            continue
+
+        if observe(without).weakref:
+            violations.append(named(bases))
+
+    assert violations == []

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -225,11 +225,47 @@ ALONE = {
     shape: built for shape in SHAPES if is_a_class(built := build((shape,)))
 }
 
+# What each shape does on its own, observed once. Every question this file asks
+# of a first base is a question about one of eleven classes, not about 784.
+BEHAVIOUR_ALONE = {shape: observe(built) for shape, built in ALONE.items()}
+ORDERS_ALONE = {shape: seen.order for shape, seen in BEHAVIOUR_ALONE.items()}
+EQUALITY_ALONE = {shape: seen.equality for shape, seen in BEHAVIOUR_ALONE.items()}
+FROZEN_ALONE = {shape: seen.frozen for shape, seen in BEHAVIOUR_ALONE.items()}
+
+
+BUILDABLE = 784
+PYTHON_REFUSES = 316
+
 
 def test_the_sweep_reaches_every_shape_at_both_widths():
     assert {base for bases, _ in ALL for base in bases} == set(SHAPES)
     assert {len(bases) for bases, _ in ALL} == {2, 3}
     assert set(ALONE) == set(SHAPES)
+
+
+def test_the_space_is_the_size_it_has_always_been():
+    """The denominator, pinned -- and the one number in this file that is an
+    expected value rather than an invariant.
+
+    It earns that because it is what every assertion below divides by: a sweep
+    that quietly covers 600 combinations instead of 784 reports the same green
+    as one that covers all of them. The other guards close the two paths that
+    lose combinations *visibly* (a salix refusal, a reworded CPython message);
+    this closes the rest, including a salix message that happens to contain one
+    of the `PYTHONS_OWN` phrases -- salix is a layout library, so `lay-out
+    conflict` is a phrase it could plausibly use itself -- and a future CPython
+    that tightens MRO or layout rules.
+
+    Measured identical on 3.10 through 3.15: 1100 arrangements, 784 salix
+    builds, 316 Python refuses outright. A change here is something to look at
+    rather than to re-baseline: it means the shape of the space moved.
+    """
+
+    impossible = [bases for bases, outcome in OUTCOMES if isinstance(outcome, Impossible)]
+
+    assert len(ALL) == BUILDABLE
+    assert len(impossible) == PYTHON_REFUSES
+    assert len(ALL) + len(impossible) == len(ARRANGEMENTS)
 
 
 def test_salix_refuses_no_arrangement_of_these_shapes():
@@ -333,6 +369,30 @@ def test_a_value_that_compares_by_value_and_can_still_move_is_unhashable():
     assert violations == []
 
 
+def test_a_weakref_slot_on_any_base_reaches_the_class():
+    """The rule `inherited_options` states in prose and nothing asserted: the
+    slot is a fact about every base, not a preference of the first.
+
+    Without it the whole multi-base weakref surface was one strict xfail, which
+    emits a single bit -- so a regression that stopped combinations inheriting
+    the slot would take them *out* of that xfail's violation list and leave it
+    failing exactly as expected, with nothing red. This is the direction that
+    makes the bucket's size mean something.
+    """
+
+    def has_slot(cls: type) -> bool:
+        return cls.__weakrefoffset__ != 0
+
+    violations = [
+        f"{named(bases)}: ref={observe(cls).weakref} slot={has_slot(cls)}"
+        for bases, cls in ALL
+        if observe(cls).weakref != any(has_slot(base) for base in bases)
+        or has_slot(cls) != observe(cls).weakref
+    ]
+
+    assert violations == []
+
+
 def test_a_frozen_promise_is_kept_by_every_arrangement_that_inherits_one():
     """What the class records against what it does, for the one option the
     differential deliberately excludes.
@@ -347,19 +407,17 @@ def test_a_frozen_promise_is_kept_by_every_arrangement_that_inherits_one():
     """
 
     def promised(bases: tuple[type, ...]) -> bool:
-        return any(base.__struct_fields__ and observe(base).frozen for base in bases)
+        return any(base.__struct_fields__ and FROZEN_ALONE[base] for base in bases)
 
-    violations = [
-        f"{named(bases)}: frozen={observe(cls).frozen} against a promise"
-        for bases, cls in ALL
-        if observe(cls).frozen != (observe(ALONE[bases[0]]).frozen or promised(bases))
-    ]
+    violations = []
+
+    for bases, cls in ALL:
+        frozen = observe(cls).frozen
+
+        if frozen != (FROZEN_ALONE[bases[0]] or promised(bases)):
+            violations.append(f"{named(bases)}: frozen={frozen} against a promise")
 
     assert violations == []
-
-
-ORDERS_ALONE = {shape: observe(built).order for shape, built in ALONE.items()}
-EQUALITY_ALONE = {shape: observe(built).equality for shape, built in ALONE.items()}
 
 
 def contested(bases: tuple[type, ...], name: str) -> bool:
@@ -568,6 +626,27 @@ def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
     assert violations == []
 
 
+WITH_A_SLOT = tuple(
+    (bases, cls)
+    for bases, cls in (*ALL, *(((shape,), built) for shape, built in ALONE.items()))
+    if any(base.__weakrefoffset__ != 0 for base in bases)
+)
+
+
+def weakref_requests_ignored(combinations: tuple[Combination, ...]) -> list[str]:
+    """Where `weakref=False` was accepted and then had no effect."""
+
+    ignored = []
+
+    for bases, cls in combinations:
+        without = build((cls,), field="fresh", weakref=False)
+
+        if is_a_class(without) and observe(without).weakref:
+            ignored.append(named(bases))
+
+    return ignored
+
+
 @pytest.mark.xfail(strict=True, reason="#78: weakref is recorded from one base and slotted from another")
 def test_the_weakref_option_and_the_slot_agree():
     """CPython cannot take an inherited `__weakref__` away, so `weakref=False`
@@ -580,18 +659,22 @@ def test_the_weakref_option_and_the_slot_agree():
     turn every other case here red and leave that one passing unexercised.
     """
 
-    violations = []
+    assert weakref_requests_ignored(WITH_A_SLOT) == []
 
-    for bases, cls in (*ALL, *(((shape,), built) for shape, built in ALONE.items())):
-        without = build((cls,), field="fresh", weakref=False)
 
-        if not is_a_class(without):
-            continue
+def test_every_class_carrying_an_inherited_slot_really_does_ignore_the_request():
+    """The bound that gives the xfail above a size, for the same reason the
+    #76 buckets have one: an aggregate `== []` over a bucket where everything
+    already fails flips only on a *complete* fix.
 
-        if observe(without).weakref:
-            violations.append(named(bases))
+    Without this, a partial fix for #78 -- one that refuses `weakref=False` for
+    some arrangements and not others -- shrinks the violation list while the
+    xfail stays failed-as-expected, and so stays green. A refusal makes
+    `is_a_class` false and drops the combination silently; here that shows up
+    as the count no longer matching the bucket.
+    """
 
-    assert violations == []
+    assert len(weakref_requests_ignored(WITH_A_SLOT)) == len(WITH_A_SLOT)
 
 
 def test_a_single_base_asking_to_drop_an_inherited_weakref_slot_is_the_same_bug():

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -369,15 +369,16 @@ def test_a_value_that_compares_by_value_and_can_still_move_is_unhashable():
     assert violations == []
 
 
-def test_a_weakref_slot_on_any_base_reaches_the_class():
-    """The rule `inherited_options` states in prose and nothing asserted: the
-    slot is a fact about every base, not a preference of the first.
+def test_a_class_is_weak_referenceable_only_where_its_bases_make_it_so():
+    """A class supports weakref exactly when one of its bases carries the slot
+    -- no more.
 
-    Without it the whole multi-base weakref surface was one strict xfail, which
-    emits a single bit -- so a regression that stopped combinations inheriting
-    the slot would take them *out* of that xfail's violation list and leave it
-    failing exactly as expected, with nothing red. This is the direction that
-    makes the bucket's size mean something.
+    The "no less" half is CPython's and not worth claiming: an inherited
+    `__weakref__` cannot be dropped, and a class that tried would be refused at
+    build time and caught by the size pin. What is salix's, and what this
+    catches, is the *other* direction -- a class becoming weak-referenceable
+    when nothing gave it a slot, whether by `build_slots` appending one over a
+    base that already has it or by a struct class growing a `__dict__`.
     """
 
     def has_slot(cls: type) -> bool:
@@ -386,9 +387,34 @@ def test_a_weakref_slot_on_any_base_reaches_the_class():
     violations = [
         f"{named(bases)}: ref={observe(cls).weakref} slot={has_slot(cls)}"
         for bases, cls in ALL
-        if observe(cls).weakref != any(has_slot(base) for base in bases)
-        or has_slot(cls) != observe(cls).weakref
+        if observe(cls).weakref and not any(has_slot(base) for base in bases)
     ]
+
+    assert violations == []
+
+
+def test_a_frozen_class_that_compares_by_value_hashes_by_value():
+    """The direction the rest of the hash surface cannot reach.
+
+    `hash_disagreements` needs two *equal* instances, and a frozen value-equal
+    class never produces a pair from differing constructor arguments; the
+    unhashable rule skips frozen classes outright. So a regression that made
+    every eq=True class unhashable, or hashed frozen ones by identity, passed
+    the whole sweep -- 290 combinations with nothing said about them.
+    """
+
+    violations = []
+
+    for bases, cls in ALL:
+        seen = observe(cls)
+
+        if not (seen.frozen and seen.equality == "value"):
+            continue
+
+        if cls.__hash__ is None:
+            violations.append(f"{named(bases)}: unhashable")
+        elif hash(instance(cls)) != hash(instance(cls)):
+            violations.append(f"{named(bases)}: equal instances hash differently")
 
     assert violations == []
 
@@ -514,12 +540,8 @@ def behaviour_differs_from_the_first_base_alone(
     violations = []
 
     for bases, multi in combinations:
-        alone = build((bases[0],))
-
-        if not is_a_class(alone):
-            continue
-
-        together, apart = getattr(observe(multi), field), getattr(observe(alone), field)
+        together = getattr(observe(multi), field)
+        apart = getattr(BEHAVIOUR_ALONE[bases[0]], field)
 
         if together != apart:
             violations.append(f"{named(bases)}: {together} against {apart} alone")
@@ -604,13 +626,35 @@ def test_equal_instances_hash_equal_when_a_later_base_answers_equality():
     assert hash_disagreements(CONTESTED_HASH) == []
 
 
-@pytest.mark.xfail(strict=True, reason="#77: the frozen pin is armed from one base and directed by another")
-def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
-    """Whether a class may be frozen is a question about which of its bases
-    made a promise, and no ordering of the same bases changes the answer.
+def inherits_a_different_frozen_reversed(bases: tuple[type, ...]) -> bool:
+    """Whether reversing these bases changes what `frozen` they inherit, in a
+    way `options_read` can act on.
+
+    Two clauses, because the refusal needs both. `inherited.frozen` is the
+    first struct base's, strengthened by any *fielded* frozen base -- so it can
+    differ between an ordering and its reverse. And the refusal only fires when
+    the layout base is constraining, which means some base has fields: an
+    all-fieldless arrangement inherits a different frozen and is accepted both
+    ways regardless.
+
+    Leaving the second clause out puts 324 orderings in the bucket to hold 188
+    real ones.
     """
 
-    violations = []
+    reversed_bases = tuple(reversed(bases))
+
+    def inherited(order: tuple[type, ...]) -> bool:
+        return FROZEN_ALONE[order[0]] or any(
+            base.__struct_fields__ and FROZEN_ALONE[base] for base in order
+        )
+
+    return any(base.__struct_fields__ for base in bases) and inherited(
+        bases
+    ) != inherited(reversed_bases)
+
+
+def frozen_refusals_that_depend_on_order() -> list[str]:
+    asymmetric = []
 
     for bases in ARRANGEMENTS:
         for wanted in (True, False):
@@ -621,9 +665,41 @@ def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
                 continue
 
             if isinstance(forwards, Refused) != isinstance(backwards, Refused):
-                violations.append(f"{named(bases)} frozen={wanted}")
+                asymmetric.append(f"{named(bases)} frozen={wanted}")
 
-    assert violations == []
+    return asymmetric
+
+
+FROZEN_AT_RISK = tuple(
+    (bases, wanted)
+    for bases in ARRANGEMENTS
+    for wanted in (True, False)
+    if inherits_a_different_frozen_reversed(bases)
+    and not isinstance(build(bases, frozen=wanted), Impossible)
+    and not isinstance(build(tuple(reversed(bases)), frozen=wanted), Impossible)
+)
+
+
+@pytest.mark.xfail(strict=True, reason="#77: the frozen pin is armed from one base and directed by another")
+def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
+    """Whether a class may be frozen is a question about which of its bases
+    made a promise, and no ordering of the same bases changes the answer.
+    """
+
+    assert frozen_refusals_that_depend_on_order() == []
+
+
+def test_every_order_dependent_frozen_refusal_really_is_one():
+    """#77's bucket bound, the last of the four this file owes.
+
+    Without it a partial fix -- one that settles the six width-2 pairs and
+    leaves the 182 width-3 arrangements -- keeps the xfail above failing
+    exactly as expected, and the tail goes unmentioned.
+
+    Delete this with the xfail when #77 lands.
+    """
+
+    assert len(frozen_refusals_that_depend_on_order()) == len(FROZEN_AT_RISK)
 
 
 WITH_A_SLOT = tuple(

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -219,19 +219,42 @@ def named(bases: tuple[type, ...]) -> str:
     return " + ".join(base.__name__ for base in bases)
 
 
-ALL = tuple(
-    (bases, outcome) for bases in ARRANGEMENTS if is_a_class(outcome := build(bases))
-)
+OUTCOMES = tuple((bases, build(bases)) for bases in ARRANGEMENTS)
+ALL = tuple((bases, outcome) for bases, outcome in OUTCOMES if is_a_class(outcome))
+ALONE = {
+    shape: built for shape in SHAPES if is_a_class(built := build((shape,)))
+}
 
 
 def test_the_sweep_reaches_every_shape_at_both_widths():
-    """A guard on the sweep itself. A change that made some shape unbuildable
-    in every arrangement would stop testing it without a word, and every test
-    below would stay green over the space that was left.
-    """
-
     assert {base for bases, _ in ALL for base in bases} == set(SHAPES)
     assert {len(bases) for bases, _ in ALL} == {2, 3}
+    assert set(ALONE) == set(SHAPES)
+
+
+def test_salix_refuses_no_arrangement_of_these_shapes():
+    """The guard that keeps the sweep from shrinking in silence.
+
+    Every combination here is buildable or Python's own to refuse, so a change
+    that makes salix decline one takes it out of `ALL` -- and every invariant
+    below would stay green over the smaller space, which is the sampling this
+    file exists to stop. Asserting the shapes each appear *somewhere* does not
+    catch that: they would still each appear somewhere.
+
+    It guards the `PYTHONS_OWN` substring test as well. That is a heuristic
+    over CPython's wording, and a release that rephrases an MRO or lay-out
+    conflict would start classifying its own refusals as salix's -- which shows
+    up here as a refusal rather than as a combination quietly leaving the
+    sweep.
+    """
+
+    refusals = [
+        f"{named(bases)}: {outcome.message}"
+        for bases, outcome in OUTCOMES
+        if isinstance(outcome, Refused)
+    ]
+
+    assert refusals == []
 
 
 def test_the_fields_are_the_layout_bases_followed_by_the_new_one():
@@ -299,22 +322,44 @@ def test_a_value_that_compares_by_value_and_can_still_move_is_unhashable():
     hash: a key whose hash moves is not a key.
     """
 
+    violations = []
+
+    for bases, cls in ALL:
+        behaviour = observe(cls)
+
+        if behaviour.equality == "value" and not behaviour.frozen and cls.__hash__ is not None:
+            violations.append(named(bases))
+
+    assert violations == []
+
+
+def test_a_frozen_promise_is_kept_by_every_arrangement_that_inherits_one():
+    """What the class records against what it does, for the one option the
+    differential deliberately excludes.
+
+    `frozen` is not the first base's preference but a promise every fielded
+    base made separately, so the rule is the strongest of them: frozen if the
+    first base alone is, or if any base with fields is. Nothing else here
+    compares that to behaviour -- a write and a delete are only checked against
+    each other, and the unhashable rule fires only for value equality -- so a
+    regression in the forced rebind could leave a class recording the promise
+    and taking every write, with all of it green.
+    """
+
+    def promised(bases: tuple[type, ...]) -> bool:
+        return any(base.__struct_fields__ and observe(base).frozen for base in bases)
+
     violations = [
-        named(bases)
+        f"{named(bases)}: frozen={observe(cls).frozen} against a promise"
         for bases, cls in ALL
-        if observe(cls).equality == "value"
-        and not observe(cls).frozen
-        and cls.__hash__ is not None
+        if observe(cls).frozen != (observe(ALONE[bases[0]]).frozen or promised(bases))
     ]
 
     assert violations == []
 
 
-ORDERS_ALONE = {
-    shape: observe(alone).order
-    for shape in SHAPES
-    if is_a_class(alone := build((shape,)))
-}
+ORDERS_ALONE = {shape: observe(built).order for shape, built in ALONE.items()}
+EQUALITY_ALONE = {shape: observe(built).equality for shape, built in ALONE.items()}
 
 
 def contested(bases: tuple[type, ...], name: str) -> bool:
@@ -350,14 +395,50 @@ SOUND_EQ, CONTESTED_EQ = halves("__eq__")
 SOUND_ORDER, CONTESTED_ORDER = halves("__lt__")
 
 
+def answers_equal_to_everything(bases: tuple[type, ...]) -> bool:
+    """Whether the later base the lookup takes `__eq__` from is one that calls
+    two differing instances equal.
+
+    The hash disagreement needs that much: a later base binding `__eq__` is
+    what puts the record and the behaviour at odds, but a binder that compares
+    by *identity* still calls two differing instances unequal, so no pair of
+    equal-and-differently-hashed objects exists to find. Only a permissive
+    binder produces one.
+
+    Without the clause the bucket is 224 wide to hold 112 real violations, and
+    the other half sits in a test that is expected to fail, where a regression
+    would be invisible.
+    """
+
+    if "__eq__" in vars(bases[0]):
+        return False
+
+    binder = next((base for base in bases[1:] if "__eq__" in vars(base)), None)
+
+    return binder is not None and EQUALITY_ALONE.get(binder) == "everything"
+
+
+SOUND_HASH = tuple(
+    (bases, cls)
+    for bases, cls in ALL
+    if not (answers_equal_to_everything(bases) and cls.__hash__ is not None)
+)
+CONTESTED_HASH = tuple(
+    (bases, cls)
+    for bases, cls in ALL
+    if answers_equal_to_everything(bases) and cls.__hash__ is not None
+)
+
+
 @pytest.mark.parametrize(
     ("sound", "broken"),
     [
         (SOUND_REPR, CONTESTED_REPR),
         (SOUND_EQ, CONTESTED_EQ),
         (SOUND_ORDER, CONTESTED_ORDER),
+        (SOUND_HASH, CONTESTED_HASH),
     ],
-    ids=["__repr__", "__eq__", "__lt__"],
+    ids=["__repr__", "__eq__", "__lt__", "__hash__"],
 )
 def test_both_halves_of_the_split_are_reached(sound, broken):
     """An empty sound half would make the test over it vacuous. An empty broken
@@ -415,7 +496,34 @@ def test_equal_instances_hash_equal():
     that compare equal and hash differently cannot find each other in a dict.
     """
 
-    assert hash_disagreements(SOUND_EQ) == []
+    assert hash_disagreements(SOUND_HASH) == []
+
+
+@pytest.mark.parametrize(
+    ("broken", "violations"),
+    [
+        (CONTESTED_REPR, lambda rows: behaviour_differs_from_the_first_base_alone(rows, "repr")),
+        (CONTESTED_EQ, lambda rows: behaviour_differs_from_the_first_base_alone(rows, "equality")),
+        (CONTESTED_ORDER, lambda rows: behaviour_differs_from_the_first_base_alone(rows, "order")),
+        (CONTESTED_HASH, hash_disagreements),
+    ],
+    ids=["__repr__", "__eq__", "__lt__", "__hash__"],
+)
+def test_every_contested_combination_really_is_broken(broken, violations):
+    """The half of the split the strict xfails cannot police, and the reason
+    each bucket is narrowed until it is exact.
+
+    An xfail over a bucket where everything already fails emits one bit: it
+    flips only when the bucket becomes *entirely* clean. A partial fix, or a
+    new violation among combinations that were sound, leaves it just as failed
+    and just as green. Asserting the bucket is wholly broken is the other
+    bound, and between them the count cannot move without a test noticing.
+
+    Delete this with the four xfails below when #76 lands; they describe the
+    same defect from opposite sides.
+    """
+
+    assert len(violations(broken)) == len(broken)
 
 
 @pytest.mark.xfail(strict=True, reason="#76: the record and the MRO disagree")
@@ -435,7 +543,7 @@ def test_ordering_is_the_first_struct_bases_when_a_later_one_binds_it():
 
 @pytest.mark.xfail(strict=True, reason="#76: a later base's __eq__ against salix's hash")
 def test_equal_instances_hash_equal_when_a_later_base_answers_equality():
-    assert hash_disagreements(CONTESTED_EQ) == []
+    assert hash_disagreements(CONTESTED_HASH) == []
 
 
 @pytest.mark.xfail(strict=True, reason="#77: the frozen pin is armed from one base and directed by another")
@@ -465,11 +573,16 @@ def test_the_weakref_option_and_the_slot_agree():
     """CPython cannot take an inherited `__weakref__` away, so `weakref=False`
     over a base that has one is a request salix cannot honour -- and accepting
     it silently leaves the class recording one answer and giving another.
+
+    `Weak` alone is in here beside the arrangements because the single base is
+    the smallest form of it: `class C(Weak, weakref=False)` builds today and
+    the reference still works. A fix aimed only at the multi-base reading would
+    turn every other case here red and leave that one passing unexercised.
     """
 
     violations = []
 
-    for bases, cls in ALL:
+    for bases, cls in (*ALL, *(((shape,), built) for shape, built in ALONE.items())):
         without = build((cls,), field="fresh", weakref=False)
 
         if not is_a_class(without):
@@ -479,3 +592,16 @@ def test_the_weakref_option_and_the_slot_agree():
             violations.append(named(bases))
 
     assert violations == []
+
+
+def test_a_single_base_asking_to_drop_an_inherited_weakref_slot_is_the_same_bug():
+    """#78's smallest form, stated on its own so that it is covered whether or
+    not the sweep above still reaches it. The slot is inherited and cannot be
+    removed, so the request is one salix should refuse rather than accept and
+    drop; today it is accepted and dropped.
+    """
+
+    without = build((Weak,), field="fresh", weakref=False)
+
+    assert is_a_class(without)
+    assert observe(without).weakref is True


### PR DESCRIPTION
#71 took six review rounds and every one found a different shape of the same
mechanism. That is the multi-base tests sampling a space instead of covering
it, so each round I fixed the shape in front of me and the next found one I
had not thought of.

This sweeps the space. Eleven base shapes, all **1100** orderings of two and
three of them, **784** of which build, and invariants asserted over every one.

## What holds today

Asserted unconditionally over all 784, so any regression is a red test naming
the combination:

| invariant |
| --- |
| the fields are `__base__`'s followed by the new one |
| every field reads back what it was given |
| `__match_args__` is the fields |
| a write and a delete agree about whether the class is frozen |
| a value that compares by value and can still move is unhashable |

## What does not, and how it is stated

The rest is a **differential**, which is salix's own rule restated: options are
inherited from the first struct base, so a class with several must behave like
the same class built on that base alone.

The combinations #76 can reach are split off by asking `vars()` which bases
bind the dunder — a structural question about the classes themselves, not a
list of known-bad examples — and the tests over that half are `xfail(strict)`.
The fix turns them red.

**The split is exact.** Every contested combination violates, so nothing sound
is parked in a bucket that is expected to fail:

| | sound half | violations | contested half | violations |
| --- | --- | --- | --- | --- |
| `__repr__` | 620 | 0 | 164 | 164 |
| `__eq__` | 512 | 0 | 272 | 272 |
| `__lt__` | 771 | 0 | 13 | 13 |
| equal ⟹ equal hash | 512 | 0 | 272 | 112 |

<details>
<summary>Why <code>__lt__</code>'s split needs a second clause, and why that is not circular</summary>

Ordering is answered by the recorded option at comparison time — `compare.c`
reads `struct_options.order` off both types — rather than by a binding. So a
later base's `__lt__` only shadows an answer where there was one to shadow,
and the risk predicate needs `the first base alone orders` beside it.

That reads off `build((bases[0],))`, which is the *reference* side of the
differential, not the class under test. Without it the bucket is 164 wide to
cover 13 real violations, and the other 151 would sit in a test that is
expected to fail — where a regression in one of them changes nothing.

</details>

## #77 and #78

One strict xfail each, both measured:

- **#77** — `frozen=` accepted in one base order and refused in the other:
  **188** arrangements. Six unordered pairs at width 2, every one of them
  `MutableFields` against a fieldless base.
- **#78** — `weakref=False` silently ignored over an inherited slot: **251**.
  **This one also reproduces with a single base** (`class C(Weak, weakref=False)`
  builds, and `weakref.ref` still works), so it is wider than #78 as filed.
  CPython cannot take an inherited `__weakref__` away, which makes it a request
  salix should refuse rather than accept and drop.

## The sweep is not decorative

Three mutations of `src/meta.c`, each built and run:

| mutation | caught by | violations |
| --- | --- | --- |
| layout base back to the first struct base (#9's bug) | `test_the_fields_are_the_layout_bases_followed_by_the_new_one` | 357, first named `Fieldless + Fields: ('z',) after Fields('a', 'b')` |
| `bind_hash` drops the `options.eq && !options.frozen` arm | `test_a_value_that_compares_by_value_and_can_still_move_is_unhashable` | 48 |
| `apply_options` never rebinds `__repr__` | the split guard **and** an `XPASS(strict)` | — |

That third one is the interesting one. Removing the rebind means
`Unrepresented` no longer carries `__repr__` in its own dict, so the contested
bucket empties — and rather than going quietly green, both
`test_both_halves_of_the_split_are_reached[__repr__]` and the xfail fail. That
pair of guards exists for exactly this: a bucket that empties in silence is a
suite that stops testing without saying so. (The full suite also catches it
five other ways, in `test_options.py` and `test_multiple_bases.py` — the
differential is blind to a *uniform* break by construction, and those are what
cover it.)

<details>
<summary>Equality is observed three ways, not two</summary>

A body `__eq__` that answers `True` to everything is indistinguishable from the
structural one until it is shown two instances that **differ**. That is the
shape #71's round 6 found and the five rounds before it did not, and it is why
`observe` classifies equality as `everything` / `value` / `identity` rather
than as a boolean. Four of my own probes while building this file were wrong
for want of it, plus one that mutated the instance before comparing it.

</details>

874 tests before, 893 after. `camas check` 25/25 across 3.10–3.15 and 3.14t.

Closes #79.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins, who said
> after #71 merged that "test coverage needs to be better if we keep playing
> whack a mole on this". This is that made concrete, and it is the first item
> of the agreed next phase.
