### PR TITLE
fix: refuse a default that claims a hash and then refuses to give one

### DIFF
--- a/src/fields.c
+++ b/src/fields.c
@@ -685,7 +685,7 @@ static enum result reject_unsafe_default(PyObject * const field_name, PyObject *
 	Py_ssize_t const filled = struct_copies_default(kind) ? PyObject_Size(value) : 0;
 
 	if (filled <= 0) {
-		return filled < 0 ? RESULT_ERROR : refuse_shared_mutable_contents(field_name, value);
+		return filled < 0 ? RESULT_ERROR : RESULT_OK;
 	}
 
 	PyErr_Format(
@@ -719,13 +719,14 @@ static enum result refuse_shared_mutable_contents(
 		return RESULT_OK;
 	}
 
-	if (PyObject_Hash(value) != -1) {
+	if (PyObject_Hash(value) != -1 || !PyErr_Occurred()) {
 		return RESULT_OK;
 	}
 
 	/* A writable memoryview answers ValueError where a tuple of lists answers
-	 * TypeError, and anything else -- a MemoryError, an interrupt -- is not the
-	 * instance declining and is left to propagate. */
+	 * TypeError, and anything else -- a MemoryError, an interrupt, whatever a
+	 * class author's own __hash__ raises -- is not the instance declining and
+	 * propagates with its own message rather than being read as this. */
 	if (!PyErr_ExceptionMatches(PyExc_TypeError) && !PyErr_ExceptionMatches(PyExc_ValueError)) {
 		return RESULT_ERROR;
 	}
@@ -734,9 +735,10 @@ static enum result refuse_shared_mutable_contents(
 
 	PyErr_Format(
 		PyExc_TypeError,
-		"field '%U' defaults to a %.100s that cannot be hashed, so it holds "
-		"something mutable that every instance would share; default it to one "
-		"that can be, and build the rest with set_field -- from __post_init__, "
+		"field '%U' defaults to a %.100s whose type hashes and whose value will "
+		"not, which is how a container of something mutable answers; salix "
+		"shares such a default across every instance, so give the field one "
+		"that hashes and build the rest with set_field -- from __post_init__, "
 		"or from your own __init__ if the body writes one",
 		field_name,
 		kind->tp_name
@@ -807,7 +809,11 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 
 		PyObject * const stored = struct_default_copy(value);
 
-		if (stored == NULL || reject_unsafe_default(field_name, stored) != RESULT_OK) {
+		if (
+			stored == NULL ||
+			reject_unsafe_default(field_name, stored) != RESULT_OK ||
+			refuse_shared_mutable_contents(field_name, stored) != RESULT_OK
+		) {
 			Py_XDECREF(stored);
 			Py_DECREF(defaults);
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -77,6 +77,7 @@ static struct special_form named_special_form(PyObject * text, struct form_probe
 static bool names_form(PyObject * text, PyObject * needle);
 static bool continues_identifier(Py_UCS4 character);
 static PyObject * module_attribute(char const * module_name, char const * attribute);
+static enum result refuse_shared_mutable_contents(PyObject * field_name, PyObject * value);
 
 /* The plan only takes references once every step has succeeded; the working
  * collections belong to this scope either way. */
@@ -684,7 +685,7 @@ static enum result reject_unsafe_default(PyObject * const field_name, PyObject *
 	Py_ssize_t const filled = struct_copies_default(kind) ? PyObject_Size(value) : 0;
 
 	if (filled <= 0) {
-		return filled < 0 ? RESULT_ERROR : RESULT_OK;
+		return filled < 0 ? RESULT_ERROR : refuse_shared_mutable_contents(field_name, value);
 	}
 
 	PyErr_Format(
@@ -694,6 +695,49 @@ static enum result reject_unsafe_default(PyObject * const field_name, PyObject *
 		"one and fill it with set_field -- from __post_init__, or from your own "
 		"__init__ if the body writes one, which displaces the constructor "
 		"__post_init__ runs from",
+		field_name,
+		kind->tp_name
+	);
+
+	return RESULT_ERROR;
+}
+
+/*
+ * A type that says it hashes and an instance that then refuses is a container
+ * whose contents are mutable, and salix shares such a default across every
+ * instance. The four copied types answer above; a deque or an array declares
+ * __hash__ = None, says so before being asked, and is left shared as msgspec
+ * leaves it.
+ */
+static enum result refuse_shared_mutable_contents(
+	PyObject * const field_name,
+	PyObject * const value
+) {
+	PyTypeObject * const kind = Py_TYPE(value);
+
+	if (kind->tp_hash == NULL || kind->tp_hash == PyObject_HashNotImplemented) {
+		return RESULT_OK;
+	}
+
+	if (PyObject_Hash(value) != -1) {
+		return RESULT_OK;
+	}
+
+	/* A writable memoryview answers ValueError where a tuple of lists answers
+	 * TypeError, and anything else -- a MemoryError, an interrupt -- is not the
+	 * instance declining and is left to propagate. */
+	if (!PyErr_ExceptionMatches(PyExc_TypeError) && !PyErr_ExceptionMatches(PyExc_ValueError)) {
+		return RESULT_ERROR;
+	}
+
+	PyErr_Clear();
+
+	PyErr_Format(
+		PyExc_TypeError,
+		"field '%U' defaults to a %.100s that cannot be hashed, so it holds "
+		"something mutable that every instance would share; default it to one "
+		"that can be, and build the rest with set_field -- from __post_init__, "
+		"or from your own __init__ if the body writes one",
 		field_name,
 		kind->tp_name
 	);

--- a/src/fields.c
+++ b/src/fields.c
@@ -256,9 +256,15 @@ static enum result append_declared(
 		/* A default is the class-body value bound to the field name. */
 		PyObject * const declared_default = PyDict_GetItem(namespace, field_name);
 
+		/* Probed here rather than where the defaults tuple is built, because that
+		 * walks the inherited ones too and would re-ask every subclass creation.
+		 * A base's defaults answered when the base was built. */
 		if (
 			declared_default != NULL &&
-			PyDict_SetItem(default_by_name, field_name, declared_default) < 0
+			(
+				PyDict_SetItem(default_by_name, field_name, declared_default) < 0 ||
+				refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+			)
 		) {
 			return RESULT_ERROR;
 		}
@@ -723,6 +729,16 @@ static enum result refuse_shared_mutable_contents(
 		return RESULT_OK;
 	}
 
+	/* A value that holds itself runs the hash out of stack rather than declining
+	 * it, so the probe never reaches an answer. Sharing is what it got before
+	 * there was a probe, and a frozen struct is safe to share whatever it points
+	 * at -- including itself. */
+	if (PyErr_ExceptionMatches(PyExc_RecursionError)) {
+		PyErr_Clear();
+
+		return RESULT_OK;
+	}
+
 	/* A writable memoryview answers ValueError where a tuple of lists answers
 	 * TypeError, and anything else -- a MemoryError, an interrupt, whatever a
 	 * class author's own __hash__ raises -- is not the instance declining and
@@ -809,11 +825,7 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 
 		PyObject * const stored = struct_default_copy(value);
 
-		if (
-			stored == NULL ||
-			reject_unsafe_default(field_name, stored) != RESULT_OK ||
-			refuse_shared_mutable_contents(field_name, stored) != RESULT_OK
-		) {
+		if (stored == NULL || reject_unsafe_default(field_name, stored) != RESULT_OK) {
 			Py_XDECREF(stored);
 			Py_DECREF(defaults);
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -729,10 +729,12 @@ static enum result refuse_shared_mutable_contents(
 		return RESULT_OK;
 	}
 
-	/* A value that holds itself runs the hash out of stack rather than declining
-	 * it, so the probe never reaches an answer. Sharing is what it got before
-	 * there was a probe, and a frozen struct is safe to share whatever it points
-	 * at -- including itself. */
+	/* A hash that runs out of stack never reaches an answer -- a value holding
+	 * itself is the way that happens without anyone meaning it -- so this shares
+	 * whatever it cannot classify, which is what a deque or an array gets for
+	 * saying up front that it does not hash. It is the incomplete half of the
+	 * rule and not a guarantee: a mutable whose own hash recurses is shared too,
+	 * and tests/test_construction.py says so. */
 	if (PyErr_ExceptionMatches(PyExc_RecursionError)) {
 		PyErr_Clear();
 
@@ -740,9 +742,9 @@ static enum result refuse_shared_mutable_contents(
 	}
 
 	/* A writable memoryview answers ValueError where a tuple of lists answers
-	 * TypeError, and anything else -- a MemoryError, an interrupt, whatever a
-	 * class author's own __hash__ raises -- is not the instance declining and
-	 * propagates with its own message rather than being read as this. */
+	 * TypeError, and anything else that is not the stack -- a MemoryError, an
+	 * interrupt, whatever a class author's own __hash__ raises -- is not the
+	 * instance declining and propagates rather than being read as this. */
 	if (!PyErr_ExceptionMatches(PyExc_TypeError) && !PyErr_ExceptionMatches(PyExc_ValueError)) {
 		return RESULT_ERROR;
 	}

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -3,7 +3,7 @@
 import pytest
 from values import COPIED_WHEN_EMPTY, NON_EMPTY
 
-from salix import Struct
+from salix import Struct, set_field
 
 
 class Point(Struct):
@@ -379,6 +379,51 @@ class TestMutableDefaults:
 
         assert calls == [1]
         assert Holder().v is value
+
+    def test_a_subclass_does_not_re_probe_an_inherited_default(self):
+        """`build_defaults` walks the inherited defaults too, so probing there
+        re-asked every default on every subclass creation -- and a `__hash__`
+        that answers differently over time could then flip `class Child(Base):
+        pass` to refused. The probe reads what this body declares, and a base's
+        defaults answered when the base was built.
+        """
+
+        calls = []
+
+        class Counted:
+            def __hash__(self) -> int:
+                calls.append(1)
+                return 7
+
+        class Base(Struct):
+            v: object = Counted()
+
+        class Child(Base):
+            pass
+
+        class Grandchild(Child):
+            pass
+
+        assert calls == [1]
+        assert Grandchild().v is Base().v
+
+    def test_a_value_that_holds_itself_is_shared_rather_than_refused(self):
+        """A frozen struct pointing at itself, built through `set_field`, runs
+        the hash out of stack instead of declining it -- so the probe never
+        reaches an answer. Sharing is what it got before there was a probe, and
+        a frozen struct is safe to share whatever it points at, itself included.
+        """
+
+        class Loop(Struct):
+            v: object = None
+
+        loop = Loop(None)
+        set_field(loop, "v", loop)
+
+        class Holder(Struct):
+            w: object = loop
+
+        assert Holder().w is loop
 
     def test_a_hash_that_fails_for_its_own_reasons_propagates_unchanged(self):
         """The probe reads TypeError and ValueError as the instance declining.

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -331,7 +331,7 @@ class TestMutableDefaults:
         does.
         """
 
-        with pytest.raises(TypeError, match="cannot be hashed"):
+        with pytest.raises(TypeError, match="whose value will not"):
 
             class Holder(Struct):
                 v: object = value
@@ -358,6 +358,46 @@ class TestMutableDefaults:
         assert Holder().v is value
         assert Holder().v is Holder().v
 
+    def test_the_probe_hashes_a_default_once(self):
+        """`build_defaults` checks the declared value and then the stored copy,
+        which for anything outside the four copied types is the same object. The
+        hash probe runs on the stored one only, so a class author's `__hash__`
+        is called once rather than twice.
+        """
+
+        calls = []
+
+        class Counted:
+            def __hash__(self) -> int:
+                calls.append(1)
+                return 7
+
+        value = Counted()
+
+        class Holder(Struct):
+            v: object = value
+
+        assert calls == [1]
+        assert Holder().v is value
+
+    def test_a_hash_that_fails_for_its_own_reasons_propagates_unchanged(self):
+        """The probe reads TypeError and ValueError as the instance declining.
+        Anything else is not that, and salix says so with the author's own
+        exception rather than claiming the value holds something mutable.
+
+        A deliberate consequence: such a class used to build and share the
+        value, and now does not.
+        """
+
+        class Angry:
+            def __hash__(self) -> int:
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+
+            class Holder(Struct):
+                v: object = Angry()
+
     def test_a_writable_memoryview_answers_ValueError_and_is_still_caught(self):
         """The trap: the probe is a hash that raises, and a writable memoryview
         raises ValueError where a tuple of lists raises TypeError. Catching only
@@ -368,7 +408,7 @@ class TestMutableDefaults:
         with pytest.raises(ValueError, match="cannot hash writable"):
             hash(memoryview(bytearray(b"abc")))
 
-        with pytest.raises(TypeError, match="cannot be hashed"):
+        with pytest.raises(TypeError, match="whose value will not"):
 
             class Holder(Struct):
                 v: object = memoryview(bytearray(b"abc"))

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -425,6 +425,35 @@ class TestMutableDefaults:
 
         assert Holder().w is loop
 
+    def test_a_mutable_whose_own_hash_recurses_is_shared_too(self):
+        """The price of sharing what the probe cannot classify, pinned rather
+        than left to be discovered: this one really is the aliasing bug, and it
+        gets through because a stack overflow is indistinguishable from the
+        self-referential struct above.
+
+        It is where the rule already stood -- a deque, an array and a
+        defaultdict are shared while holding mutables for the same reason, by
+        saying up front that they do not hash.
+        """
+
+        class RecursiveHash:
+            def __init__(self) -> None:
+                self.items: list[str] = []
+
+            def __hash__(self) -> int:
+                return hash(self)
+
+        value = RecursiveHash()
+
+        class Holder(Struct):
+            v: object = value
+
+        assert Holder().v is value
+
+        value.items.append("seen by every instance")
+
+        assert Holder().v.items == ["seen by every instance"]
+
     def test_a_hash_that_fails_for_its_own_reasons_propagates_unchanged(self):
         """The probe reads TypeError and ValueError as the instance declining.
         Anything else is not that, and salix says so with the author's own

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -276,7 +276,7 @@ class TestMutableDefaults:
         [
             pytest.param(__import__("array").array("i", [1, 2]), id="array"),
             pytest.param(__import__("collections").deque([1, 2]), id="deque"),
-            pytest.param(memoryview(bytearray(b"abc")), id="memoryview"),
+            pytest.param(__import__("collections").defaultdict(list), id="defaultdict"),
             pytest.param(Mutable(1), id="a_mutable_struct"),
             *(
                 pytest.param(subclass_of(kind)(NON_EMPTY[kind]), id=f"a_{kind.__name__}_subclass")
@@ -286,9 +286,10 @@ class TestMutableDefaults:
     )
     def test_a_mutable_container_outside_the_four_is_shared_and_not_refused(self, value):
         """The boundary is the four exact types, not mutability, so these are
-        neither copied nor refused. Every one is unhashable, which is the test
-        #51 argues should replace the list -- salix's own `frozen=False` struct
-        included, since `eq` without `frozen` sets `__hash__` to None.
+        neither copied nor refused. Every one of these declares `__hash__` is
+        None -- it says it does not hash before being asked -- which is what
+        #51's rule leaves alone; salix's own `frozen=False` struct included,
+        since `eq` without `frozen` sets `__hash__` to None.
 
         The four subclasses are the sharpest of them: a *non-empty* subclass of
         a type the refusal covers is shared outright, which is the aliasing bug
@@ -309,6 +310,68 @@ class TestMutableDefaults:
 
         assert Holder().v is Holder().v
         assert Holder._struct_defaults_[0] is value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(([],), id="a_tuple_of_a_list"),
+            pytest.param(((1, []),), id="a_tuple_two_deep"),
+            pytest.param(memoryview(bytearray(b"abc")), id="a_writable_memoryview"),
+            pytest.param((frozenset(), []), id="a_pair_holding_one_of_each"),
+        ],
+    )
+    def test_a_shallowly_immutable_container_of_something_mutable_is_refused(self, value):
+        """#51's addition to the rule. A tuple is not one of the four, so it was
+        shared outright -- and `xs: object = ([],)` handed every instance the
+        same inner list, which is the aliasing bug the four-type rule exists to
+        stop, one level down and outside its reach.
+
+        The type says it hashes and the instance then refuses, which is exactly
+        what a container of something mutable does and what nothing immutable
+        does.
+        """
+
+        with pytest.raises(TypeError, match="cannot be hashed"):
+
+            class Holder(Struct):
+                v: object = value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param((1, 2), id="a_tuple_of_ints"),
+            pytest.param("text", id="a_string"),
+            pytest.param(frozenset({1}), id="a_frozenset"),
+            pytest.param(memoryview(b"abc"), id="a_read_only_memoryview"),
+            pytest.param(Point(1, 2), id="a_frozen_struct"),
+        ],
+    )
+    def test_an_immutable_container_is_still_shared(self, value):
+        """The control. Every one of these hashes, so none of them can be
+        holding anything mutable, and sharing is right: there is nothing an
+        instance could do to one that another instance would see.
+        """
+
+        class Holder(Struct):
+            v: object = value
+
+        assert Holder().v is value
+        assert Holder().v is Holder().v
+
+    def test_a_writable_memoryview_answers_ValueError_and_is_still_caught(self):
+        """The trap: the probe is a hash that raises, and a writable memoryview
+        raises ValueError where a tuple of lists raises TypeError. Catching only
+        TypeError would let it through and turn class creation into a ValueError
+        from nowhere.
+        """
+
+        with pytest.raises(ValueError, match="cannot hash writable"):
+            hash(memoryview(bytearray(b"abc")))
+
+        with pytest.raises(TypeError, match="cannot be hashed"):
+
+            class Holder(Struct):
+                v: object = memoryview(bytearray(b"abc"))
 
     def test_a_body_init_does_not_exempt_the_declared_default(self):
         """Its constructor never reads the default, so nothing is shared -- but

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -14,6 +14,7 @@ from values import (
     Inner,
     Outer,
     identify,
+    refused_as_default,
 )
 
 from salix import Struct
@@ -42,6 +43,14 @@ def test_a_value_may_be_a_default(value):
         with pytest.raises(TypeError, match="non-empty"):
 
             class Refused(Struct):
+                field: object = value
+
+        return
+
+    if refused_as_default(value):
+        with pytest.raises(TypeError, match="cannot be hashed"):
+
+            class SharesContents(Struct):
                 field: object = value
 
         return

--- a/tests/test_field_values.py
+++ b/tests/test_field_values.py
@@ -48,7 +48,7 @@ def test_a_value_may_be_a_default(value):
         return
 
     if refused_as_default(value):
-        with pytest.raises(TypeError, match="cannot be hashed"):
+        with pytest.raises(TypeError, match="whose value will not"):
 
             class SharesContents(Struct):
                 field: object = value

--- a/tests/values.py
+++ b/tests/values.py
@@ -157,6 +157,40 @@ assert all(
 )
 
 
+def _shares_mutable_contents(value: object) -> bool:
+    """The type says it hashes and the instance then refuses, which is how a
+    container of something mutable answers. `refuse_shared_mutable_contents` in
+    src/fields.c is what this mirrors. ValueError as well as TypeError: a
+    writable memoryview raises the first.
+    """
+
+    if type(value).__hash__ is None:
+        return False
+
+    try:
+        hash(value)
+    except (TypeError, ValueError):
+        return True
+
+    return False
+
+
+# What salix refuses as a class-body default for holding something mutable that
+# every instance would otherwise share. Selected from EVERY rather than built
+# fresh, because the callers below test identity against the parametrized value.
+REFUSED_AS_DEFAULT = tuple(value for value in EVERY if _shares_mutable_contents(value))
+
+# The membership, stated rather than left to the rule, so widening or narrowing
+# the rule has to come here and say so. A writable memoryview is the only value
+# in the set whose type claims a hash that the instance then refuses; everything
+# else unhashable here declares __hash__ = None before being asked.
+assert [type(value).__name__ for value in REFUSED_AS_DEFAULT] == ["memoryview"]
+
+
+def refused_as_default(value: object) -> bool:
+    return any(value is refused for refused in REFUSED_AS_DEFAULT)
+
+
 def identify(value: object) -> str:
     """A stable, readable parametrize id for values whose repr is unwieldy."""
 


### PR DESCRIPTION
Closes #51.

`xs: object = ([],)` handed every instance the **same inner list**. A tuple is not one of the four types the copy rule covers, so it was shared outright — the aliasing bug that rule exists to stop, one level down and outside its reach.

This is the narrow version you ruled on 2026-08-08: keep the four types exactly as they are, and additionally refuse only the container-of-mutables case.

## The discriminator, re-measured against this `main` before writing anything

The type claims a hash and the instance then declines:

| default | type claims | `hash()` | before | now |
| --- | --- | --- | --- | --- |
| `([],)` | yes | `TypeError` | shared | **refused** |
| `((1, []),)` | yes | `TypeError` | shared | **refused** |
| `memoryview(bytearray())` | yes | **`ValueError`** | shared | **refused** |
| `(1, 2)`, `'text'`, `frozenset()`, `memoryview(b'')` | yes | ok | shared | shared |
| `deque()`, `defaultdict(list)`, `array('i')` | **no** | raises | shared | shared |
| `[]` | no | raises | copied | copied |

The last two rows are why the **type** is asked first. A deque, an array or a mutable struct sets `__hash__ = None` — it says it does not hash before being asked — and is left shared, which is where msgspec leaves it and what the ruling keeps.

**A writable memoryview raises `ValueError`, not `TypeError`.** Catching only the second lets it through and turns class creation into a `ValueError` from nowhere. Anything that is neither — a `MemoryError`, an interrupt — is not the instance declining, and propagates unchanged.

<details>
<summary><b>Two mutations, each its own build</b></summary>

**Remove the type-claims guard** — 27 failures, the shared-and-not-refused controls among them:

```
FAILED test_a_value_may_be_a_default[dict] [set] [bytearray] [array] [Mutable] ...
FAILED test_refcounts.py::test_a_copied_default_hands_out_no_reference_to_itself
27 failed, 953 passed
```

**Drop `ValueError` from the catch** — three failures, and the raw error escapes into class creation, which is the whole reason the trap is worth a test of its own:

```
E   ValueError: cannot hash writable memoryview object
3 failed, 977 passed
```

</details>

<details>
<summary><b>Cost: two prebuilt <code>.so</code> files swapped between interleaved runs</b></summary>

30 defaulted tuple fields, µs per class:

```
before  13.81   13.63   13.51
after   13.78   14.38   13.97
```

The ranges overlap, so this is at most a few percent and three pairs cannot resolve it further — stated as measured rather than as "no cost". A class declaring **no** defaults pays nothing (5.4 either way). A tuple caches its hash, so the second call on the stored copy is free.

</details>

<details>
<summary><b>What moved in the tests, and one thing I got wrong first</b></summary>

`tests/values.py` gains `REFUSED_AS_DEFAULT`, **selected out of `EVERY`** rather than built fresh so callers can test identity, with the membership written out and asserted:

```python
assert [type(value).__name__ for value in REFUSED_AS_DEFAULT] == ["memoryview"]
```

Getting that wrong was the first thing that happened: the tuple held a *second* memoryview with the same contents, the identity test never matched the one in `EVERY`, and the drift assertion fired at import. It was the assertion doing its job on its first run.

Two existing tests move rather than break. A writable memoryview was listed as shared-and-not-refused and is now refused, so it leaves that parametrize and gets its own. The surrounding docstring said *"every one is unhashable, which is the test #51 argues should replace the list"* — true of the rule as it was, not of the one you ruled. What those values have in common now is that their **types** declare `__hash__ = None`.

</details>

`check` 25/25 across 3.10–3.15 and 3.14t, `flake_check` green.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins, who asked me to proceed to the next phase and drive its PRs to merge. This implements the narrower of the two options she approved for #51.
