### PR TITLE
fix: a body __slots__ entry that is not a field is refused, not dropped

### DIFF
--- a/src/meta.c
+++ b/src/meta.c
@@ -79,7 +79,11 @@ static PyObject * build_class_namespace(
 	bool inherits_body_eq,
 	bool derive_not_equal
 );
-static enum result refuse_displaced_slots(PyObject * original_namespace, PyObject * new_names);
+static enum result refuse_displaced_slots(
+	PyObject * original_namespace,
+	PyObject * all_names,
+	bool carries_a_weakref_slot
+);
 static PyObject * build_slots(PyObject * new_names, bool weakref);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
@@ -288,7 +292,14 @@ static PyObject * build_struct_class(
 		return NULL;
 	}
 
-	if (refuse_displaced_slots(original_namespace, plan.new_names) != RESULT_OK) {
+	if (
+		refuse_displaced_slots(
+			original_namespace,
+			plan.all_names,
+			request.options.weakref || has_weakref_slot(base)
+		) !=
+		RESULT_OK
+	) {
 		field_plan_clear(&plan);
 
 		return NULL;
@@ -714,7 +725,8 @@ static PyObject * build_class_namespace(
 
 static enum result refuse_displaced_slots(
 	PyObject * const original_namespace,
-	PyObject * const new_names
+	PyObject * const all_names,
+	bool const carries_a_weakref_slot
 ) {
 	PyObject * const declared = PyDict_GetItemString(original_namespace, "__slots__");
 
@@ -733,17 +745,38 @@ static enum result refuse_displaced_slots(
 
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(entries); ++i) {
 		PyObject * const entry = PyTuple_GET_ITEM(entries, i);
-		int const named_by_a_field = PySequence_Contains(new_names, entry);
+
+		if (!PyUnicode_Check(entry)) {
+			PyErr_Format(
+				PyExc_TypeError,
+				"__slots__ items must be strings, not '%.200s'",
+				Py_TYPE(entry)->tp_name
+			);
+
+			return RESULT_ERROR;
+		}
+
+		if (PyUnicode_CompareWithASCIIString(entry, "__weakref__") == 0) {
+			if (carries_a_weakref_slot) {
+				continue;
+			}
+
+			PyErr_SetString(
+				PyExc_TypeError,
+				"__slots__ names __weakref__, which salix writes only for a class "
+				"that asks for it; pass weakref=True instead"
+			);
+
+			return RESULT_ERROR;
+		}
+
+		int const named_by_a_field = PySequence_Contains(all_names, entry);
 
 		if (named_by_a_field < 0) {
 			return RESULT_ERROR;
 		}
 
 		if (named_by_a_field == 1) {
-			continue;
-		}
-
-		if (PyUnicode_Check(entry) && PyUnicode_CompareWithASCIIString(entry, "__weakref__") == 0) {
 			continue;
 		}
 

--- a/src/meta.c
+++ b/src/meta.c
@@ -66,6 +66,7 @@ static struct definition any_base_defines(PyObject * bases, Py_ssize_t first, Py
 static struct options inherited_options(PyObject * bases, StructType const * behaviour);
 static bool any_struct_base_is_mutable(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
+static bool any_base_has_weakref_slot(PyObject * bases);
 static struct options base_options(StructType const * base);
 static PyObject * build_class_namespace(
 	PyObject * original_namespace,
@@ -296,7 +297,7 @@ static PyObject * build_struct_class(
 		refuse_displaced_slots(
 			original_namespace,
 			plan.all_names,
-			request.options.weakref || has_weakref_slot(base)
+			request.options.weakref || any_base_has_weakref_slot(bases)
 		) !=
 		RESULT_OK
 	) {
@@ -681,6 +682,18 @@ static bool has_weakref_slot(StructType const * const base) {
 	return base != NULL && base->heap_type.ht_type.tp_weaklistoffset != 0;
 }
 
+static bool any_base_has_weakref_slot(PyObject * const bases) {
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+
+		if (PyType_Check(base) && ((PyTypeObject *) base)->tp_weaklistoffset != 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /* The namespace handed to type.__new__: a copy of the original with every
  * class-body binding of a field name removed (so none of them clashes with the
  * __slots__ descriptor that reads the value) plus __slots__ / __match_args__
@@ -763,8 +776,9 @@ static enum result refuse_displaced_slots(
 
 			PyErr_SetString(
 				PyExc_TypeError,
-				"__slots__ names __weakref__, which salix writes only for a class "
-				"that asks for it; pass weakref=True instead"
+				"__slots__ names __weakref__ and this class carries no weakref "
+				"slot to name; a struct gets one from weakref=True or from a base "
+				"that has one"
 			);
 
 			return RESULT_ERROR;

--- a/src/meta.c
+++ b/src/meta.c
@@ -79,6 +79,7 @@ static PyObject * build_class_namespace(
 	bool inherits_body_eq,
 	bool derive_not_equal
 );
+static enum result refuse_displaced_slots(PyObject * original_namespace, PyObject * new_names);
 static PyObject * build_slots(PyObject * new_names, bool weakref);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
@@ -284,6 +285,12 @@ static PyObject * build_struct_class(
 	struct field_plan plan = field_plan_build(base, original_namespace);
 
 	if (field_plan_failed(&plan)) {
+		return NULL;
+	}
+
+	if (refuse_displaced_slots(original_namespace, plan.new_names) != RESULT_OK) {
+		field_plan_clear(&plan);
+
 		return NULL;
 	}
 
@@ -703,6 +710,55 @@ static PyObject * build_class_namespace(
 	}
 
 	return NULL;
+}
+
+static enum result refuse_displaced_slots(
+	PyObject * const original_namespace,
+	PyObject * const new_names
+) {
+	PyObject * const declared = PyDict_GetItemString(original_namespace, "__slots__");
+
+	if (declared == NULL) {
+		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
+	}
+
+	PY_OWNED(
+		entries,
+		PyUnicode_Check(declared) ? PyTuple_Pack(1, declared) : PySequence_Tuple(declared)
+	);
+
+	if (entries == NULL) {
+		return RESULT_ERROR;
+	}
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(entries); ++i) {
+		PyObject * const entry = PyTuple_GET_ITEM(entries, i);
+		int const named_by_a_field = PySequence_Contains(new_names, entry);
+
+		if (named_by_a_field < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (named_by_a_field == 1) {
+			continue;
+		}
+
+		if (PyUnicode_Check(entry) && PyUnicode_CompareWithASCIIString(entry, "__weakref__") == 0) {
+			continue;
+		}
+
+		PyErr_Format(
+			PyExc_TypeError,
+			"__slots__ names %R, which is not a field of this class; a struct's "
+			"fields are its slots, so salix would drop it -- declare it as a field, "
+			"or drop __slots__",
+			entry
+		);
+
+		return RESULT_ERROR;
+	}
+
+	return RESULT_OK;
 }
 
 /* __weakref__ is a slot like any other; a class that wants to be the target of

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -550,11 +550,48 @@ class TestBindingsSalixOwns:
         and dropping it leaves a class that cannot be weak-referenced at all.
         """
 
-        with pytest.raises(TypeError, match="pass weakref=True instead"):
+        with pytest.raises(TypeError, match="carries no weakref slot to name"):
 
             class Unasked(Struct):
                 x: int
                 __slots__ = ("__weakref__", "x")
+
+    def test_an_inherited_weakref_slot_exempts_it_too(self):
+        """The other half of the exemption: the class need not ask for the slot
+        if a base already has one, because then salix drops nothing.
+        """
+
+        class Referenceable(Struct, weakref=True):
+            pass
+
+        class Child(Referenceable):
+            x: int = 0
+            __slots__ = ("__weakref__",)
+
+        held = Child(1)
+
+        assert weakref.ref(held)() is held
+
+    def test_the_base_with_the_slot_need_not_be_the_layout_base(self):
+        """`has_weakref_slot` asks the widest struct base, which is the one
+        CPython gives `tp_base`. The slot comes from *any* base, so asking only
+        that one refused a class that is weak-referenceable without the entry --
+        and the same class one base-order over was accepted.
+        """
+
+        class Referenceable(Struct, weakref=True):
+            pass
+
+        class Wider(Struct):
+            a: int
+            b: int
+
+        class Both(Wider, Referenceable):
+            __slots__ = ("__weakref__",)
+
+        held = Both(1, 2)
+
+        assert weakref.ref(held)() is held
 
     def test_a_slot_naming_an_inherited_field_is_accepted(self):
         """Refused when an entry would be lost, and an inherited field's slot is

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -529,11 +529,60 @@ class TestBindingsSalixOwns:
         assert Agreeing(1).x == 1
 
     def test_weakref_may_be_named_because_salix_writes_it(self):
+        """`held` rather than a temporary: `weakref.ref(Weak(1))()` answers None,
+        because the argument is decref'd when the call returns and nothing else
+        holds it. It passes under pytest anyway -- assertion rewriting binds the
+        intermediate to a local -- and fails under `--assert=plain`, so the
+        temporary form would have been green for a reason unrelated to weakref.
+        """
+
         class Weak(Struct, weakref=True):
             x: int
             __slots__ = ("__weakref__", "x")
 
-        assert weakref.ref(Weak(1))() is not None
+        held = Weak(1)
+
+        assert weakref.ref(held)() is held
+
+    def test_naming_weakref_without_asking_for_it_is_refused(self):
+        """salix writes `__weakref__` only for a class that passes
+        `weakref=True`, so without it the entry is one that would be dropped --
+        and dropping it leaves a class that cannot be weak-referenced at all.
+        """
+
+        with pytest.raises(TypeError, match="pass weakref=True instead"):
+
+            class Unasked(Struct):
+                x: int
+                __slots__ = ("__weakref__", "x")
+
+    def test_a_slot_naming_an_inherited_field_is_accepted(self):
+        """Refused when an entry would be lost, and an inherited field's slot is
+        already on the base -- salix writes only this class's new fields, so
+        naming an inherited one loses nothing.
+        """
+
+        class Base(Struct):
+            x: int
+
+        class Child(Base):
+            y: int = 0
+            __slots__ = ("x",)
+
+        assert Child(1).x == 1
+
+    def test_a_non_string_slot_entry_is_refused(self):
+        """Membership would otherwise be decided by `__eq__`, so an object that
+        compares equal to a field name would pass the check and then be dropped
+        by `type.__new__` -- and one whose `__eq__` raises would replace the
+        refusal with its own error.
+        """
+
+        with pytest.raises(TypeError, match="__slots__ items must be strings"):
+
+            class Numbered(Struct):
+                x: int
+                __slots__ = (1,)
 
     def test_a_body_match_args_is_replaced_by_the_fields(self):
         class Matched(Struct):
@@ -555,6 +604,7 @@ class TestBindingsSalixOwns:
         class Matched(Struct, match_args=False):
             x: int
             __match_args__ = ("nope",)
+            __slots__ = ("x",)
 
         class Silent(Struct, match_args=False):
             x: int

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -17,6 +17,7 @@ import dataclasses
 import functools
 import struct as struct_module
 import sys
+import weakref
 from typing import NamedTuple
 
 import pytest
@@ -489,16 +490,50 @@ class TestCaching:
 
 class TestBindingsSalixOwns:
     """Not every body binding is the body's to keep, and neither of these
-    collides with a field name. `__slots__` is taken unconditionally;
-    `__match_args__` only while the class wants one.
+    collides with a field name. `__slots__` is taken unconditionally, so an
+    entry that is not a field is refused rather than dropped -- #12.
+    `__match_args__` is taken only while the class wants one.
     """
 
-    def test_a_body_slots_is_replaced_by_the_fields(self):
-        class Slotted(Struct):
-            x: int
-            __slots__ = ("extra",)
+    def test_a_body_slot_that_is_not_a_field_is_refused(self):
+        with pytest.raises(TypeError, match="'extra', which is not a field"):
 
-        assert Slotted.__slots__ == ("x",)
+            class Slotted(Struct):
+                x: int
+                __slots__ = ("extra",)
+
+    def test_a_bare_string_slots_is_refused_too(self):
+        """`__slots__ = "extra"` is one name to `type.__new__`, not five
+        characters, so it has to be read the same way here.
+        """
+
+        with pytest.raises(TypeError, match="'extra', which is not a field"):
+
+            class Stringy(Struct):
+                x: int
+                __slots__ = "extra"
+
+    def test_a_body_slots_naming_only_fields_is_accepted(self):
+        """Refused when an entry would be *lost*, not merely when `__slots__` is
+        present. salix writes the field tuple over it, so a body that names the
+        fields loses nothing -- and the transformed namespace re-enters class
+        creation when a delegating metaclass wins, carrying salix's own
+        `__slots__` with it. `test_struct_identity.py` covers that path.
+        """
+
+        class Agreeing(Struct):
+            x: int
+            __slots__ = ("x",)
+
+        assert Agreeing.__slots__ == ("x",)
+        assert Agreeing(1).x == 1
+
+    def test_weakref_may_be_named_because_salix_writes_it(self):
+        class Weak(Struct, weakref=True):
+            x: int
+            __slots__ = ("__weakref__", "x")
+
+        assert weakref.ref(Weak(1))() is not None
 
     def test_a_body_match_args_is_replaced_by_the_fields(self):
         class Matched(Struct):
@@ -509,7 +544,7 @@ class TestBindingsSalixOwns:
 
     def test_opting_out_of_match_args_leaves_the_body_its_own(self):
         """`match_args=False` means salix writes none into this namespace, so
-        the body keeps what it wrote -- and `__slots__` does not.
+        the body keeps what it wrote.
 
         Not that the class has none: `Struct` itself carries a generated `()`,
         which every subclass sees through the MRO, so a struct that opts out and
@@ -520,7 +555,6 @@ class TestBindingsSalixOwns:
         class Matched(Struct, match_args=False):
             x: int
             __match_args__ = ("nope",)
-            __slots__ = ("extra",)
 
         class Silent(Struct, match_args=False):
             x: int


### PR DESCRIPTION
Closes the `__slots__` half of #12. The `__new__` half stays open — it is blocked on #13 by measurement.

A body `__slots__` entry that is not a field is now refused instead of thrown away:

```
TypeError: __slots__ names 'extra', which is not a field of this class; a struct's
fields are its slots, so salix would drop it -- declare it as a field, or drop __slots__
```

## The issue asked for a flat refusal and a flat refusal is not implementable

The issue proposed:

```
TypeError: a struct class may not declare __slots__; its fields are its slots
```

I built exactly that first. It **refuses salix's own `__slots__`**, and the suite says so — mutation 2 below. The path:

1. `META("Built", (Base,), namespace)` where `Base`'s metatype is a `_StructMeta` subclass with a Python `__new__`;
2. `build_class_namespace` writes `__slots__` into its copy of the namespace;
3. `create_class` calls `PyType_Type.tp_new(metatype, ...)`, and `type_new` sees `winner != metatype` with a non-`type_new` `tp_new`, so it **hands off** to that metaclass's `__new__`;
4. which calls `super().__new__(...)` — landing back in `StructMeta_new` with the namespace from step 2, `__slots__` and all.

That hand-off is deliberate: it is how a user's metaclass gets to see the class, and `reject_unless_planned` is what guards the result. So the refusal has to tolerate re-entry.

**The rule is therefore: refuse every entry that would be lost.** An entry that names a field, or `__weakref__`, is one salix writes itself — replacing it changes nothing, so there is nothing to refuse. Anything else is discarded today, and that is the whole of the defect.

| `__slots__` | fields | outcome |
| --- | --- | --- |
| `("extra",)` | `x` | **refused** — `extra` would be lost |
| `"extra"` | `x` | **refused** — a bare string is one name to `type.__new__`, so it is read as one here |
| `("x",)` | `x` | accepted; salix writes `("x",)` over it, so nothing is lost |
| `("__weakref__", "x")` | `x`, `weakref=True` | accepted; salix writes both |
| salix's own, on re-entry | — | accepted, which is the point |

It also fixes the weakref corner a value-comparison rule would have had: the re-entrant call arrives with **no keywords** (that is #55), so it recomputes `weakref` from the inherited options and would disagree with the tuple salix wrote one frame up. Membership does not care.

<details>
<summary><b>Two mutations, each a separate build</b></summary>

Different `.so` hashes (`eff8bd6e…`, `3fa329f5…`), `touch src/*.c` in front of each.

**1. The refusal disabled** — only the two refusal tests fail, so nothing else in the suite is standing in for them:

```
FAILED TestBindingsSalixOwns::test_a_body_slot_that_is_not_a_field_is_refused
FAILED TestBindingsSalixOwns::test_a_bare_string_slots_is_refused_too
2 failed, 963 passed
```

**2. The flat refusal the issue proposed** — `present` means refuse:

```
FAILED TestBindingsSalixOwns::test_a_body_slots_naming_only_fields_is_accepted
FAILED TestBindingsSalixOwns::test_weakref_may_be_named_because_salix_writes_it
FAILED TestAMetaclassSubclass::test_a_delegate_that_writes_its_own_new_is_refused_not_mis_planned
```

That third one is the demonstration. Its own message is *"did not plan"*; under the flat rule it becomes *"a struct class may not declare `__slots__`"*, on a namespace no class body wrote.

</details>

<details>
<summary><b>Why it runs after the field plan, and what it does not cover</b></summary>

It needs the field names to know what would be lost, so it runs straight after `field_plan_build` and clears the plan on refusal. A body with both a `ClassVar` and a bad `__slots__` reports the `ClassVar`, since that refusal comes first.

`__slots__` is read from `original_namespace`, so a `NULL` return with an exception set is separated from a plain absence rather than swallowed — otherwise the next C call would run with a pending exception, which is [#83](https://github.com/JPHutchins/salix/pull/83)'s failure mode.

Not covered, and unchanged: a `__slots__` naming a field *twice*, which `type.__new__` would reject on its own; and `__dict__` in `__slots__`, which is refused by this rule since it is not a field — a struct with a `__dict__` is not a shape salix offers.

</details>

`Struct` itself is unaffected — `create_struct_base` builds it from a namespace holding only `__module__`, checked before writing this.

`check` 25/25 across 3.10–3.15 and 3.14t, `flake_check` green.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins, who asked me to proceed to the next phase and drive its PRs to merge. She ruled this half of #12 "reject" on 2026-08-01; the note I left saying a naive refusal cannot work turned out to be still true, so this is the version that can.
