### PR TITLE
style: comments that carry the reason and not the issue number

### DIFF
--- a/src/annotations.c
+++ b/src/annotations.c
@@ -64,9 +64,9 @@ static PyObject * borrow_annotate(PyObject * const namespace) {
  * the callable and re-runs every annotation in the dict, so a class holding one
  * forward reference evaluates its other annotations again. Plain 3.14 evaluates
  * once and defers. Format.STRING would avoid it, because only the keys are read
- * here -- but not for long: #50 adds the #14 ClassVar check, which reads the
- * values, and STRING hands it strings. Not in this tree yet, so the reason to
- * keep FORWARDREF is a pending one rather than a present one.
+ * here -- but the ClassVar and InitVar check reads the values, and STRING hands
+ * it strings, which would put every class on the text matcher's heuristics
+ * instead of only the ones whose module deferred its annotations.
  *
  * FORWARDREF is the fallback: it leaves an unresolved bare forward reference as
  * a ForwardRef instead of raising, which is all we need since only the field

--- a/src/construct.c
+++ b/src/construct.c
@@ -271,7 +271,7 @@ static enum result fill_defaults(
  * whitelists the same four types.
  *
  * Every one of them is unhashable, which is the single test that would replace
- * this list; #51 is where that is argued. msgspec shares them as well.
+ * this list. msgspec shares them as well.
  *
  * dataclasses refuses the shape outright and needs default_factory to express
  * it at all. This copies, so the common spelling means what it looks like it

--- a/src/fields.c
+++ b/src/fields.c
@@ -335,9 +335,8 @@ static enum inheritance inherits_field(StructType const * const base, PyObject *
  *
  * The annotation is walked rather than probed once, because
  * Annotated[ClassVar[int], ...] reaches ClassVar two hops down and is otherwise
- * the same bug wearing a wrapper. A tree since #57's ruling and not a chain:
- * __origin__, every element of __args__, and a PEP 695 alias's __value__ are
- * all edges.
+ * the same bug wearing a wrapper. A tree and not a chain: __origin__, every
+ * element of __args__, and a PEP 695 alias's __value__ are all edges.
  */
 enum : int {
 	/* A budget on work rather than on depth, because bounding the shape stopped
@@ -414,14 +413,14 @@ static struct special_form special_form_of(
  * The form can be anywhere in a subscripted annotation, not only at the end of
  * the __origin__ chain. `Optional[Annotated[ClassVar[int], 'm']]` keeps it in
  * the arguments, where a chain walk never looks, so it became a field while
- * the text path refused the same source -- #14 again, on the path almost every
- * class takes. Both are walked now, per #57's ruling.
+ * the text path refused the same source, on the path almost every class takes.
+ * Both are walked now.
  *
  * It does not reach `Annotated[int, ClassVar]`, where the form is metadata
  * rather than the type, because Annotated keeps metadata in __metadata__ and
  * not in __args__ -- so that shape is still a field here while the text path
- * refuses it. #57 owns the disagreement; when this comment claimed the walk had
- * closed it, the test one file over already said otherwise.
+ * refuses it. The disagreement is left open here; when this comment claimed the
+ * walk had closed it, the test one file over already said otherwise.
  *
  * A str reached by the walk is walked and not matched, which costs nothing
  * today: the only strings in an __args__ are the ones a caller put there, and
@@ -578,8 +577,8 @@ static struct special_form named_special_form(
  * than the type -- including when it is quoted, since a quote is a boundary.
  * That last one is deliberate: `x: 'ClassVar[int]'` is a nested forward
  * reference and has to be refused, and nothing short of parsing tells the two
- * apart. #57 keeps the list. The object path is exact, and it is what
- * runs unless the module asked for `from __future__ import annotations`.
+ * apart. The object path is exact, and it is what runs unless the module asked
+ * for `from __future__ import annotations`.
  */
 static bool continues_identifier(Py_UCS4 const character) {
 	/* Python owns the answer and spells it one way in the C API: a name is an
@@ -638,7 +637,8 @@ static bool names_form(PyObject * const text, PyObject * const needle) {
  * and turns the guard off for this class because there is nothing it could be
  * naming. NULL *with* an exception set is a failure, and the caller has to tell
  * them apart: swallowing the second one turns a MemoryError into a silently
- * unguarded class, which is #14 again with no way to notice.
+ * unguarded class, where a ClassVar becomes a field again with no way to
+ * notice.
  */
 static PyObject * module_attribute(char const * const module_name, char const * const attribute) {
 	PY_OWNED(name, PyUnicode_FromString(module_name));
@@ -674,11 +674,10 @@ static PyObject * module_attribute(char const * const module_name, char const * 
  * every other: Struct_new writes that class's declared defaults before the
  * __init__ runs, so a non-empty one would be copied per instance and is
  * shallow there for the same reason. It used to over-fire on a declaration
- * nothing would ever hand out, which is what #56 was; the message states the
- * rule rather than a consequence because that reads the same either way, and
- * names the remedy that still works there: __post_init__ runs from the
- * constructor a body __init__ displaces, so only set_field from that __init__
- * is left.
+ * nothing would ever hand out; the message states the rule rather than a
+ * consequence because that reads the same either way, and names the remedy
+ * that still works there: __post_init__ runs from the constructor a body
+ * __init__ displaces, so only set_field from that __init__ is left.
  */
 static enum result reject_unsafe_default(PyObject * const field_name, PyObject * const value) {
 	PyTypeObject * const kind = Py_TYPE(value);
@@ -755,8 +754,7 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		 * the work the first check exists to skip and not the invariant.
 		 *
 		 * `_struct_defaults_` still hands the stored object out, so filling it
-		 * through there defeats this. That route is out of contract and #51 is
-		 * where the whole type list is argued. */
+		 * through there defeats this. That route is out of contract. */
 		if (reject_unsafe_default(field_name, value) != RESULT_OK) {
 			Py_DECREF(defaults);
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -24,7 +24,7 @@ Py_hash_t Struct_hash(PyObject * const self) {
 	 * NotImplemented and the co-base's reflected __eq__ says yes -- so an
 	 * identity hash made it equal to a value it could not be looked up beside.
 	 * Refusing to hash is what puts equality and hashing back in one place, and
-	 * being unhashable is an ordinary thing for an object to be. #66.
+	 * being unhashable is an ordinary thing for an object to be.
 	 *
 	 * Unhashable to the operator and not to the ABC: collections.abc.Hashable
 	 * asks whether tp_hash is non-NULL, and the mixin's is, so an impostor is an

--- a/src/meta.c
+++ b/src/meta.c
@@ -22,15 +22,15 @@ struct member_lookup {
 	Py_ssize_t offset;
 };
 
-/* Whether the __eq__ a class resolves came from a class body, and whether the
- * question could be answered -- asking a base runs whatever its metaclass
- * defines, so the lookup can raise. */
 /* Whether a name is defined, and whether the dicts could be read at all. */
 struct definition {
 	enum { DEFINITION_READ, DEFINITION_UNREADABLE } tag;
 	bool found;
 };
 
+/* Whether the __eq__ a class resolves came from a class body -- always a
+ * base's, never this class's own, since a body that writes __eq__ is never
+ * asked. */
 struct equality_source {
 	enum { EQUALITY_RESOLVED, EQUALITY_FAILED } tag;
 	bool from_a_body;
@@ -294,9 +294,8 @@ static PyObject * build_struct_class(
 	 * namespace and that is what the lookup finds first. */
 	bool const body_defines_eq = PyDict_GetItemString(original_namespace, "__eq__") != NULL;
 
-	/* Only asked when the answer can be used, because asking means reading
-	 * every co-base's __eq__ -- which runs whatever the co-base put under the
-	 * name and can refuse a class that would otherwise build.
+	/* Only asked when the answer can be used, because asking walks the class
+	 * dicts along every co-base's MRO.
 	 *
 	 * A class that changes the eq option has salix's binding written into its
 	 * own namespace for all six comparison names, and a class whose body writes
@@ -472,7 +471,7 @@ static struct equality_source resolves_body_equality(PyObject * const bases) {
 	);
 }
 
-/* Split out so that the two sentinels are fetched once for the walk and not at
+/* Split out so that the two names are interned once for the walk and not at
  * all for a class whose first base is a struct, which is nearly all of them. */
 static struct equality_source equality_from_the_co_bases(
 	PyObject * const bases,

--- a/src/meta.c
+++ b/src/meta.c
@@ -295,7 +295,9 @@ static PyObject * build_struct_class(
 	bool const body_defines_eq = PyDict_GetItemString(original_namespace, "__eq__") != NULL;
 
 	/* Only asked when the answer can be used, because asking walks the class
-	 * dicts along every co-base's MRO.
+	 * dicts along every co-base's MRO -- and a dict it cannot read is answered
+	 * as a failure, so an unnecessary walk can still refuse a class that would
+	 * otherwise build.
 	 *
 	 * A class that changes the eq option has salix's binding written into its
 	 * own namespace for all six comparison names, and a class whose body writes

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -73,9 +73,9 @@ static PyGetSetDef Struct_getset[] = {
  * whatever the co-base defines would mean walking the MRO for something to
  * borrow, on a path reachable only by subclassing a private class.
  *
- * Hash is the exception, and #66 is why: it cannot be a local decision, because
- * hashing and equality have to agree and equality here is the co-base's. It
- * refuses instead. See src/hash.c.
+ * Hash is the exception: it cannot be a local decision, because hashing and
+ * equality have to agree and equality here is the co-base's. It refuses
+ * instead. See src/hash.c.
  *
  * Setattr takes object's too, and that one is worth saying out loud because it
  * *overrides* rather than falls back: a co-base with its own `__setattr__`
@@ -85,8 +85,8 @@ static PyGetSetDef Struct_getset[] = {
  * walking the MRO for a setter to borrow, on a path reachable only by
  * subclassing a private class.
  *
- * Equality is left intransitive by all of this, and #66's fix does not change
- * it. `rich_compare` answers NotImplemented for a non-struct, so two
+ * Equality is left intransitive by all of this, and refusing to hash does not
+ * change it. `rich_compare` answers NotImplemented for a non-struct, so two
  * content-equal impostors fall back to identity and compare unequal, while each
  * compares equal to the plain value they wrap through the co-base's reflected
  * `__eq__`. Pinned in tests/test_struct_identity.py rather than left to be
@@ -96,10 +96,9 @@ static PyGetSetDef Struct_getset[] = {
  * The metadata getsets are the exception either way -- all four of them, the
  * two salix defines and the two it answers to for msgspec's sake: they report
  * struct metadata and nothing else, so there is nothing to fall back to and
- * they raise. An
- * AttributeError rather than a TypeError, because "this object does not have
- * that attribute" is what happened and it is what `hasattr` and `getattr`'s
- * default are written to catch.
+ * they raise. An AttributeError rather than a TypeError, because "this object
+ * does not have that attribute" is what happened and it is what `hasattr` and
+ * `getattr`'s default are written to catch.
  */
 static PyObject * metadata_of(
 	PyObject * const self,

--- a/src/types.h
+++ b/src/types.h
@@ -129,14 +129,14 @@ struct slot_pair {
 /*
  * A new reference to a field, taken under the same lock the writer takes.
  *
- * #7 made the write side safe by going through PyMember_SetOne, which holds a
- * critical section on the instance over the store and defers the release past
+ * The write side is safe because it goes through PyMember_SetOne, which holds
+ * a critical section on the instance over the store and defers the release past
  * the end of it. Every reader here loaded the slot and then increffed what it
  * found, which is two steps with a window between them: on a free-threaded
  * build a concurrent write frees the pointer inside that window, and repr and
  * == segfault. Measured, 3.14t, four writers and three readers of one kind:
  * `repr` exited 134/139/134 and `==` 139/134/134, while the same loop reading
- * through CPython's own member descriptor survived every time. #46.
+ * through CPython's own member descriptor survived every time.
  *
  * Every acquisition is in this file, so a fifth reader cannot forget one. The
  * macros are a bare scope on a build with the GIL, so all three of these are


### PR DESCRIPTION
Fourteen GitHub issue references were left behind in `src/` comments by already-merged PRs. CLAUDE.md puts that kind of metadata in the commit message: a reference in a `.c` file points at something that moves — closed, retitled, superseded — and rots there with no one watching. Each reference is deleted and the reason it stood for is kept.

**Comments only. No code is touched**, so there is nothing here that can change behaviour. `check` 25/25 and `flake_check` green.

Four comments were also **false**, and this is where they are paid off rather than in another review round on a PR that had already converged:

| file | said | now |
| --- | --- | --- |
| `meta.c` | `equality_source`'s docstring, stranded above `struct definition`, still described the attribute fetch #83 removed | says which body `from_a_body` means — always a base's, never this class's own |
| `meta.c` | the walk's gate blamed "runs whatever the co-base put under the name" for why it is only asked when usable | the reason is the cost of reading the class dicts along every co-base's MRO |
| `meta.c` | "the two **sentinels** are fetched once for the walk" | the two **names** are interned once |
| `annotations.c` | the `ClassVar` check that reads annotation *values* is "not in this tree yet, so the reason to keep FORWARDREF is a pending one" | #50 merged and `special_form_of` reads them, so the reason is a present one |

<details>
<summary><b>Every reference removed, and what stands in its place</b></summary>

Reasons are preserved verbatim wherever the reference was the only thing deleted.

| site | reference | what changed |
| --- | --- | --- |
| `types.h:132` | `#7 made the write side safe by going through PyMember_SetOne` | "The write side is safe because it goes through PyMember_SetOne" |
| `types.h:139` | `...survived every time. #46.` | trailing reference dropped; the measurement above it is untouched |
| `construct.c:274` | `...that would replace this list; #51 is where that is argued.` | "...that would replace this list." |
| `annotations.c:67` | `#50 adds the #14 ClassVar check` | rewritten — see the table above |
| `fields.c:338` | `A tree since #57's ruling and not a chain` | "A tree and not a chain" |
| `fields.c:417` | `-- #14 again, on the path almost every class takes. Both are walked now, per #57's ruling.` | "on the path almost every class takes. Both are walked now." |
| `fields.c:423` | `#57 owns the disagreement; when this comment claimed...` | "The disagreement is left open here; when this comment claimed..." |
| `fields.c:581` | `#57 keeps the list.` | sentence dropped; the list of escapes above it stays |
| `fields.c:641` | `...a silently unguarded class, which is #14 again with no way to notice.` | "...where a `ClassVar` becomes a field again with no way to notice." |
| `fields.c:677` | `...nothing would ever hand out, which is what #56 was;` | "...nothing would ever hand out;" |
| `fields.c:758` | `That route is out of contract and #51 is where the whole type list is argued.` | "That route is out of contract." |
| `mixin.c:76` | `Hash is the exception, and #66 is why:` | "Hash is the exception:" |
| `mixin.c:88` | `...and #66's fix does not change it.` | "...and refusing to hash does not change it." |
| `hash.c:27` | `...for an object to be. #66.` | trailing reference dropped |

Lines are rewrapped wherever a deletion left a short one, plus one paragraph in `mixin.c` that #81 left wrapped after three words (`they raise. An` / `AttributeError rather than...`).

</details>

<details>
<summary><b>Why the four false ones are in this PR and not their own</b></summary>

The three `meta.c` ones are #83's round-8 nits. That review had come back at a **convergence score of 1** — converged — with nothing but those comments left. Pushing a fix would have started a round 9 and the repo's rule is that every PR ends with a landed review on its current head, so the cheapest correct place for them was the next src-comment-only PR. This is it.

The `annotations.c` one is different in kind: nobody wrote it wrong. It was true when it was written and #50 merging made it false, which is the failure mode a cross-reference has and a stated reason does not. It also could not be *fixed* without deleting a reference, since the sentence's subject was `#50`, so it belongs here regardless.

Verified before rewriting it rather than assumed: `append_declared` holds the annotation value and hands it to `special_form_of`, which reads it — so the check does read the values, and `Format.STRING` would hand every class a string and put it on the text matcher's heuristics instead of only the modules that deferred their annotations.

</details>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. She asked me to proceed to the next phase of work and drive its PRs to merge; this is the queued comment cleanup that her instruction *"code comments should never point at metadata such as GH issues, refer to my CLAUDE.md"* called for, carried out as its own no-behaviour PR so it cannot hide inside a fix.
