### PR TITLE
feat: name the metadata _struct_fields_, keep msgspec's name as an alias

### DIFF
--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -4,6 +4,8 @@ from typing_extensions import dataclass_transform
 
 @dataclass_transform(frozen_default=True)
 class Struct:
+    _struct_fields_: Final[tuple[str, ...]]
+    _struct_defaults_: Final[tuple[Any, ...]]
     __struct_fields__: Final[tuple[str, ...]]
     __struct_defaults__: Final[tuple[Any, ...]]
     def __init_subclass__(

--- a/src/construct.c
+++ b/src/construct.c
@@ -89,7 +89,7 @@ PyObject * Struct_vectorcall(
  * What a class whose body writes __init__ allocates with. That class declined
  * the generated constructor, and fill_defaults went with it: a declared default
  * was never written, for the class and for every subclass, so
- * __struct_defaults__ advertised a value no instance would ever carry (#56).
+ * _struct_defaults_ advertised a value no instance would ever carry.
  * Writing them here means the __init__ runs over a struct that already holds
  * them and overwrites whatever it means to -- which is where a dataclass leaves
  * them too, on the class, readable.

--- a/src/fields.c
+++ b/src/fields.c
@@ -754,7 +754,7 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		 * declaration, so of course it is) and refused there, so the race costs
 		 * the work the first check exists to skip and not the invariant.
 		 *
-		 * `__struct_defaults__` still hands the stored object out, so filling it
+		 * `_struct_defaults_` still hands the stored object out, so filling it
 		 * through there defeats this. That route is out of contract and #51 is
 		 * where the whole type list is argued. */
 		if (reject_unsafe_default(field_name, value) != RESULT_OK) {

--- a/src/meta.c
+++ b/src/meta.c
@@ -131,17 +131,30 @@ PyTypeObject StructMeta_Type = {
 
 /* The mixin answers these for an instance; the metaclass answers the same
  * questions of the class, which is where msgspec puts them and so where a
- * reader looks first. */
+ * reader looks first. Both spellings, for the reason src/mixin.c gives: the
+ * sunder is salix's, and the dunder is msgspec's name honoured rather than a
+ * dunder of salix's own invention. Unlike the mixin's, these getters need no
+ * name of their own -- there is no non-struct for them to refuse. */
 static PyGetSetDef StructMeta_getset[] = {
 	{
-		.name = "__struct_fields__",
+		.name = "_struct_fields_",
 		.get = StructMeta_get_field_names,
 		.doc = "tuple of field names",
 	},
 	{
-		.name = "__struct_defaults__",
+		.name = "_struct_defaults_",
 		.get = StructMeta_get_defaults,
 		.doc = "tuple of trailing defaults",
+	},
+	{
+		.name = "__struct_fields__",
+		.get = StructMeta_get_field_names,
+		.doc = "tuple of field names, under msgspec's name for it",
+	},
+	{
+		.name = "__struct_defaults__",
+		.get = StructMeta_get_defaults,
+		.doc = "tuple of trailing defaults, under msgspec's name for it",
 	},
 	{.name = NULL},
 };

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -10,6 +10,8 @@
 static int Struct_set_attribute(PyObject * self, PyObject * name, PyObject * value);
 static PyObject * Struct_get_field_names(PyObject * self, void * closure);
 static PyObject * Struct_get_defaults(PyObject * self, void * closure);
+static PyObject * Struct_get_fields_as_msgspec(PyObject * self, void * closure);
+static PyObject * Struct_get_defaults_as_msgspec(PyObject * self, void * closure);
 static PyObject * metadata_of(PyObject * self, enum struct_metadata which, char const * name);
 static PyGetSetDef Struct_getset[];
 
@@ -25,16 +27,36 @@ PyTypeObject StructMixin_Type = {
 	.tp_getset = Struct_getset,
 };
 
+/*
+ * A sunder for salix's own metadata, and the dunder beside it for msgspec's.
+ *
+ * The language reference reserves `__name__` for the interpreter and its
+ * implementation, and PEP 8 says never to invent one -- only to use a
+ * documented one. So the pair salix defines is `_struct_fields_`, and
+ * `__struct_fields__` is here because msgspec spells it that way and code
+ * written against msgspec reads it. Using another project's documented name is
+ * the half PEP 8 permits; minting one is not.
+ */
 static PyGetSetDef Struct_getset[] = {
 	{
-		.name = "__struct_fields__",
+		.name = "_struct_fields_",
 		.get = Struct_get_field_names,
 		.doc = "tuple of field names",
 	},
 	{
-		.name = "__struct_defaults__",
+		.name = "_struct_defaults_",
 		.get = Struct_get_defaults,
 		.doc = "tuple of trailing defaults",
+	},
+	{
+		.name = "__struct_fields__",
+		.get = Struct_get_fields_as_msgspec,
+		.doc = "tuple of field names, under msgspec's name for it",
+	},
+	{
+		.name = "__struct_defaults__",
+		.get = Struct_get_defaults_as_msgspec,
+		.doc = "tuple of trailing defaults, under msgspec's name for it",
 	},
 	{.name = NULL},
 };
@@ -117,11 +139,22 @@ static int Struct_set_attribute(
 	return RESULT_ERROR;
 }
 
-/* Two entry points because the getset table needs two; the answer is one. */
+/* Four entry points because the getset table names four attributes and hands
+ * the getter no way to tell which one was asked for; there are two answers. The
+ * name is spelled here rather than passed through `closure` so that a lookup
+ * that fails is refused under the name the caller used. */
 static PyObject * Struct_get_field_names(PyObject * const self, void * const closure) {
-	return metadata_of(self, STRUCT_FIELD_NAMES, "__struct_fields__");
+	return metadata_of(self, STRUCT_FIELD_NAMES, "_struct_fields_");
 }
 
 static PyObject * Struct_get_defaults(PyObject * const self, void * const closure) {
+	return metadata_of(self, STRUCT_DEFAULTS, "_struct_defaults_");
+}
+
+static PyObject * Struct_get_fields_as_msgspec(PyObject * const self, void * const closure) {
+	return metadata_of(self, STRUCT_FIELD_NAMES, "__struct_fields__");
+}
+
+static PyObject * Struct_get_defaults_as_msgspec(PyObject * const self, void * const closure) {
 	return metadata_of(self, STRUCT_DEFAULTS, "__struct_defaults__");
 }

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -93,8 +93,10 @@ static PyGetSetDef Struct_getset[] = {
  * discovered, because it is a consequence of the fallback policy and not a
  * separate decision.
  *
- * The two getsets are the exception either way: they report struct metadata and
- * nothing else, so there is nothing to fall back to and they raise. An
+ * The metadata getsets are the exception either way -- all four of them, the
+ * two salix defines and the two it answers to for msgspec's sake: they report
+ * struct metadata and nothing else, so there is nothing to fall back to and
+ * they raise. An
  * AttributeError rather than a TypeError, because "this object does not have
  * that attribute" is what happened and it is what `hasattr` and `getattr`'s
  * default are written to catch.

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -35,7 +35,7 @@ def test_a_hand_written_annotate_is_called_directly():
 
     Manual = type(Struct)("Manual", (Struct,), {"__annotate__": annotate})
 
-    assert Manual.__struct_fields__ == ("x", "y")
+    assert Manual._struct_fields_ == ("x", "y")
     assert Manual(1, 2).x == 1
 
 
@@ -100,7 +100,7 @@ class TestANonFunctionAnnotate:
 
         Built = type(Struct)("Built", (Struct,), {"__annotate__": Annotate()})
 
-        assert Built.__struct_fields__ == ("x", "y")
+        assert Built._struct_fields_ == ("x", "y")
         assert Built(1, 2).y == 2
 
     @pytest.mark.skipif(
@@ -128,7 +128,7 @@ class TestANonFunctionAnnotate:
 
         Built = type(Struct)("Built", (Struct,), {"__annotate__": fake_globals_aware})
 
-        assert Built.__struct_fields__ == ("x", "y")
+        assert Built._struct_fields_ == ("x", "y")
         assert Built(1, 2).y == 2
 
     @pytest.mark.skipif(
@@ -155,7 +155,7 @@ class TestANonFunctionAnnotate:
 
         Built = type(Struct)("Built", (Struct,), {"__annotate__": inconsistent})
 
-        assert Built.__struct_fields__ == ("answered_3",)
+        assert Built._struct_fields_ == ("answered_3",)
 
     @pytest.mark.skipif(
         sys.version_info < (3, 14),
@@ -255,7 +255,7 @@ class TestANonFunctionAnnotate:
 
         Built = type(Struct)("Built", (Struct,), {"__annotate__": functools.partial(annotate)})
 
-        assert Built.__struct_fields__ == ("z",)
+        assert Built._struct_fields_ == ("z",)
         assert Built(1).z == 1
 
 
@@ -269,14 +269,14 @@ class TestForwardReferences:
             value: int
             nxt: Node = None  # noqa: F821
 
-        assert Node.__struct_fields__ == ("value", "nxt")
+        assert Node._struct_fields_ == ("value", "nxt")
         assert Node(1, Node(2)).nxt.value == 2
 
     def test_an_annotation_that_never_resolves_is_a_field_anyway(self):
         class Bare(Struct):
             x: NeverDefined  # noqa: F821
 
-        assert Bare.__struct_fields__ == ("x",)
+        assert Bare._struct_fields_ == ("x",)
         assert Bare(1).x == 1
 
     def test_two_classes_may_refer_to_each_other(self):
@@ -294,7 +294,7 @@ class TestForwardReferences:
             second: Unresolvable  # noqa: F821
             third: str
 
-        assert Mixed.__struct_fields__ == ("first", "second", "third")
+        assert Mixed._struct_fields_ == ("first", "second", "third")
 
     def test_a_subclass_may_forward_reference_too(self):
         class Base(Struct):
@@ -303,7 +303,7 @@ class TestForwardReferences:
         class Child(Base):
             y: Child = None  # noqa: F821
 
-        assert Child.__struct_fields__ == ("x", "y")
+        assert Child._struct_fields_ == ("x", "y")
 
     def test_the_annotations_still_resolve_once_the_class_exists(self):
         """Reading them early does not leave a ForwardRef behind for everyone else."""
@@ -352,7 +352,7 @@ class TestForwardReferences:
         class Deferred(Struct):
             x: helper()
 
-        assert Deferred.__struct_fields__ == ("x",)
+        assert Deferred._struct_fields_ == ("x",)
 
     def test_a_forged_name_attribute_reads_as_a_forward_reference(self):
         """The discriminator asks whether `.name` is set, and the keyword form
@@ -367,7 +367,7 @@ class TestForwardReferences:
         class Built(Struct):
             v: forged()
 
-        assert Built.__struct_fields__ == ("v",)
+        assert Built._struct_fields_ == ("v",)
 
     def test_the_exemption_is_order_dependent(self):
         """The rescue is all-or-nothing: it re-evaluates every annotation and
@@ -383,7 +383,7 @@ class TestForwardReferences:
             x: Missing  # noqa: F821
             y: boom()
 
-        assert Rescued.__struct_fields__ == ("x", "y")
+        assert Rescued._struct_fields_ == ("x", "y")
 
         with pytest.raises(NameError, match="boom"):
 
@@ -413,7 +413,7 @@ class TestForwardReferences:
             a: counted()
             b: Missing  # noqa: F821
 
-        assert Mixed.__struct_fields__ == ("a", "b")
+        assert Mixed._struct_fields_ == ("a", "b")
         assert len(evaluations) > 1
 
     def test_a_raised_NameError_is_arbitrary_failure_too(self):
@@ -448,7 +448,7 @@ class TestForwardReferences:
         class Deferred(Struct):
             x: Unresolvable + 1  # noqa: F821
 
-        assert Deferred.__struct_fields__ == ("x",)
+        assert Deferred._struct_fields_ == ("x",)
         assert Deferred(1).x == 1
 
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -211,13 +211,13 @@ class TestMutableDefaults:
 
         shared.append([2])
 
-        assert Holder.__struct_defaults__[0] is not shared
+        assert Holder._struct_defaults_[0] is not shared
         assert Holder().xs == []
 
     def test_construction_and_inheritance_agree_after_that_mutation(self):
         """One copies and one refuses, so they have to be looking at the same
         thing -- the stored default, which the module-level alias no longer
-        reaches. `__struct_defaults__` still hands it out and #51 is where that
+        reaches. `_struct_defaults_` still hands it out and #51 is where that
         route is argued; what this pins is that the two agree.
         """
 
@@ -308,12 +308,12 @@ class TestMutableDefaults:
             v: object = value
 
         assert Holder().v is Holder().v
-        assert Holder.__struct_defaults__[0] is value
+        assert Holder._struct_defaults_[0] is value
 
     def test_a_body_init_does_not_exempt_the_declared_default(self):
         """Its constructor never reads the default, so nothing is shared -- but
         the declaration is still a promise the class makes through
-        __struct_defaults__, and dataclasses refuses it under init=False for the
+        _struct_defaults_, and dataclasses refuses it under init=False for the
         same reason. The message names both hooks because __post_init__ is not
         one of them here: a body __init__ displaces the generated constructor,
         and run_post_init goes with it.

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -47,7 +47,7 @@ def test_the_signature_is_the_body_s():
 
 
 def test_the_struct_machinery_is_otherwise_untouched():
-    assert Handwritten.__struct_fields__ == ("x", "y")
+    assert Handwritten._struct_fields_ == ("x", "y")
     assert Handwritten.__match_args__ == ("x", "y")
     assert repr(Handwritten(7)) == "Handwritten(x=7, y=7)"
     assert Handwritten(7) == Generated(7, 7)
@@ -101,7 +101,7 @@ def test_defaults_are_written_before_a_body_init_runs():
     """What the class declared, the instance carries.
 
     The declaration used to be inert: the vectorcall filled defaults and this
-    class declined it, so `__struct_defaults__` advertised a value no instance
+    class declined it, so `_struct_defaults_` advertised a value no instance
     would ever have. tp_new writes them now, which is where a dataclass leaves
     them readable too.
     """

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -49,7 +49,7 @@ def test_a_value_may_be_a_default(value):
     class Local(Struct):
         field: object = value
 
-    (stored,) = Local.__struct_defaults__
+    (stored,) = Local._struct_defaults_
 
     assert Local().field == value
     assert stored == value

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -123,7 +123,7 @@ def test_a_shared_struct_is_safe_to_read_from_every_thread():
     def work():
         for _ in range(ITERATIONS):
             assert shared.x == 1
-            assert shared.__struct_fields__ == ("x", "y")
+            assert shared._struct_fields_ == ("x", "y")
 
     run_on_every_thread(work)
 

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -15,7 +15,7 @@ def test_a_subclass_appends_its_own_fields():
         z: int
 
     assert Extended.__match_args__ == ("x", "y", "z")
-    assert Extended(1, 2, 3).__struct_fields__ == ("x", "y", "z")
+    assert Extended(1, 2, 3)._struct_fields_ == ("x", "y", "z")
 
 
 def test_an_inherited_field_keeps_its_position():
@@ -33,7 +33,7 @@ def test_inherited_defaults_carry_over():
     class Extended(WithDefault):
         c: int = 8
 
-    assert Extended(1).__struct_defaults__ == (7, 8)
+    assert Extended(1)._struct_defaults_ == (7, 8)
     assert (Extended(1).b, Extended(1).c) == (7, 8)
 
 
@@ -43,7 +43,7 @@ def test_a_subclass_may_give_an_inherited_field_a_default():
 
     assert Defaulted(1).y == 5
     assert Defaulted.__match_args__ == ("x", "y")
-    assert Defaulted(1).__struct_fields__ == ("x", "y")
+    assert Defaulted(1)._struct_fields_ == ("x", "y")
 
 
 def test_a_redefaulted_inherited_field_is_not_shadowed_by_its_class_variable():
@@ -96,7 +96,7 @@ def test_a_class_with_no_annotations_is_transparent():
     class Bottom(Middle):
         z: int
 
-    assert Bottom(1, 2, 3).__struct_fields__ == ("x", "y", "z")
+    assert Bottom(1, 2, 3)._struct_fields_ == ("x", "y", "z")
 
 
 def test_a_deep_chain_accumulates_in_order():
@@ -105,12 +105,12 @@ def test_a_deep_chain_accumulates_in_order():
     for name in ("p", "q", "r"):
         current = type(current)(f"Level_{name}", (current,), {"__annotations__": {name: int}})
 
-    assert current(1, 2, 3, 4, 5).__struct_fields__ == ("x", "y", "p", "q", "r")
+    assert current(1, 2, 3, 4, 5)._struct_fields_ == ("x", "y", "p", "q", "r")
 
 
 def test_the_base_itself_has_no_fields():
-    assert Struct().__struct_fields__ == ()
-    assert Struct().__struct_defaults__ == ()
+    assert Struct()._struct_fields_ == ()
+    assert Struct()._struct_defaults_ == ()
 
 
 def test_two_field_bearing_bases_are_rejected():
@@ -132,5 +132,5 @@ def test_a_fieldless_second_base_is_allowed():
     class Combined(Base, Marker):
         z: int
 
-    assert Combined(1, 2, 3).__struct_fields__ == ("x", "y", "z")
+    assert Combined(1, 2, 3)._struct_fields_ == ("x", "y", "z")
     assert isinstance(Combined(1, 2, 3), Marker)

--- a/tests/test_metadata_names.py
+++ b/tests/test_metadata_names.py
@@ -20,7 +20,6 @@ from salix import Struct
 
 SALIX = ("_struct_fields_", "_struct_defaults_")
 MSGSPEC = ("__struct_fields__", "__struct_defaults__")
-PAIRS = tuple(zip(SALIX, MSGSPEC, strict=True))
 FIELD_NAMES = (SALIX[0], MSGSPEC[0])
 EXPECTED = (
     ("_struct_fields_", ("x", "y")),
@@ -108,11 +107,29 @@ def test_a_body_that_takes_one_of_these_names_is_read_two_ways(name):
     assert getattr(shadowed(5, 6), name) == 5
 
 
+@pytest.mark.parametrize("name", SALIX + MSGSPEC)
+def test_a_plain_class_variable_of_that_name_is_read_two_ways_too(name):
+    """The other half of the same shape, and it arrives by a different route:
+    `drop_class_variables` strips only names the body annotated, so an
+    unannotated assignment stays in the class dict and the instance finds it
+    there.
+    """
+
+    shadowed = type(Struct)(
+        "Shadowed", (Struct,), {"__annotations__": {"x": int}, name: 999}
+    )
+    metadata = ("x",) if name in FIELD_NAMES else ()
+
+    assert vars(shadowed)[name] == 999
+    assert getattr(shadowed, name) == metadata
+    assert getattr(shadowed(1), name) == 999
+
+
 def test_a_subclass_reports_its_own_fields_under_both_names():
     class Extended(Point):
         z: int = 3
 
     assert Extended._struct_fields_ == ("x", "y", "z")
-    assert Extended.__struct_fields__ == Extended._struct_fields_
+    assert Extended.__struct_fields__ == ("x", "y", "z")
     assert Extended._struct_defaults_ == (2, 3)
-    assert Extended.__struct_defaults__ == Extended._struct_defaults_
+    assert Extended.__struct_defaults__ == (2, 3)

--- a/tests/test_metadata_names.py
+++ b/tests/test_metadata_names.py
@@ -21,6 +21,13 @@ from salix import Struct
 SALIX = ("_struct_fields_", "_struct_defaults_")
 MSGSPEC = ("__struct_fields__", "__struct_defaults__")
 PAIRS = tuple(zip(SALIX, MSGSPEC, strict=True))
+FIELD_NAMES = (SALIX[0], MSGSPEC[0])
+EXPECTED = (
+    ("_struct_fields_", ("x", "y")),
+    ("__struct_fields__", ("x", "y")),
+    ("_struct_defaults_", (2,)),
+    ("__struct_defaults__", (2,)),
+)
 MIXIN = Struct.__mro__[1]
 META = type(Struct)
 
@@ -30,19 +37,25 @@ class Point(Struct):
     y: int = 2
 
 
-@pytest.mark.parametrize(("ours", "theirs"), PAIRS)
-def test_the_alias_answers_what_the_sunder_does_on_the_class(ours, theirs):
-    assert getattr(Point, theirs) == getattr(Point, ours)
+@pytest.mark.parametrize(("name", "expected"), EXPECTED)
+def test_every_spelling_reports_the_value_itself_on_the_class(name, expected):
+    """The value rather than the other spelling. On the class both spellings
+    are wired to the same C getter, so comparing them to each other holds by
+    construction and would survive a fields getter that returned the defaults
+    for both.
+    """
+
+    assert getattr(Point, name) == expected
 
 
-@pytest.mark.parametrize(("ours", "theirs"), PAIRS)
-def test_the_alias_answers_what_the_sunder_does_on_an_instance(ours, theirs):
-    assert getattr(Point(1), theirs) == getattr(Point(1), ours)
+@pytest.mark.parametrize(("name", "expected"), EXPECTED)
+def test_every_spelling_reports_the_value_itself_on_an_instance(name, expected):
+    """Worth stating separately: the mixin wires the four names to four
+    different functions, so a crossed `which` enum shows up here and nowhere
+    else.
+    """
 
-
-def test_the_sunder_reports_the_fields_and_the_defaults():
-    assert Point._struct_fields_ == ("x", "y")
-    assert Point._struct_defaults_ == (2,)
+    assert getattr(Point(1), name) == expected
 
 
 @pytest.mark.parametrize("name", SALIX + MSGSPEC)
@@ -57,16 +70,42 @@ def test_neither_spelling_may_be_assigned(name):
 
 
 @pytest.mark.parametrize("name", SALIX + MSGSPEC)
-def test_both_spellings_are_descriptors_rather_than_values_in_each_class(name):
+def test_salix_writes_no_spelling_into_the_classes_it_builds(name):
     """A getset on the metaclass answers for the class and one on the mixin
-    answers for the instance, so no class dict carries either -- which is what
-    stops a subclass shadowing one spelling and leaving the other to report
-    something the first no longer agrees with.
+    answers for the instance; salix puts neither into the class it builds.
+
+    An earlier version of this said that arrangement stops a class shadowing
+    one spelling. It does not, and the test below is what that actually does.
     """
 
     assert name not in vars(Point)
     assert name in vars(META)
     assert name in vars(MIXIN)
+
+
+@pytest.mark.parametrize("name", SALIX + MSGSPEC)
+def test_a_body_that_takes_one_of_these_names_is_read_two_ways(name):
+    """Reserving the names did not make them unusable, and a class that uses
+    one anyway answers differently depending on where it is read.
+
+    The metaclass getset is a data descriptor, so it wins on the class. On an
+    instance the class's own binding is what the lookup reaches first -- the
+    slot descriptor for a field, or the value for a plain assignment -- so the
+    metadata is what the class says and the body is what the instance says.
+
+    This is not new with the sunder: `__struct_fields__` as a field name has
+    always done it. What is new is that two more names now behave this way,
+    which is the cost of reserving them. Filed as #82; pinned here so that a
+    decision about it is a decision rather than a discovery.
+    """
+
+    shadowed = type(Struct)(
+        "Shadowed", (Struct,), {"__annotations__": {name: int, "x": int}}
+    )
+    metadata = (name, "x") if name in FIELD_NAMES else ()
+
+    assert getattr(shadowed, name) == metadata
+    assert getattr(shadowed(5, 6), name) == 5
 
 
 def test_a_subclass_reports_its_own_fields_under_both_names():

--- a/tests/test_metadata_names.py
+++ b/tests/test_metadata_names.py
@@ -1,0 +1,79 @@
+"""What the field metadata is called, and why it is called two things.
+
+`_struct_fields_` and `_struct_defaults_` are salix's. The language reference
+reserves `__name__` for "the interpreter and its implementation, including the
+standard library", and says any other such use is "subject to breakage without
+warning"; PEP 8 puts it as never invent one, only use a documented one. A
+library that mints a dunder for itself is taking a name it was not offered.
+
+`__struct_fields__` and `__struct_defaults__` are msgspec's, and they are here
+because code written against msgspec reads them. That is the half PEP 8
+permits: using another project's documented name is not inventing one.
+
+So the two are not equal in standing, and the tests below say which is which
+rather than treating them as interchangeable spellings.
+"""
+
+import pytest
+
+from salix import Struct
+
+SALIX = ("_struct_fields_", "_struct_defaults_")
+MSGSPEC = ("__struct_fields__", "__struct_defaults__")
+PAIRS = tuple(zip(SALIX, MSGSPEC, strict=True))
+MIXIN = Struct.__mro__[1]
+META = type(Struct)
+
+
+class Point(Struct):
+    x: int
+    y: int = 2
+
+
+@pytest.mark.parametrize(("ours", "theirs"), PAIRS)
+def test_the_alias_answers_what_the_sunder_does_on_the_class(ours, theirs):
+    assert getattr(Point, theirs) == getattr(Point, ours)
+
+
+@pytest.mark.parametrize(("ours", "theirs"), PAIRS)
+def test_the_alias_answers_what_the_sunder_does_on_an_instance(ours, theirs):
+    assert getattr(Point(1), theirs) == getattr(Point(1), ours)
+
+
+def test_the_sunder_reports_the_fields_and_the_defaults():
+    assert Point._struct_fields_ == ("x", "y")
+    assert Point._struct_defaults_ == (2,)
+
+
+@pytest.mark.parametrize("name", SALIX + MSGSPEC)
+def test_neither_spelling_may_be_assigned(name):
+    """Both are getsets with no setter, on the class and on the instance."""
+
+    with pytest.raises(AttributeError):
+        setattr(Point, name, ("z",))
+
+    with pytest.raises(TypeError, match="does not support attribute assignment"):
+        setattr(Point(1), name, ("z",))
+
+
+@pytest.mark.parametrize("name", SALIX + MSGSPEC)
+def test_both_spellings_are_descriptors_rather_than_values_in_each_class(name):
+    """A getset on the metaclass answers for the class and one on the mixin
+    answers for the instance, so no class dict carries either -- which is what
+    stops a subclass shadowing one spelling and leaving the other to report
+    something the first no longer agrees with.
+    """
+
+    assert name not in vars(Point)
+    assert name in vars(META)
+    assert name in vars(MIXIN)
+
+
+def test_a_subclass_reports_its_own_fields_under_both_names():
+    class Extended(Point):
+        z: int = 3
+
+    assert Extended._struct_fields_ == ("x", "y", "z")
+    assert Extended.__struct_fields__ == Extended._struct_fields_
+    assert Extended._struct_defaults_ == (2, 3)
+    assert Extended.__struct_defaults__ == Extended._struct_defaults_

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -562,7 +562,7 @@ class TestNameCollisions:
         """
 
         Collide = self.colliding_method()
-        (default,) = Collide.__struct_defaults__
+        (default,) = Collide._struct_defaults_
 
         assert callable(default)
         assert Collide().x is default
@@ -575,7 +575,7 @@ class TestNameCollisions:
             def y(self) -> str:
                 return "property"
 
-        (default,) = CollideProp.__struct_defaults__
+        (default,) = CollideProp._struct_defaults_
 
         assert isinstance(default, property)
         assert CollideProp().y is default

--- a/tests/test_multiple_bases.py
+++ b/tests/test_multiple_bases.py
@@ -41,7 +41,7 @@ def test_a_fieldless_base_in_front_does_not_hide_the_fields_behind_it():
 
     instance = Both(1, 2, 3)
 
-    assert Both.__struct_fields__ == ("a", "b", "c")
+    assert Both._struct_fields_ == ("a", "b", "c")
     assert (instance.a, instance.b, instance.c) == (1, 2, 3)
     assert repr(instance) == "Both(a=1, b=2, c=3)"
 
@@ -58,7 +58,7 @@ def test_a_weakref_base_in_front_does_not_hide_them_either():
 
     instance = Both(1, 2)
 
-    assert Both.__struct_fields__ == ("a", "c")
+    assert Both._struct_fields_ == ("a", "c")
     assert (instance.a, instance.c) == (1, 2)
 
 
@@ -83,7 +83,7 @@ def test_the_layout_base_is_the_one_cpython_chose(bases):
 
     child = type(Struct)("Child", bases, {"__annotations__": {"c": int}})
 
-    assert child.__struct_fields__ == (*child.__base__.__struct_fields__, "c")
+    assert child._struct_fields_ == (*child.__base__._struct_fields_, "c")
 
 
 def test_the_order_of_the_bases_does_not_change_the_fields():
@@ -93,7 +93,7 @@ def test_the_order_of_the_bases_does_not_change_the_fields():
     class Backwards(WithFields, Fieldless):
         c: int
 
-    assert Forwards.__struct_fields__ == Backwards.__struct_fields__
+    assert Forwards._struct_fields_ == Backwards._struct_fields_
 
 
 def test_the_frozen_keyword_is_answered_by_any_base_with_fields():

--- a/tests/test_post_init.py
+++ b/tests/test_post_init.py
@@ -34,7 +34,7 @@ def test_a_struct_without_one_is_unaffected():
     class Plain(Struct):
         x: int
 
-    assert Plain.__struct_fields__ == ("x",)
+    assert Plain._struct_fields_ == ("x",)
     assert Plain(1).x == 1
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -80,7 +80,7 @@ def test_field_names_survive_a_round_trip(names):
     values = tuple(range(len(names)))
     instance = struct_class(*values)
 
-    assert instance.__struct_fields__ == tuple(names)
+    assert instance._struct_fields_ == tuple(names)
     assert instance.__match_args__ == tuple(names)
     assert tuple(getattr(instance, name) for name in names) == values
 

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -79,7 +79,7 @@ def test_a_copied_default_hands_out_no_reference_to_itself():
     class Holder(Struct):
         xs: list = []  # noqa: RUF012 -- the copy is what is being counted
 
-    (stored,) = Holder.__struct_defaults__
+    (stored,) = Holder._struct_defaults_
     before = sys.getrefcount(stored)
     instances = [Holder() for _ in range(10)]
 
@@ -98,7 +98,7 @@ def test_an_uncopied_default_is_shared_by_every_instance():
     name says which of the two it pins, now that both exist.
     """
 
-    default = Defaulted.__struct_defaults__ if hasattr(Defaulted, "__struct_defaults__") else None
+    default = Defaulted._struct_defaults_ if hasattr(Defaulted, "_struct_defaults_") else None
     sentinel = Defaulted(None).optional
     before = sys.getrefcount(sentinel)
     instances = [Defaulted(None) for _ in range(10)]
@@ -122,7 +122,7 @@ def test_a_body_init_shares_an_uncopied_default_the_same_way():
         def __init__(self) -> None:
             pass
 
-    (sentinel,) = Declining.__struct_defaults__
+    (sentinel,) = Declining._struct_defaults_
     before = sys.getrefcount(sentinel)
     instances = [Declining() for _ in range(10)]
 
@@ -140,7 +140,7 @@ def test_a_body_init_copies_a_mutable_default_without_retaining_it():
         def __init__(self) -> None:
             pass
 
-    (stored,) = Declining.__struct_defaults__
+    (stored,) = Declining._struct_defaults_
     before = sys.getrefcount(stored)
     instances = [Declining() for _ in range(10)]
 
@@ -160,7 +160,7 @@ def test_a_body_init_that_raises_releases_the_defaults_tp_new_wrote():
         def __init__(self) -> None:
             raise ValueError
 
-    (sentinel,) = Failing.__struct_defaults__
+    (sentinel,) = Failing._struct_defaults_
     before = sys.getrefcount(sentinel)
 
     for _ in range(10):
@@ -177,7 +177,7 @@ def test_a_body_init_that_raises_releases_the_defaults_tp_new_wrote():
         def __init__(self) -> None:
             pass
 
-    assert Writing().optional is Writing.__struct_defaults__[0]
+    assert Writing().optional is Writing._struct_defaults_[0]
 
 
 def test_reading_a_field_does_not_accumulate():
@@ -367,7 +367,7 @@ def test_a_delegating_metatype_installs_the_field_table_once():
     before = sys.getrefcount(post_init)
     built = type(Struct)("Built", (Base,), namespace)
 
-    assert built.__struct_fields__ == ("x", "y")
+    assert built._struct_fields_ == ("x", "y")
     assert built(1, 2).y == 2
 
     # `before` already counts the namespace dict's reference. The two are the

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -98,14 +98,13 @@ def test_an_uncopied_default_is_shared_by_every_instance():
     name says which of the two it pins, now that both exist.
     """
 
-    default = Defaulted._struct_defaults_
     sentinel = Defaulted(None).optional
     before = sys.getrefcount(sentinel)
     instances = [Defaulted(None) for _ in range(10)]
 
     assert sys.getrefcount(sentinel) == before + 10
 
-    del instances, default
+    del instances
 
     assert sys.getrefcount(sentinel) == before
 

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -98,7 +98,7 @@ def test_an_uncopied_default_is_shared_by_every_instance():
     name says which of the two it pins, now that both exist.
     """
 
-    default = Defaulted._struct_defaults_ if hasattr(Defaulted, "_struct_defaults_") else None
+    default = Defaulted._struct_defaults_
     sentinel = Defaulted(None).optional
     before = sys.getrefcount(sentinel)
     instances = [Defaulted(None) for _ in range(10)]

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -56,7 +56,7 @@ def test_an_ordinary_annotation_of_the_same_shape_is_untouched():
         a: Final[int] = 1
         b: str | None = None
 
-    assert Ordinary.__struct_fields__ == ("a", "b")
+    assert Ordinary._struct_fields_ == ("a", "b")
 
 
 def test_a_field_named_after_the_form_is_still_a_field():
@@ -66,7 +66,7 @@ def test_a_field_named_after_the_form_is_still_a_field():
         ClassVar: int = 1
         InitVar: int = 2
 
-    assert Named.__struct_fields__ == ("ClassVar", "InitVar")
+    assert Named._struct_fields_ == ("ClassVar", "InitVar")
     assert Named().ClassVar == 1
 
 
@@ -188,7 +188,7 @@ def test_a_name_that_merely_contains_the_form_is_a_field(text):
 
     Ordinary = type(Struct)("Ordinary", (Struct,), {"__annotations__": {"v": text}})
 
-    assert Ordinary.__struct_fields__ == ("v",)
+    assert Ordinary._struct_fields_ == ("v",)
 
 
 def test_re_annotating_an_inherited_field_stays_a_no_op():
@@ -202,7 +202,7 @@ def test_re_annotating_an_inherited_field_stays_a_no_op():
     class Sub(Base):
         x: ClassVar[int]
 
-    assert Sub.__struct_fields__ == ("x",)
+    assert Sub._struct_fields_ == ("x",)
     assert Sub(1).x == 1
 
 
@@ -214,7 +214,7 @@ def test_a_renamed_import_is_not_resolved_in_the_source_text_form():
 
     Escaped = type(Struct)("Escaped", (Struct,), {"__annotations__": {"v": "CV[int]"}})
 
-    assert Escaped.__struct_fields__ == ("v",)
+    assert Escaped._struct_fields_ == ("v",)
 
 
 def test_a_plain_annotated_is_still_a_field():
@@ -227,7 +227,7 @@ def test_a_plain_annotated_is_still_a_field():
         v: Annotated[int, "meta"]
         w: Annotated[list, "meta", "more"]
 
-    assert Tagged.__struct_fields__ == ("v", "w")
+    assert Tagged._struct_fields_ == ("v", "w")
     assert Tagged(1, []).v == 1
 
 
@@ -274,7 +274,7 @@ def test_a_real_future_annotations_module_still_builds_ordinary_fields():
     exec(compile(source, "<future_ordinary>", "exec"), namespace)
     Frame = namespace["Frame"]
 
-    assert Frame.__struct_fields__ == ("length", "tag")  # type: ignore[attr-defined]
+    assert Frame._struct_fields_ == ("length", "tag")  # type: ignore[attr-defined]
     assert Frame(1).tag == "x"  # type: ignore[operator]
 
 
@@ -329,7 +329,7 @@ def test_walking_the_arguments_does_not_widen_what_counts_as_a_form(annotation):
 
     Ordinary = type(Struct)("Ordinary", (Struct,), {"__annotations__": {"v": annotation}})
 
-    assert Ordinary.__struct_fields__ == ("v",)
+    assert Ordinary._struct_fields_ == ("v",)
 
 
 @pytest.mark.skipif(
@@ -352,7 +352,7 @@ def test_the_form_as_annotated_metadata_is_still_a_field_on_the_object_path():
         "Metadata", (Struct,), {"__annotations__": {"v": Annotated[int, ClassVar]}}
     )
 
-    assert Metadata.__struct_fields__ == ("v",)
+    assert Metadata._struct_fields_ == ("v",)
 
 
 @pytest.mark.parametrize(
@@ -415,7 +415,7 @@ def test_a_failing_origin_probe_fails_the_class():
 
     Ordinary = type(Struct)("Ordinary", (Struct,), {"__annotations__": {"v": Quiet()}})
 
-    assert Ordinary.__struct_fields__ == ("v",)
+    assert Ordinary._struct_fields_ == ("v",)
 
 
 def test_an_annotation_that_rewrites_the_annotations_does_not_take_the_walk_with_it():
@@ -445,7 +445,7 @@ def test_an_annotation_that_rewrites_the_annotations_does_not_take_the_walk_with
 
     Built = type(Struct)("Rewritten", (Struct,), {"__annotations__": annotations})
 
-    assert Built.__struct_fields__ == ("first", "last")
+    assert Built._struct_fields_ == ("first", "last")
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 `type` is a syntax error before 3.12")
@@ -488,7 +488,7 @@ def test_a_pep_695_alias_to_something_else_is_still_a_field():
         "Ordinary", (Struct,), {"__annotations__": {"v": namespace["Aliased"]}}
     )
 
-    assert Ordinary.__struct_fields__ == ("v",)
+    assert Ordinary._struct_fields_ == ("v",)
 
 
 def test_a_str_injected_during_the_walk_is_matched_rather_than_crashing():
@@ -542,5 +542,5 @@ def test_the_object_path_is_skipped_when_neither_module_is_loaded(monkeypatch):
 
     Ordinary = type(Struct)("Ordinary", (Struct,), {"__annotations__": {"v": Watched()}})
 
-    assert Ordinary.__struct_fields__ == ("v",)
+    assert Ordinary._struct_fields_ == ("v",)
     assert probed == []

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -46,7 +46,7 @@ def test_non_ascii_field_name():
 
     item = MenuItem(café=3)
     assert item.café == 3
-    assert item.__struct_fields__ == ("café",)
+    assert item._struct_fields_ == ("café",)
 
 
 def test_match_args():
@@ -63,15 +63,15 @@ def test_annotations():
 
 
 def test_struct_fields_introspection():
-    assert Point2D(1.0, 2.0).__struct_fields__ == ("x", "y")
-    assert WithDefaults(1).__struct_defaults__ == (2, 3)
+    assert Point2D(1.0, 2.0)._struct_fields_ == ("x", "y")
+    assert WithDefaults(1)._struct_defaults_ == (2, 3)
 
 
 def test_introspection_answers_on_the_class_too():
-    assert Point2D.__struct_fields__ == ("x", "y")
-    assert WithDefaults.__struct_defaults__ == (2, 3)
-    assert Struct.__struct_fields__ == ()
-    assert Struct.__struct_defaults__ == ()
+    assert Point2D._struct_fields_ == ("x", "y")
+    assert WithDefaults._struct_defaults_ == (2, 3)
+    assert Struct._struct_fields_ == ()
+    assert Struct._struct_defaults_ == ()
 
 
 def test_defaults():
@@ -134,7 +134,7 @@ def test_inheritance_extends_fields():
     p = Point3D(1.0, 2.0, 3.0)
     assert (p.x, p.y, p.z) == (1.0, 2.0, 3.0)
     assert Point3D.__match_args__ == ("x", "y", "z")
-    assert p.__struct_fields__ == ("x", "y", "z")
+    assert p._struct_fields_ == ("x", "y", "z")
 
 
 def test_empty_struct():

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -21,6 +21,15 @@ from salix import Struct
 MIXIN = Struct.__mro__[1]
 META = type(Struct)
 
+# Both spellings of both, in one place: two literals drifted apart is a test
+# that silently stops covering a name.
+METADATA_NAMES = (
+    "_struct_fields_",
+    "_struct_defaults_",
+    "__struct_fields__",
+    "__struct_defaults__",
+)
+
 
 class Point(Struct):
     x: int
@@ -136,10 +145,7 @@ class TestAMixinSubclass:
 
         assert impostor.z == 1
 
-    @pytest.mark.parametrize(
-        "attribute",
-        ["_struct_fields_", "_struct_defaults_", "__struct_fields__", "__struct_defaults__"],
-    )
+    @pytest.mark.parametrize("attribute", METADATA_NAMES)
     def test_it_has_no_metadata_to_report(self, impostor, attribute):
         """An AttributeError rather than a TypeError, because that is what the
         two facilities for asking whether an attribute is there catch.
@@ -189,10 +195,7 @@ class TestTheMetaclassWithoutTheMixin:
         assert built._struct_fields_ == ("x", "y")
         assert built(1, 2) == built(1, 2)
 
-    @pytest.mark.parametrize(
-        "attribute",
-        ["_struct_fields_", "_struct_defaults_", "__struct_fields__", "__struct_defaults__"],
-    )
+    @pytest.mark.parametrize("attribute", METADATA_NAMES)
     def test_its_own_metadata_getters_are_never_handed_the_metaclass(self, attribute):
         """They read fields that live past the end of a PyTypeObject, so what
         they are handed has to be an instance of the metaclass -- sized by its

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -136,7 +136,10 @@ class TestAMixinSubclass:
 
         assert impostor.z == 1
 
-    @pytest.mark.parametrize("attribute", ["__struct_fields__", "__struct_defaults__"])
+    @pytest.mark.parametrize(
+        "attribute",
+        ["_struct_fields_", "_struct_defaults_", "__struct_fields__", "__struct_defaults__"],
+    )
     def test_it_has_no_metadata_to_report(self, impostor, attribute):
         """An AttributeError rather than a TypeError, because that is what the
         two facilities for asking whether an attribute is there catch.
@@ -183,10 +186,13 @@ class TestTheMetaclassWithoutTheMixin:
     def test_calling_it_with_a_struct_base_still_works(self):
         built = META("Extended", (Point,), {"__annotations__": {"y": int}})
 
-        assert built.__struct_fields__ == ("x", "y")
+        assert built._struct_fields_ == ("x", "y")
         assert built(1, 2) == built(1, 2)
 
-    @pytest.mark.parametrize("attribute", ["__struct_fields__", "__struct_defaults__"])
+    @pytest.mark.parametrize(
+        "attribute",
+        ["_struct_fields_", "_struct_defaults_", "__struct_fields__", "__struct_defaults__"],
+    )
     def test_its_own_metadata_getters_are_never_handed_the_metaclass(self, attribute):
         """They read fields that live past the end of a PyTypeObject, so what
         they are handed has to be an instance of the metaclass -- sized by its
@@ -268,7 +274,7 @@ class TestTheUninstalledClassCannotBeBuilt:
 
         built = types.new_class("S", (Point,), {"metaclass": META})
 
-        assert built.__struct_fields__ == ("x",)
+        assert built._struct_fields_ == ("x",)
         assert built(1) == built(1)
 
 
@@ -280,7 +286,7 @@ class TestAMetaclassSubclass:
         class Delegated(Struct, metaclass=Delegating):
             a: int
 
-        assert Delegated(1).__struct_fields__ == ("a",)
+        assert Delegated(1)._struct_fields_ == ("a",)
         assert type(Delegated) is Delegating
 
     def test_a_keyword_option_survives_the_handoff_to_a_derived_metatype(self):
@@ -374,7 +380,7 @@ class TestAMetaclassSubclass:
         class Statement(Base, order=True):
             y: int = 42
 
-        assert Statement.__struct_fields__ == ("x", "y")
+        assert Statement._struct_fields_ == ("x", "y")
         assert Statement(1).y == 42
         assert Statement(1) < Statement(1, 43)
 

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -59,6 +59,8 @@ def inheritance_extends_the_signature() -> None:
 
 
 def introspection_is_typed_on_both_the_class_and_the_instance() -> None:
+    assert_type(Point._struct_fields_, tuple[str, ...])
+    assert_type(Point(1, "two")._struct_fields_, tuple[str, ...])
     assert_type(Point.__struct_fields__, tuple[str, ...])
     assert_type(Point(1, "two").__struct_fields__, tuple[str, ...])
     # Narrower than the stub declares: the transform synthesises the literal

--- a/tests/typing/rejected.py
+++ b/tests/typing/rejected.py
@@ -115,7 +115,7 @@ def the_defaults_may_not_be_assigned_on_an_instance() -> None:
     Point(1, "two")._struct_defaults_ = (9,)  # type: ignore[misc]
 
 
-def msgspecs_names_for_them_may_not_be_assigned_either() -> None:
+def msgspec_names_for_them_may_not_be_assigned_either() -> None:
     Point.__struct_fields__ = ("z",)  # type: ignore[misc]
     Point.__struct_defaults__ = (9,)  # type: ignore[misc]
     Point(1, "two").__struct_fields__ = ("z",)  # type: ignore[misc]

--- a/tests/typing/rejected.py
+++ b/tests/typing/rejected.py
@@ -100,16 +100,23 @@ def set_field_will_not_take_keywords() -> None:
 
 
 def the_field_names_may_not_be_assigned_on_the_class() -> None:
-    Point.__struct_fields__ = ("z",)  # type: ignore[misc]
+    Point._struct_fields_ = ("z",)  # type: ignore[misc]
 
 
 def the_defaults_may_not_be_assigned_on_the_class() -> None:
-    Point.__struct_defaults__ = (9,)  # type: ignore[misc]
+    Point._struct_defaults_ = (9,)  # type: ignore[misc]
 
 
 def the_field_names_may_not_be_assigned_on_an_instance() -> None:
-    Point(1, "two").__struct_fields__ = ("z",)  # type: ignore[misc]
+    Point(1, "two")._struct_fields_ = ("z",)  # type: ignore[misc]
 
 
 def the_defaults_may_not_be_assigned_on_an_instance() -> None:
+    Point(1, "two")._struct_defaults_ = (9,)  # type: ignore[misc]
+
+
+def msgspecs_names_for_them_may_not_be_assigned_either() -> None:
+    Point.__struct_fields__ = ("z",)  # type: ignore[misc]
+    Point.__struct_defaults__ = (9,)  # type: ignore[misc]
+    Point(1, "two").__struct_fields__ = ("z",)  # type: ignore[misc]
     Point(1, "two").__struct_defaults__ = (9,)  # type: ignore[misc]

--- a/tests/typing/rejected.py
+++ b/tests/typing/rejected.py
@@ -120,3 +120,21 @@ def msgspec_names_for_them_may_not_be_assigned_either() -> None:
     Point.__struct_defaults__ = (9,)  # type: ignore[misc]
     Point(1, "two").__struct_fields__ = ("z",)  # type: ignore[misc]
     Point(1, "two").__struct_defaults__ = (9,)  # type: ignore[misc]
+
+
+class AFieldMayNotTakeOneOfTheMetadataNames(Struct):
+    """Declaring the four names Final is what makes a checker refuse them as
+    field names, and that refusal is deliberate rather than a side effect.
+
+    The runtime still builds this class -- #82 is the decision about whether it
+    should -- and until that is settled the two answers differ: a checker says
+    no and salix says yes. The direction is the safe one, since the class it
+    builds reports the metadata when read from the class and the field when
+    read from an instance, so the refusal here is the reservation being real
+    somewhere. Stated in this file so that it is checked rather than assumed.
+    """
+
+    _struct_fields_: int  # type: ignore[assignment,misc]
+    _struct_defaults_: int  # type: ignore[assignment,misc]
+    __struct_fields__: int  # type: ignore[assignment,misc]
+    __struct_defaults__: int  # type: ignore[assignment,misc]


### PR DESCRIPTION
> did we invent this dunder? that is not allowed

We did, and it is not. So the pair salix defines is now `_struct_fields_` /
`_struct_defaults_`, and `__struct_fields__` / `__struct_defaults__` stay
beside them as **msgspec's** names, honoured rather than invented.

## Why the two are not the same kind of thing

The language reference reserves `__name__` for "the interpreter and its
implementation, including the standard library", and says any other use is
"subject to breakage without warning". PEP 8 puts the same rule as: **never
invent such names; only use them as documented.**

That is an asymmetry, not a prohibition, and it is the whole of the ruling
here. Minting `__struct_fields__` for salix is inventing one. Answering to
msgspec's `__struct_fields__` is using a documented one, which is the half PEP 8
allows — and it is what makes code written against msgspec work unchanged.

<details>
<summary>msgspec's names and semantics, measured rather than assumed</summary>

```
msgspec 0.21.1
class attrs: ['__struct_config__', '__struct_defaults__',
              '__struct_encode_fields__', '__struct_fields__']
__struct_fields__:   ('x', 'y')
__struct_defaults__: (2,)
on an instance:      ('x', 'y')
sunder present?      False
```

Same two names, same semantics salix has — the field-name tuple and the
trailing-defaults tuple, on both the class and the instance. msgspec also
carries `__struct_config__` and `__struct_encode_fields__`; salix has no
equivalent and does not invent one.

</details>

## What changed

| | |
| --- | --- |
| `src/mixin.c` | the instance-side getset table grows from two entries to four |
| `src/meta.c` | the class-side table likewise |
| `salix/__init__.pyi` | all four declared `Final` |
| `tests/` | 83 uses renamed to the sunder — 59 `__struct_fields__`, 24 `__struct_defaults__` |
| `tests/test_metadata_names.py` | new: the aliases are a surface with its own tests, not a spelling |

The two parametrised tests in `test_struct_identity.py` that sweep the metadata
attributes now sweep all four, so the impostor's `AttributeError` and the
"never handed the metaclass" guard both cover the aliases.

<details>
<summary>Why the mixin needs four getters where the metaclass needs two</summary>

The metaclass getters take the class and read it. The mixin's have to refuse a
non-struct — the mixin is a permitted base and a subclass of it need not be one
— and the refusal names the attribute asked for:

```
_struct_fields_ is defined on structs, and Impostor is not one
```

The getset machinery gives the getter no way to tell which of its names was
used, and the only channel that would (`closure`) needs a cast to `void *`. Four
one-line getters is the cast-free version, and it keeps the message honest:
ask for the dunder and the dunder is what the error names.

</details>

## One line of unrelated cleanup, declared

`src/construct.c`'s comment said `__struct_defaults__ advertised a value no
instance would ever carry (#56)`. The rename touches that sentence, so the
stale issue reference went with it rather than being left in a line being
rewritten. The other 13 issue references in `src/` are still queued for their
own src-only PR, untouched here.

902 tests pass, 10 skipped, 2 xfailed. `camas check` 25/25 across 3.10–3.15 and
3.14t; `camas flake_check` green, which is the only local thing that
cross-builds Windows.

Closes #74.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins, who asked
> "did we invent this dunder?" on #74 and then ruled: keep the compliant name,
> alias the non-compliant one.
