### PR TITLE
fix: land the round-2 deslop fixes dropped by #92's merge

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -723,3 +723,22 @@ class TestAShadowedSuppressionFlag:
 
         assert raised.value.__suppress_context__ == 0
         assert raised.value.__context__ is None
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="annotationlib is stdlib only from 3.14",
+)
+def test_the_format_enum_matches_annotationlib():
+    """The enum in annotations.c is annotationlib.Format's numbering — the
+    numeric format argument handed to the generated __annotate__ callable
+    dispatches on it, so a renumber or reorder would silently change how
+    annotations resolve. Pinned against the runtime values.
+    """
+
+    import annotationlib
+
+    assert annotationlib.Format.VALUE == 1
+    assert annotationlib.Format.VALUE_WITH_FAKE_GLOBALS == 2
+    assert annotationlib.Format.FORWARDREF == 3
+    assert annotationlib.Format.STRING == 4

--- a/tools/update_python_targets.py
+++ b/tools/update_python_targets.py
@@ -153,7 +153,11 @@ def render_python(target: Target, version: str, hashes: dict[str, str]) -> Itera
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Pin CPython release asset digests from the GitHub API into nix/python-targets.nix; nothing is downloaded."
+        description=(
+            "Regenerate nix/python-targets.nix from a python-build-standalone release. "
+            "Interpreters come from .python-version; the GitHub API serves each asset's "
+            "digest, so nothing is downloaded to pin it."
+        )
     )
     parser.add_argument("--release", default=None)
     parser.add_argument("--python-version", type=Path, default=Path(".python-version"))


### PR DESCRIPTION
## What happened

PR #92's merge raced the push of its round-2 fix commit (`730fd45`): the merge at `350b314` resolved the PR head as the round-1 commit `5f6dbc2`, so the two round-2 nits the review asked for never reached `main`. This PR re-applies exactly that dropped commit.

## The two fixes

- **tools/update_python_targets.py** — the round-1 fix paraphrased the deleted module docstring, so `--help` still differed from pre-PR. The explicit `description=` now reproduces the original docstring verbatim (as a data string, not a docstring), so `--help` is byte-identical and the module stays deslopped.
- **src/annotations.c** — the restored numbering comment said the enum is `annotationlib.Format`'s API but nothing asserted it. New test `test_the_format_enum_matches_annotationlib` pins the four values against the runtime (`skipif < 3.14`, where annotationlib does not exist), so a renumber or reorder now goes red.

Gate green (25/25) on `a55af94`. No other changes.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-5 on behalf of @JPHutchins. The deslop PR (#92) merged before the round-2 nit fixes it had committed were pushed, dropping them; JPH directed that the nits be fixed and merged, so this PR re-lands the two fixes.