### PR TITLE
feat: the reconstruction and reduce layer — copy/deepcopy, getnewargs, completeness (rest of #13, slice B)

### DIFF
--- a/src/construct.c
+++ b/src/construct.c
@@ -5,6 +5,22 @@
 #include "result.h"
 #include "types.h"
 
+/* Py_TPFLAGS_INLINE_VALUES and Py_TPFLAGS_MANAGED_DICT joined the public
+ * object.h in 3.13 and 3.11 respectively; the flag values have been stable, so
+ * they are spelled here rather than gated on the public header. */
+enum {
+	STRUCT_TPFLAGS_INLINE_VALUES = 1 << 2,
+	STRUCT_TPFLAGS_MANAGED_DICT = 1 << 4,
+};
+
+/* A heap type's instance dict lives just before the object header on a
+ * managed-dict build (3.11+). Reading it directly, rather than through
+ * _PyObject_GetDictPtr, avoids materializing an inline-values dict: that
+ * helper creates and stores one for a null slot, which would make __getstate__
+ * mutate the instance. The offset is CPython's MANAGED_DICT_OFFSET. */
+
+_Thread_local PyTypeObject * struct_reconstruction_type = NULL;
+
 struct field_lookup {
 	enum { FIELD_LOOKUP_FOUND, FIELD_LOOKUP_MISSING, FIELD_LOOKUP_ERROR } tag;
 	Py_ssize_t index;
@@ -42,6 +58,23 @@ static enum result write_slot(
 	PyObject * value
 );
 static enum result run_post_init(StructType const * type, PyObject * self);
+static PyObject * instance_dict_owned(PyObject * self);
+static PyObject * instance_dict_ref(PyObject * self);
+static enum result resolve_state(
+	StructType const * type,
+	PyObject * values,
+	PyObject * unset_names,
+	Py_ssize_t * * const values_indices,
+	PyObject * * const value_snapshot,
+	Py_ssize_t * * const unset_indices
+);
+static enum result require_restore_complete(
+	StructType const * type,
+	PyObject * self,
+	Py_ssize_t const * unset_indices,
+	Py_ssize_t unset_count,
+	bool declares_getnewargs
+);
 
 PyObject * Struct_vectorcall(
 	PyObject * const struct_class,
@@ -85,22 +118,93 @@ PyObject * Struct_vectorcall(
 	return py_move(&self);
 }
 
+static enum result bind_reconstruction(
+	StructType const * const type,
+	PyObject * const self,
+	PyObject * const arguments,
+	PyObject * const keywords
+) {
+	Py_ssize_t const positional_count = PyTuple_GET_SIZE(arguments);
+
+	if (positional_count > type->struct_field_count) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"%.200s() takes at most %zd positional arguments but %zd were given",
+			struct_type_name(type),
+			type->struct_field_count,
+			positional_count
+		);
+
+		return RESULT_ERROR;
+	}
+
+	for (Py_ssize_t i = 0; i < positional_count; ++i) {
+		*struct_slot(type, self, i) = Py_NewRef(PyTuple_GET_ITEM(arguments, i));
+	}
+
+	if (keywords == NULL) {
+		return RESULT_OK;
+	}
+
+	Py_ssize_t position = 0;
+	PyObject * name = NULL;
+	PyObject * value = NULL;
+
+	while (PyDict_Next(keywords, &position, &name, &value)) {
+		struct field_lookup const found = find_field(type, name);
+
+		switch (found.tag) {
+			case FIELD_LOOKUP_ERROR:
+				return RESULT_ERROR;
+			case FIELD_LOOKUP_MISSING:
+				PyErr_Format(
+					PyExc_TypeError,
+					"%.200s() got an unexpected keyword argument '%U'",
+					struct_type_name(type),
+					name
+				);
+
+				return RESULT_ERROR;
+			case FIELD_LOOKUP_FOUND:
+				break;
+		}
+
+		PyObject * * const slot = struct_slot(type, self, found.index);
+
+		if (*slot != NULL) {
+			/* The redundant half of a __getnewargs_ex__ that returns the same
+			 * field both positionally and by keyword; the positional wins. */
+			continue;
+		}
+
+		*slot = Py_NewRef(value);
+	}
+
+	return RESULT_OK;
+}
+
 PyObject * Struct_new(
 	PyTypeObject * const struct_class,
 	PyObject * const arguments,
 	PyObject * const keywords
 ) {
-	if (!defines_own_init((StructType *) struct_class)) {
-		Py_ssize_t const argument_count = (
-			PyTuple_GET_SIZE(arguments) +
-			(keywords != NULL ? PyDict_GET_SIZE(keywords) : 0)
-		);
+	StructType * const type = (StructType *) struct_class;
+	bool const body_init = defines_own_init(type);
+	Py_ssize_t const argument_count = (
+		PyTuple_GET_SIZE(arguments) +
+		(keywords != NULL ? PyDict_GET_SIZE(keywords) : 0)
+	);
+	bool declares = false;
+	bool declares_ex = false;
 
-		if (argument_count > 0) {
-			PyErr_Format(PyExc_TypeError, "%.200s() takes no arguments", struct_class->tp_name);
+	if (struct_probe_getnewargs(struct_class, &declares, &declares_ex) < 0) {
+		return NULL;
+	}
 
-			return NULL;
-		}
+	if (argument_count > 0 && !body_init && !declares) {
+		PyErr_Format(PyExc_TypeError, "%.200s() takes no arguments", struct_class->tp_name);
+
+		return NULL;
 	}
 
 	PY_MOVABLE(self, struct_class->tp_alloc(struct_class, 0));
@@ -109,7 +213,39 @@ PyObject * Struct_new(
 		return NULL;
 	}
 
-	StructType const * const type = (StructType *) struct_class;
+	if (declares && argument_count > 0 && (struct_reconstructing(struct_class) || !body_init)) {
+		if (bind_reconstruction(type, self, arguments, keywords) != RESULT_OK) {
+			return NULL;
+		}
+	}
+
+	/* A bare __new__ call on a getnewargs-declaring struct must not silently
+	 * build a half-built struct: the arguments are all it will ever get, since
+	 * no __setstate__ follows a direct new. A reduce reconstruction raises the
+	 * marker and is exempt -- its state completes the fields -- and so is a body
+	 * __new__, whose super().__new__(cls) is called empty and which fills the
+	 * fields itself. */
+	if (
+		declares &&
+		!body_init &&
+		!struct_reconstructing(struct_class) &&
+		type->struct_body_new == NULL
+	) {
+		Py_ssize_t const required_count = struct_required_count(type);
+
+		for (Py_ssize_t i = 0; i < required_count; ++i) {
+			if (*struct_slot(type, self, i) == NULL) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"%.200s() missing required argument '%U'",
+					struct_class->tp_name,
+					PyTuple_GET_ITEM(type->struct_field_names, i)
+				);
+
+				return NULL;
+			}
+		}
+	}
 
 	return (
 		fill_defaults(type, self, struct_required_count(type)) == RESULT_OK ? py_move(&self) :
@@ -393,6 +529,90 @@ static enum result require_field(
 	Py_UNREACHABLE();
 }
 
+static PyObject * instance_dict_owned(PyObject * const self) {
+	PyObject * * const dict_slot = _PyObject_GetDictPtr(self);
+	PY_MOVABLE(dict, NULL);
+
+	STRUCT_BEGIN_CRITICAL_SECTION(self);
+	dict = Py_XNewRef(*dict_slot);
+
+	if (dict == NULL) {
+		dict = PyDict_New();
+
+		if (dict != NULL) {
+			*dict_slot = dict;
+			dict = Py_NewRef(dict);
+		}
+	}
+	STRUCT_END_CRITICAL_SECTION();
+
+	return py_move(&dict);
+}
+
+/* The existing instance dict, or NULL when the slot is empty. Unlike
+ * instance_dict_owned this never creates and stores one, so __getstate__
+ * stays observationally read-only: a struct with a null dict slot reports
+ * None for the third state element and the slot stays null. On a managed-dict
+ * build the pointer is read directly rather than through _PyObject_GetDictPtr,
+ * which would materialize and store an empty dict for an inline-values type. */
+static PyObject * instance_dict_ref(PyObject * const self) {
+	PY_MOVABLE(dict, NULL);
+
+	STRUCT_BEGIN_CRITICAL_SECTION(self);
+#if PY_VERSION_HEX >= 0x030B0000
+	if (Py_TYPE(self)->tp_flags & STRUCT_TPFLAGS_MANAGED_DICT) {
+#	ifdef Py_GIL_DISABLED
+		Py_ssize_t const offset = -((Py_ssize_t) sizeof(PyObject *));
+#	else
+		Py_ssize_t const offset = -3 * ((Py_ssize_t) sizeof(PyObject *));
+#	endif
+
+		dict = Py_XNewRef(*(PyObject * *) ((char *) self + offset));
+	} else
+#endif
+	{
+		PyObject * * const dict_slot = _PyObject_GetDictPtr(self);
+		dict = Py_XNewRef(dict_slot != NULL ? *dict_slot : NULL);
+	}
+	STRUCT_END_CRITICAL_SECTION();
+
+	if (dict != NULL) {
+		return py_move(&dict);
+	}
+
+	/* A managed-dict type with inline values holds instance attributes behind
+	 * a null dict pointer. _PyObject_GetDictPtr packs that inline-values area
+	 * into a dict on demand (3.13+) and stores it in the managed-dict slot, so
+	 * reading through it materializes the attributes. An empty materialization
+	 * is restored to the null slot so getstate stays read-only; the read and the
+	 * restore run under one acquisition so a concurrent writer cannot store
+	 * between the size check and the null restore. */
+#if PY_VERSION_HEX >= 0x030B0000
+	if (Py_TYPE(self)->tp_flags & STRUCT_TPFLAGS_INLINE_VALUES) {
+		PyObject * * const slot = _PyObject_GetDictPtr(self);
+		PyObject * materialized = NULL;
+
+		STRUCT_BEGIN_CRITICAL_SECTION(self);
+		materialized = slot != NULL ? *slot : NULL;
+
+		if (materialized != NULL && PyDict_GET_SIZE(materialized) == 0) {
+			*slot = NULL;
+			Py_DECREF(materialized);
+			materialized = NULL;
+		} else if (materialized != NULL) {
+			materialized = Py_NewRef(materialized);
+		}
+		STRUCT_END_CRITICAL_SECTION();
+
+		if (materialized != NULL) {
+			return materialized;
+		}
+	}
+#endif
+
+	return NULL;
+}
+
 PyObject * Struct_get_state(PyObject * const self, PyObject * const noargs) {
 	if (!is_struct(self)) {
 #if PY_VERSION_HEX >= 0x030B0000
@@ -404,7 +624,7 @@ PyObject * Struct_get_state(PyObject * const self, PyObject * const noargs) {
 
 		return PyObject_CallOneArg(method, self);
 #else
-		PY_MOVABLE(dict, struct_instance_dict_ref(self));
+		PY_MOVABLE(dict, instance_dict_ref(self));
 
 		if (dict == NULL) {
 			if (PyErr_Occurred()) {
@@ -428,11 +648,9 @@ PyObject * Struct_get_state(PyObject * const self, PyObject * const noargs) {
 
 	enum result collected = RESULT_OK;
 
-	STRUCT_BEGIN_CRITICAL_SECTION(self);
-
 	for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
 		PyObject * const name = PyTuple_GET_ITEM(type->struct_field_names, i);
-		PyObject * const value = *struct_slot(type, self, i);
+		PY_MOVABLE(value, struct_slot_ref(type, self, i));
 
 		if (value == NULL) {
 			if (PyList_Append(unset_names, name) < 0) {
@@ -445,8 +663,6 @@ PyObject * Struct_get_state(PyObject * const self, PyObject * const noargs) {
 		}
 	}
 
-	STRUCT_END_CRITICAL_SECTION();
-
 	if (collected != RESULT_OK) {
 		return NULL;
 	}
@@ -454,11 +670,7 @@ PyObject * Struct_get_state(PyObject * const self, PyObject * const noargs) {
 	PY_MOVABLE(instance_dict, NULL);
 
 	if (Py_TYPE(self)->tp_dictoffset != 0) {
-		PY_MOVABLE(dict, struct_instance_dict_ref(self));
-
-		if (dict == NULL && PyErr_Occurred()) {
-			return NULL;
-		}
+		PY_MOVABLE(dict, instance_dict_ref(self));
 
 		if (dict != NULL) {
 			instance_dict = PyDict_Copy(dict);
@@ -496,7 +708,7 @@ static enum result restore_unset(
 	return outcome;
 }
 
-static enum result validate_state(
+static enum result resolve_state(
 	StructType const * const type,
 	PyObject * const values,
 	PyObject * const unset_names,
@@ -605,6 +817,52 @@ error:
 	return RESULT_ERROR;
 }
 
+static enum result require_restore_complete(
+	StructType const * const type,
+	PyObject * const self,
+	Py_ssize_t const * const unset_indices,
+	Py_ssize_t const unset_count,
+	bool const declares_getnewargs
+) {
+	Py_ssize_t const required_count = struct_required_count(type);
+
+	/* A getnewargs reconstruction is complete only when every required field is
+	 * covered by its args and state together; a required field that stays unset
+	 * and is not explicitly named by the state is a half-built struct and must
+	 * not round-trip. A field the state names as unset is deliberately unset --
+	 * a del or a custom __setstate__ recompute -- and is preserved. A struct
+	 * that does not declare getnewargs keeps its partial states. */
+	for (Py_ssize_t i = 0; i < required_count; ++i) {
+		if (*struct_slot(type, self, i) != NULL) {
+			continue;
+		}
+
+		bool explicitly_unset = false;
+
+		for (Py_ssize_t u = 0; u < unset_count; ++u) {
+			if (unset_indices[u] == i) {
+				explicitly_unset = true;
+				break;
+			}
+		}
+
+		if (explicitly_unset || !declares_getnewargs) {
+			continue;
+		}
+
+		PyErr_Format(
+			PyExc_TypeError,
+			"%.200s() missing required argument '%U'",
+			struct_type_name(type),
+			PyTuple_GET_ITEM(type->struct_field_names, i)
+		);
+
+		return RESULT_ERROR;
+	}
+
+	return RESULT_OK;
+}
+
 PyObject * Struct_set_state(PyObject * const self, PyObject * const state) {
 	if (!is_struct(self)) {
 		if (state == Py_None) {
@@ -622,18 +880,8 @@ PyObject * Struct_set_state(PyObject * const self, PyObject * const state) {
 		if (dict != Py_None && !PyDict_Check(dict)) {
 			PyErr_Format(
 				PyExc_TypeError,
-				"__setstate__() dict element must be a dict or None, not %.200s",
-				Py_TYPE(dict)->tp_name
-			);
-
-			return NULL;
-		}
-
-		if (slots != NULL && slots != Py_None && !PyDict_Check(slots)) {
-			PyErr_Format(
-				PyExc_TypeError,
-				"__setstate__() slots element must be a dict, not %.200s",
-				Py_TYPE(slots)->tp_name
+				"__setstate__() argument 1 must be a dict, None, or (dict, slots) tuple, not %.200s",
+				Py_TYPE(state)->tp_name
 			);
 
 			return NULL;
@@ -660,6 +908,16 @@ PyObject * Struct_set_state(PyObject * const self, PyObject * const state) {
 		}
 
 		if (slots != NULL && slots != Py_None) {
+			if (!PyDict_Check(slots)) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"__setstate__() slots element must be a dict, not %.200s",
+					Py_TYPE(slots)->tp_name
+				);
+
+				return NULL;
+			}
+
 			PY_OWNED(items, PyDict_Items(slots));
 
 			if (items == NULL) {
@@ -736,7 +994,7 @@ PyObject * Struct_set_state(PyObject * const self, PyObject * const state) {
 	PY_MOVABLE(value_snapshot, NULL);
 
 	if (
-		validate_state(
+		resolve_state(
 			type,
 			values,
 			unset_names,
@@ -749,13 +1007,52 @@ PyObject * Struct_set_state(PyObject * const self, PyObject * const state) {
 		return NULL;
 	}
 
+	Py_ssize_t const value_count = PyList_GET_SIZE(value_snapshot);
+	Py_ssize_t const unset_count = PyTuple_GET_SIZE(unset_names);
+	enum result outcome = RESULT_OK;
+
+	for (Py_ssize_t i = 0; i < value_count; ++i) {
+		if (
+			write_slot(type, self, values_indices[i], PyList_GET_ITEM(value_snapshot, i)) !=
+			RESULT_OK
+		) {
+			outcome = RESULT_ERROR;
+			break;
+		}
+	}
+
+	if (outcome == RESULT_OK) {
+		for (Py_ssize_t u = 0; u < unset_count; ++u) {
+			if (restore_unset(type, self, unset_indices[u]) != RESULT_OK) {
+				outcome = RESULT_ERROR;
+				break;
+			}
+		}
+	}
+
+	if (outcome == RESULT_OK) {
+		bool declares = false;
+		bool declares_ex = false;
+
+		if (struct_probe_getnewargs((PyTypeObject *) type, &declares, &declares_ex) < 0) {
+			outcome = RESULT_ERROR;
+		} else {
+			outcome = require_restore_complete(type, self, unset_indices, unset_count, declares);
+		}
+	}
+
+	PyMem_Free(values_indices);
+	PyMem_Free(unset_indices);
+
+	if (outcome != RESULT_OK) {
+		return NULL;
+	}
+
 	if (Py_TYPE(self)->tp_dictoffset != 0) {
 		if (instance_dict == Py_None) {
-			PY_MOVABLE(dict, struct_instance_dict_ref(self));
+			PY_MOVABLE(dict, instance_dict_ref(self));
 
 			if (dict == NULL && PyErr_Occurred()) {
-				PyMem_Free(values_indices);
-				PyMem_Free(unset_indices);
 				return NULL;
 			}
 
@@ -773,51 +1070,40 @@ PyObject * Struct_set_state(PyObject * const self, PyObject * const state) {
 				STRUCT_END_CRITICAL_SECTION();
 			}
 		} else {
-			PY_MOVABLE(dict, struct_instance_dict_ref(self));
+			PY_MOVABLE(dict, instance_dict_owned(self));
 
-			if (dict == NULL && PyErr_Occurred()) {
-				PyMem_Free(values_indices);
-				PyMem_Free(unset_indices);
+			if (dict == NULL) {
 				return NULL;
 			}
 
-			if (dict == NULL || instance_dict != dict) {
+			/* The clear and the swap both mutate the instance's dict storage, so
+			 * each runs under the instance's critical section (the same lock a
+			 * concurrent writer's attr store takes) -- otherwise a writer's store
+			 * landing between the read and the mutation is silently dropped. The
+			 * replacement is built up front and swapped only on full success, so a
+			 * failing merge leaves the instance untouched; the swap replaces the
+			 * dict object and strands external references, the accepted cost of
+			 * atomicity. The None branch clears in place. */
+			if (instance_dict != dict) {
 				PY_MOVABLE(fresh, PyDict_New());
 
 				if (fresh == NULL || PyDict_Update(fresh, instance_dict) < 0) {
-					PyMem_Free(values_indices);
-					PyMem_Free(unset_indices);
 					return NULL;
 				}
 
+				int swapped;
+
 				STRUCT_BEGIN_CRITICAL_SECTION(self);
-				PyObject_GenericSetDict(self, fresh, NULL);
+				swapped = PyObject_GenericSetDict(self, fresh, NULL);
 				STRUCT_END_CRITICAL_SECTION();
+
+				if (swapped < 0) {
+					return NULL;
+				}
 			}
 		}
 	}
 
-	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(value_snapshot); ++i) {
-		if (
-			write_slot(type, self, values_indices[i], PyList_GET_ITEM(value_snapshot, i)) !=
-			RESULT_OK
-		) {
-			PyMem_Free(values_indices);
-			PyMem_Free(unset_indices);
-			return NULL;
-		}
-	}
-
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(unset_names); ++i) {
-		if (restore_unset(type, self, unset_indices[i]) != RESULT_OK) {
-			PyMem_Free(values_indices);
-			PyMem_Free(unset_indices);
-			return NULL;
-		}
-	}
-
-	PyMem_Free(values_indices);
-	PyMem_Free(unset_indices);
 	Py_RETURN_NONE;
 }
 

--- a/src/meta.c
+++ b/src/meta.c
@@ -135,7 +135,24 @@ static enum result reject_unless_planned(
 	struct options options
 );
 static enum result install_post_init(StructType * struct_class);
+static int is_reconstruction_shape(
+	StructType const * struct_class,
+	PyObject * rest,
+	PyObject * keywords
+);
+static PyObject * dispatch_new(
+	StructType * struct_class,
+	PyTypeObject * subtype,
+	PyObject * rest,
+	PyObject * keywords
+);
 static PyObject * Struct_new_wrapper(PyObject * self, PyObject * arguments, PyObject * keywords);
+static PyObject * Struct_new_thunk(
+	PyTypeObject * struct_class,
+	PyObject * arguments,
+	PyObject * keywords
+);
+static bool is_struct_new_wrapper(PyObject * wrapper);
 static PyMethodDef struct_new_methoddef[];
 static enum result install_new_wrapper(StructType * struct_class);
 static PyObject * StructMeta_call(PyObject * self, PyObject * args, PyObject * keywords);
@@ -1117,16 +1134,102 @@ static enum result install_fields(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = resolves_body_eq;
 
-	struct_class->heap_type.ht_type.tp_new = Struct_new;
-
-	if (!defines_own_init(struct_class)) {
-		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
+	if (install_new_wrapper(struct_class) != RESULT_OK) {
+		return RESULT_ERROR;
 	}
 
-	return (
-		install_new_wrapper(struct_class) == RESULT_OK ? install_post_init(struct_class) :
-		RESULT_ERROR
-	);
+	PyTypeObject * const python_class = &struct_class->heap_type.ht_type;
+
+	if (struct_class->struct_body_new != NULL) {
+		python_class->tp_new = Struct_new_thunk;
+	} else {
+		python_class->tp_new = Struct_new;
+
+		if (!defines_own_init(struct_class)) {
+			python_class->tp_vectorcall = Struct_vectorcall;
+		}
+	}
+
+	return install_post_init(struct_class);
+}
+
+static int is_reconstruction_shape(
+	StructType const * const struct_class,
+	PyObject * const rest,
+	PyObject * const keywords
+) {
+	Py_ssize_t const extra = PyTuple_GET_SIZE(rest);
+	bool const has_keywords = keywords != NULL && PyDict_GET_SIZE(keywords) > 0;
+	bool declares = false;
+	bool declares_ex = false;
+
+	if (struct_probe_getnewargs(&struct_class->heap_type.ht_type, &declares, &declares_ex) < 0) {
+		return -1;
+	}
+
+	return ((extra > 0 && !has_keywords && declares) || (has_keywords && declares_ex));
+}
+
+static PyObject * dispatch_new(
+	StructType * const struct_class,
+	PyTypeObject * const subtype,
+	PyObject * const rest,
+	PyObject * const keywords
+) {
+	Py_ssize_t const extra = PyTuple_GET_SIZE(rest);
+
+	if (struct_class->struct_body_new != NULL) {
+		PY_OWNED(body_args, PyTuple_New(extra + 1));
+
+		if (body_args == NULL) {
+			return NULL;
+		}
+
+		PyTuple_SET_ITEM(body_args, 0, Py_NewRef(subtype));
+
+		for (Py_ssize_t i = 0; i < extra; ++i) {
+			PyTuple_SET_ITEM(body_args, i + 1, Py_NewRef(PyTuple_GET_ITEM(rest, i)));
+		}
+
+		/* A body __new__ that raises propagates the error; there is no fallback
+		 * to Struct_new on a TypeError. A body that cannot reconstruct must
+		 * accept the reconstruction arguments, or raise something other than
+		 * TypeError for a genuine rejection. */
+		return PyObject_Call(struct_class->struct_body_new, body_args, keywords);
+	}
+
+	bool const has_keywords = keywords != NULL && PyDict_GET_SIZE(keywords) > 0;
+	int const reconstruction_shape = is_reconstruction_shape(struct_class, rest, keywords);
+
+	if (reconstruction_shape < 0) {
+		return NULL;
+	}
+
+	if (has_keywords && !reconstruction_shape) {
+		PyErr_SetString(PyExc_TypeError, "__new__() takes no keyword arguments");
+
+		return NULL;
+	}
+
+	if (extra > 1 && !reconstruction_shape) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__new__() takes at most 1 excess positional argument but %zd were given",
+			extra
+		);
+
+		return NULL;
+	}
+
+	return Struct_new(subtype, rest, keywords);
+}
+
+static PyObject * Struct_new_thunk(
+	PyTypeObject * const struct_class,
+	PyObject * const arguments,
+	PyObject * const keywords
+) {
+	return dispatch_new((StructType *) struct_class, struct_class, arguments, keywords);
 }
 
 static PyObject * Struct_new_wrapper(
@@ -1134,12 +1237,6 @@ static PyObject * Struct_new_wrapper(
 	PyObject * const arguments,
 	PyObject * const keywords
 ) {
-	if (keywords != NULL && PyDict_GET_SIZE(keywords) > 0) {
-		PyErr_SetString(PyExc_TypeError, "__new__() takes no keyword arguments");
-
-		return NULL;
-	}
-
 	if (PyTuple_GET_SIZE(arguments) < 1) {
 		PyErr_SetString(PyExc_TypeError, "__new__() expected at least 1 argument");
 
@@ -1174,24 +1271,13 @@ static PyObject * Struct_new_wrapper(
 		return NULL;
 	}
 
-	if (defines_own_init((StructType *) subtype) && PyTuple_GET_SIZE(arguments) > 2) {
-		PyErr_Format(
-			PyExc_TypeError,
-			"%.200s.__new__() takes at most 2 positional arguments but %zd were given",
-			subtype->tp_name,
-			PyTuple_GET_SIZE(arguments)
-		);
-
-		return NULL;
-	}
-
 	PY_OWNED(rest, PyTuple_GetSlice(arguments, 1, PyTuple_GET_SIZE(arguments)));
 
 	if (rest == NULL) {
 		return NULL;
 	}
 
-	return ((PyTypeObject *) self)->tp_new(subtype, rest, keywords);
+	return dispatch_new((StructType *) self, subtype, rest, keywords);
 }
 
 static PyMethodDef struct_new_methoddef[] = {
@@ -1206,6 +1292,63 @@ static PyMethodDef struct_new_methoddef[] = {
 	{.ml_name = NULL},
 };
 
+static bool is_struct_new_wrapper(PyObject * const wrapper) {
+	return (
+		PyCFunction_Check(wrapper) &&
+		PyCFunction_GET_FUNCTION(wrapper) == _PyCFunction_CAST(Struct_new_wrapper)
+	);
+}
+
+static struct definition first_body_new(
+	PyObject * const base,
+	PyObject * const name,
+	PyObject * * const value
+) {
+	PyObject * const mro = ((PyTypeObject *) base)->tp_mro;
+
+	if (mro == NULL) {
+		return (struct definition){.tag = DEFINITION_READ, .found = false};
+	}
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyObject * const entry = PyTuple_GET_ITEM(mro, i);
+
+		if (entry == (PyObject *) &PyBaseObject_Type || entry == (PyObject *) &StructMixin_Type) {
+			continue;
+		}
+
+		PY_OWNED(dict, struct_type_dict((PyTypeObject *) entry));
+
+		if (dict == NULL) {
+			return (struct definition){.tag = DEFINITION_UNREADABLE};
+		}
+
+		PY_MOVABLE(bound, dict_value_ref(dict, name));
+
+		if (bound == NULL) {
+			if (PyErr_Occurred()) {
+				return (struct definition){.tag = DEFINITION_UNREADABLE};
+			}
+		} else if (!is_struct_new_wrapper(bound)) {
+			*value = py_move(&bound);
+
+			return (struct definition){.tag = DEFINITION_READ, .found = true};
+		}
+
+		if (is_struct_class(entry)) {
+			PyObject * const body = ((StructType *) entry)->struct_body_new;
+
+			if (body != NULL) {
+				*value = Py_NewRef(body);
+
+				return (struct definition){.tag = DEFINITION_READ, .found = true};
+			}
+		}
+	}
+
+	return (struct definition){.tag = DEFINITION_READ, .found = false};
+}
+
 static enum result install_new_wrapper(StructType * const struct_class) {
 	PY_OWNED(new_name, PyUnicode_InternFromString("__new__"));
 
@@ -1213,20 +1356,21 @@ static enum result install_new_wrapper(StructType * const struct_class) {
 		return RESULT_ERROR;
 	}
 
-	struct definition const defined = base_defines((PyObject *) struct_class, new_name);
-
-	if (defined.tag == DEFINITION_UNREADABLE) {
-		return RESULT_ERROR;
-	}
-
-	if (defined.found) {
-		return RESULT_OK;
-	}
-
 	PY_OWNED(dict, struct_type_dict(&struct_class->heap_type.ht_type));
 
 	if (dict == NULL) {
 		return RESULT_ERROR;
+	}
+
+	PY_MOVABLE(mro_new, NULL);
+	struct definition const found = first_body_new((PyObject *) struct_class, new_name, &mro_new);
+
+	if (found.tag == DEFINITION_UNREADABLE) {
+		return RESULT_ERROR;
+	}
+
+	if (found.found) {
+		struct_class->struct_body_new = py_move(&mro_new);
 	}
 
 	PY_OWNED(wrapper, PyCFunction_NewEx(struct_new_methoddef, (PyObject *) struct_class, NULL));
@@ -1243,10 +1387,35 @@ static PyObject * StructMeta_call(
 	PyObject * const args,
 	PyObject * const keywords
 ) {
-	return (
-		((PyTypeObject *) self)->tp_vectorcall != NULL ? PyVectorcall_Call(self, args, keywords) :
-		PyType_Type.tp_call(self, args, keywords)
-	);
+	if (((PyTypeObject *) self)->tp_vectorcall != NULL) {
+		return PyVectorcall_Call(self, args, keywords);
+	}
+
+	StructType * const type = (StructType *) self;
+
+	/* A body __new__ is the constructor; route construction through the same
+	 * dispatch the wrapper uses so a body error propagates. */
+	if (type->struct_body_new != NULL) {
+		PY_MOVABLE(obj, dispatch_new(type, (PyTypeObject *) self, args, keywords));
+
+		if (obj == NULL) {
+			return NULL;
+		}
+
+		if (!PyObject_TypeCheck(obj, (PyTypeObject *) self)) {
+			return py_move(&obj);
+		}
+
+		PyTypeObject * const instance_type = Py_TYPE(obj);
+
+		if (instance_type->tp_init != NULL && instance_type->tp_init(obj, args, keywords) < 0) {
+			return NULL;
+		}
+
+		return py_move(&obj);
+	}
+
+	return PyType_Type.tp_call(self, args, keywords);
 }
 
 static enum result install_post_init(StructType * const struct_class) {
@@ -1342,6 +1511,7 @@ static int StructMeta_traverse(PyObject * const self, visitproc const visit, voi
 	Py_VISIT(struct_class->struct_field_names);
 	Py_VISIT(struct_class->struct_defaults);
 	Py_VISIT(struct_class->struct_post_init);
+	Py_VISIT(struct_class->struct_body_new);
 
 	return PyType_Type.tp_traverse(self, visit, arg);
 }
@@ -1350,6 +1520,7 @@ static int StructMeta_clear(PyObject * const self) {
 	StructType * const struct_class = (StructType *) self;
 
 	Py_CLEAR(struct_class->struct_post_init);
+	Py_CLEAR(struct_class->struct_body_new);
 
 	if (struct_class->struct_field_names == NULL) {
 		return RESULT_OK;

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -4,6 +4,7 @@
 #include "construct.h"
 #include "hash.h"
 #include "mixin.h"
+#include "owned.h"
 #include "repr.h"
 #include "result.h"
 #include "types.h"
@@ -14,6 +15,8 @@ static PyObject * Struct_get_defaults(PyObject * self, void * closure);
 static PyObject * Struct_get_fields_as_msgspec(PyObject * self, void * closure);
 static PyObject * Struct_get_defaults_as_msgspec(PyObject * self, void * closure);
 static PyObject * metadata_of(PyObject * self, enum struct_metadata which, char const * name);
+static PyObject * Struct_deepcopy(PyObject * self, PyObject * memo);
+static PyObject * Struct_reduce_ex(PyObject * self, PyObject * args);
 static PyGetSetDef Struct_getset[];
 static PyMethodDef Struct_methods[];
 
@@ -64,6 +67,16 @@ static PyMethodDef Struct_methods[] = {
 		.ml_name = "__setstate__",
 		.ml_meth = Struct_set_state,
 		.ml_flags = METH_O,
+	},
+	{
+		.ml_name = "__deepcopy__",
+		.ml_meth = Struct_deepcopy,
+		.ml_flags = METH_O,
+	},
+	{
+		.ml_name = "__reduce_ex__",
+		.ml_meth = Struct_reduce_ex,
+		.ml_flags = METH_VARARGS,
 	},
 	{.ml_name = NULL},
 };
@@ -120,4 +133,618 @@ static PyObject * Struct_get_fields_as_msgspec(PyObject * const self, void * con
 
 static PyObject * Struct_get_defaults_as_msgspec(PyObject * const self, void * const closure) {
 	return metadata_of(self, STRUCT_DEFAULTS, "__struct_defaults__");
+}
+
+static PyObject * object_reduce_ex(PyObject * const self, PyObject * const args) {
+	PY_OWNED(reduce_ex, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__reduce_ex__"));
+
+	if (reduce_ex == NULL) {
+		return NULL;
+	}
+
+	PY_OWNED(call_args, PyTuple_New(PyTuple_GET_SIZE(args) + 1));
+
+	if (call_args == NULL) {
+		return NULL;
+	}
+
+	PyTuple_SET_ITEM(call_args, 0, Py_NewRef(self));
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(args); ++i) {
+		PyTuple_SET_ITEM(call_args, i + 1, Py_NewRef(PyTuple_GET_ITEM(args, i)));
+	}
+
+	return PyObject_Call(reduce_ex, call_args, NULL);
+}
+
+/* copyreg's __newobj__ equivalents, raised around the __new__ call so
+ * Struct_new can tell a reconstruction from a normal construction (the type
+ * being reconstructed is visible to it during the call). The reduce names these
+ * instead of copyreg's, so pickle and copy both route a getnewargs
+ * reconstruction through them. A user __reduce__ may name them directly, so the
+ * arguments are validated before any tuple item is read. */
+static PyObject * reconstruct_raised(
+	PyTypeObject * const cls,
+	PyObject * const call_args,
+	PyObject * const kwargs
+) {
+	PY_MOVABLE(new_method, PyObject_GetAttrString((PyObject *) cls, "__new__"));
+
+	if (new_method == NULL) {
+		return NULL;
+	}
+
+	PyTypeObject * const saved = struct_reconstruction_type;
+	struct_reconstruction_type = cls;
+	PY_MOVABLE(result, PyObject_Call(new_method, call_args, kwargs));
+	struct_reconstruction_type = saved;
+
+	return py_move(&result);
+}
+
+PyObject * Struct_reduce_newobj(PyObject * const module, PyObject * const args) {
+	if (PyTuple_GET_SIZE(args) < 1) {
+		PyErr_SetString(
+			PyExc_TypeError,
+			"__reduce_newobj__() missing 1 required positional argument: 'cls'"
+		);
+
+		return NULL;
+	}
+
+	return reconstruct_raised((PyTypeObject *) PyTuple_GET_ITEM(args, 0), args, NULL);
+}
+
+PyObject * Struct_reduce_newobj_check(PyObject * const module, PyObject * const args) {
+	if (PyTuple_GET_SIZE(args) < 1) {
+		PyErr_SetString(
+			PyExc_TypeError,
+			"__reduce_newobj__() missing 1 required positional argument: 'cls'"
+		);
+
+		return NULL;
+	}
+
+	PY_MOVABLE(result, reconstruct_raised((PyTypeObject *) PyTuple_GET_ITEM(args, 0), args, NULL));
+
+	if (result == NULL || struct_reconstruction_complete(result) < 0) {
+		return NULL;
+	}
+
+	return py_move(&result);
+}
+
+static PyObject * validate_ex_args(
+	PyObject * const args,
+	PyTypeObject * * const cls,
+	PyObject * * const newargs,
+	PyObject * * const kwargs
+) {
+	if (PyTuple_GET_SIZE(args) != 3) {
+		PyErr_SetString(
+			PyExc_TypeError,
+			"__reduce_newobj_ex__() expected 3 positional arguments: 'cls', 'args' and 'kwargs'"
+		);
+
+		return NULL;
+	}
+
+	PyObject * const class_object = PyTuple_GET_ITEM(args, 0);
+	PyObject * const args_object = PyTuple_GET_ITEM(args, 1);
+	PyObject * const kwargs_object = PyTuple_GET_ITEM(args, 2);
+
+	if (!PyTuple_Check(args_object)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__reduce_newobj_ex__() 'args' must be a tuple, not %.200s",
+			Py_TYPE(args_object)->tp_name
+		);
+
+		return NULL;
+	}
+
+	if (!PyDict_Check(kwargs_object)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__reduce_newobj_ex__() 'kwargs' must be a dict, not %.200s",
+			Py_TYPE(kwargs_object)->tp_name
+		);
+
+		return NULL;
+	}
+
+	*cls = (PyTypeObject *) class_object;
+	*newargs = args_object;
+	*kwargs = kwargs_object;
+
+	return args;
+}
+
+static PyObject * reconstruct_ex_raised(PyObject * const args, bool const check_complete) {
+	PyTypeObject * cls = NULL;
+	PyObject * newargs = NULL;
+	PyObject * kwargs = NULL;
+
+	if (validate_ex_args(args, &cls, &newargs, &kwargs) == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(prefixed, PyTuple_New(PyTuple_GET_SIZE(newargs) + 1));
+
+	if (prefixed == NULL) {
+		return NULL;
+	}
+
+	PyTuple_SET_ITEM(prefixed, 0, Py_NewRef((PyObject *) cls));
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(newargs); ++i) {
+		PyTuple_SET_ITEM(prefixed, i + 1, Py_NewRef(PyTuple_GET_ITEM(newargs, i)));
+	}
+
+	PY_MOVABLE(result, reconstruct_raised(cls, prefixed, kwargs));
+
+	if (result == NULL || (check_complete && struct_reconstruction_complete(result) < 0)) {
+		return NULL;
+	}
+
+	return py_move(&result);
+}
+
+PyObject * Struct_reduce_newobj_ex(PyObject * const module, PyObject * const args) {
+	return reconstruct_ex_raised(args, false);
+}
+
+PyObject * Struct_reduce_newobj_ex_check(PyObject * const module, PyObject * const args) {
+	return reconstruct_ex_raised(args, true);
+}
+
+static PyObject * reduce_with_newargs(
+	PyObject * const self,
+	PyObject * const newargs,
+	PyObject * const newkwargs
+) {
+	bool const has_kwargs = newkwargs != NULL && PyDict_GET_SIZE(newkwargs) > 0;
+	PY_OWNED(salix, PyImport_ImportModule("salix"));
+
+	if (salix == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(newobj, NULL);
+	PY_MOVABLE(args, NULL);
+	PY_OWNED(cls, Py_NewRef((PyObject *) Py_TYPE(self)));
+	PY_MOVABLE(state, PyObject_CallMethod(self, "__getstate__", NULL));
+
+	if (state == NULL) {
+		return NULL;
+	}
+
+	/* A None state skips __setstate__ (stdlib's contract), so the completeness
+	 * check cannot run there -- the reconstruction callable itself must verify
+	 * the getnewargs arguments covered the required fields. A carried state
+	 * uses the plain callable and leaves the check to __setstate__, which sees
+	 * the state's explicitly-unset names. */
+	bool const check_complete = state == Py_None;
+
+	if (has_kwargs) {
+		newobj = PyObject_GetAttrString(
+			salix,
+			check_complete ? "__reduce_newobj_ex_check__" : "__reduce_newobj_ex__"
+		);
+		args = PyTuple_Pack(3, cls, newargs, newkwargs);
+	} else {
+		newobj = PyObject_GetAttrString(
+			salix,
+			check_complete ? "__reduce_newobj_check__" : "__reduce_newobj__"
+		);
+		Py_ssize_t const count = PyTuple_GET_SIZE(newargs);
+		args = PyTuple_New(count + 1);
+
+		if (args != NULL) {
+			PyTuple_SET_ITEM(args, 0, Py_NewRef(cls));
+
+			for (Py_ssize_t i = 0; i < count; ++i) {
+				PyTuple_SET_ITEM(args, i + 1, Py_NewRef(PyTuple_GET_ITEM(newargs, i)));
+			}
+		}
+	}
+
+	if (newobj == NULL || args == NULL) {
+		return NULL;
+	}
+
+	return PyTuple_Pack(5, newobj, args, state, Py_None, Py_None);
+}
+
+static PyObject * reduce_without_newargs(PyObject * const self) {
+	PY_OWNED(empty, PyTuple_New(0));
+
+	return empty != NULL ? reduce_with_newargs(self, empty, NULL) : NULL;
+}
+
+/* Whether the class's MRO binds its own __reduce__, which object.__reduce_ex__
+ * honors before it touches getnewargs. Walking the class dicts, not getattr, so
+ * a user __getattr__ never runs. Returns -1 with an exception set when a dict
+ * cannot be read, so a real error is never swallowed into "no custom reduce". */
+static int has_custom_reduce(PyObject * const self) {
+	PY_OWNED(reduce_name, PyUnicode_InternFromString("__reduce__"));
+	PY_OWNED(object_reduce, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__reduce__"));
+
+	if (reduce_name == NULL || object_reduce == NULL) {
+		return -1;
+	}
+
+	PyObject * const mro = Py_TYPE(self)->tp_mro;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyObject * const entry = PyTuple_GET_ITEM(mro, i);
+		PY_OWNED(dict, struct_type_dict((PyTypeObject *) entry));
+
+		if (dict == NULL) {
+			return -1;
+		}
+
+		PY_MOVABLE(bound, dict_value_ref(dict, reduce_name));
+
+		if (bound == NULL) {
+			if (PyErr_Occurred()) {
+				return -1;
+			}
+
+			continue;
+		}
+
+		return bound != object_reduce;
+	}
+
+	return 0;
+}
+
+static PyObject * getnewargs_plain(PyObject * const self) {
+	PY_OWNED(method, PyObject_GetAttrString(self, "__getnewargs__"));
+
+	if (method == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(args, PyObject_CallNoArgs(method));
+
+	if (args == NULL) {
+		return NULL;
+	}
+
+	if (!PyTuple_Check(args)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__getnewargs__ should return a tuple, not '%.200s'",
+			Py_TYPE(args)->tp_name
+		);
+
+		return NULL;
+	}
+
+	return py_move(&args);
+}
+
+static PyObject * getnewargs_ex(PyObject * const self, PyObject * * const kwargs) {
+	PY_OWNED(method, PyObject_GetAttrString(self, "__getnewargs_ex__"));
+
+	if (method == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(result, PyObject_CallNoArgs(method));
+
+	if (result == NULL) {
+		return NULL;
+	}
+
+	if (!PyTuple_Check(result)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__getnewargs_ex__ should return a tuple, not '%.200s'",
+			Py_TYPE(result)->tp_name
+		);
+
+		return NULL;
+	}
+
+	if (PyTuple_GET_SIZE(result) != 2) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__getnewargs_ex__ should return a tuple of length 2, not %zd",
+			PyTuple_GET_SIZE(result)
+		);
+
+		return NULL;
+	}
+
+	PyObject * const args = PyTuple_GET_ITEM(result, 0);
+	PyObject * const kw = PyTuple_GET_ITEM(result, 1);
+
+	if (!PyTuple_Check(args)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"first item of the tuple returned by __getnewargs_ex__ must be a tuple, not '%.200s'",
+			Py_TYPE(args)->tp_name
+		);
+
+		return NULL;
+	}
+
+	if (!PyDict_Check(kw)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"second item of the tuple returned by __getnewargs_ex__ must be a dict, not '%.200s'",
+			Py_TYPE(kw)->tp_name
+		);
+
+		return NULL;
+	}
+
+	*kwargs = Py_NewRef(kw);
+
+	return Py_NewRef(args);
+}
+
+/* object.__reduce_ex__ calls whatever __getnewargs__ resolves to, and a class
+ * that declares a present-but-None value hits "'NoneType' object is not
+ * callable". A struct treats that declaration as absence and builds the reduce
+ * itself for every getnewargs-declaring class, so a None __getnewargs__ is
+ * never called and the reconstruction always carries a restorable state. A
+ * None __getstate__ is passed through: stdlib's contract is that it skips
+ * __setstate__, and the reconstruction stands on the getnewargs arguments.
+ * A class with no declaration, or one with a custom __reduce__, defers to
+ * object.__reduce_ex__, which honors the protocol-below-2 refusal. */
+static PyObject * Struct_reduce_ex(PyObject * const self, PyObject * const args) {
+	if (!is_struct(self)) {
+		return object_reduce_ex(self, args);
+	}
+
+	if (PyTuple_GET_SIZE(args) != 1) {
+		/* object.__reduce_ex__ takes exactly one protocol argument; defer the
+		 * argument-count validation so a missing or extra argument raises the
+		 * same TypeError stdlib does. */
+		return object_reduce_ex(self, args);
+	}
+
+	PyObject * const protocol_object = PyTuple_GET_ITEM(args, 0);
+	int const protocol = (int) PyLong_AsLong(protocol_object);
+
+	if (protocol == -1 && PyErr_Occurred()) {
+		return NULL;
+	}
+
+	if (protocol < 2) {
+		return object_reduce_ex(self, args);
+	}
+
+	int const custom_reduce = has_custom_reduce(self);
+
+	if (custom_reduce < 0) {
+		return NULL;
+	}
+
+	if (custom_reduce > 0) {
+		return object_reduce_ex(self, args);
+	}
+
+	PY_OWNED(ex_name, PyUnicode_InternFromString("__getnewargs_ex__"));
+	PY_OWNED(plain_name, PyUnicode_InternFromString("__getnewargs__"));
+
+	if (ex_name == NULL || plain_name == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(first_ex, NULL);
+	PY_MOVABLE(first_plain, NULL);
+	PyObject * const mro = Py_TYPE(self)->tp_mro;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyObject * const entry = PyTuple_GET_ITEM(mro, i);
+		PY_OWNED(dict, struct_type_dict((PyTypeObject *) entry));
+
+		if (dict == NULL) {
+			return NULL;
+		}
+
+		if (first_ex == NULL) {
+			first_ex = dict_value_ref(dict, ex_name);
+
+			if (first_ex == NULL && PyErr_Occurred()) {
+				return NULL;
+			}
+		}
+
+		if (first_plain == NULL) {
+			first_plain = dict_value_ref(dict, plain_name);
+
+			if (first_plain == NULL && PyErr_Occurred()) {
+				return NULL;
+			}
+		}
+
+		if (first_ex != NULL && first_plain != NULL) {
+			break;
+		}
+	}
+
+	bool const ex_real = first_ex != NULL && first_ex != Py_None;
+	bool const plain_real = first_plain != NULL && first_plain != Py_None;
+	bool const ex_present_none = first_ex != NULL && first_ex == Py_None;
+	bool const plain_present_none = first_plain != NULL && first_plain == Py_None;
+
+	if (ex_real) {
+		PY_MOVABLE(kwargs, NULL);
+		PY_MOVABLE(newargs, getnewargs_ex(self, &kwargs));
+
+		if (newargs == NULL) {
+			return NULL;
+		}
+
+		return reduce_with_newargs(self, newargs, kwargs);
+	}
+
+	if (plain_real) {
+		PY_MOVABLE(newargs, getnewargs_plain(self));
+
+		if (newargs == NULL) {
+			return NULL;
+		}
+
+		return reduce_with_newargs(self, newargs, NULL);
+	}
+
+	if (ex_present_none || plain_present_none) {
+		return reduce_without_newargs(self);
+	}
+
+	return object_reduce_ex(self, args);
+}
+
+static PyObject * call_reduce_or_error(PyObject * const self) {
+	PY_MOVABLE(reduce, PyObject_GetAttrString(self, "__reduce__"));
+
+	if (reduce == NULL) {
+		if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+			PyErr_Clear();
+		} else {
+			return NULL;
+		}
+	} else if (reduce == Py_None) {
+		Py_DECREF(reduce);
+		reduce = NULL;
+	} else {
+		return PyObject_CallNoArgs(reduce);
+	}
+
+	PY_OWNED(copy_module, PyImport_ImportModule("copy"));
+
+	if (copy_module == NULL) {
+		return NULL;
+	}
+
+	PY_OWNED(copy_error, PyObject_GetAttrString(copy_module, "Error"));
+
+	if (copy_error == NULL) {
+		return NULL;
+	}
+
+	PyErr_Format(copy_error, "un(deep)copyable object of type %R", (PyObject *) Py_TYPE(self));
+
+	return NULL;
+}
+
+static PyObject * Struct_deepcopy(PyObject * const self, PyObject * const memo) {
+	if (!is_struct(self)) {
+		PyErr_Format(
+			PyExc_AttributeError,
+			"__deepcopy__ is defined on structs, and %.200s is not one",
+			Py_TYPE(self)->tp_name
+		);
+
+		return NULL;
+	}
+
+	if (!PyDict_Check(memo)) {
+		PyErr_SetString(PyExc_TypeError, "__deepcopy__() argument must be a dict");
+
+		return NULL;
+	}
+
+	/* A struct deep-copies by reconstructing through the same reduce tuple
+	 * copy.deepcopy uses for a class without __deepcopy__: copyreg's
+	 * dispatch_table, then __reduce_ex__, then __reduce__. copy._reconstruct
+	 * does the deep copy of the args and state, memoizing the new object
+	 * before the state so a self-reference resolves to the copy. The point of
+	 * defining __deepcopy__ at all is that copy.deepcopy probes the instance
+	 * for it first -- a struct whose __getattr__ returns a value for unknown
+	 * names would otherwise have that value called. */
+	PY_MOVABLE(rv, NULL);
+	PY_OWNED(copyreg, PyImport_ImportModule("copyreg"));
+
+	if (copyreg == NULL) {
+		return NULL;
+	}
+
+	PY_OWNED(dispatch_table, PyObject_GetAttrString(copyreg, "dispatch_table"));
+
+	if (dispatch_table == NULL) {
+		return NULL;
+	}
+
+	PY_MOVABLE(copier, dict_value_ref(dispatch_table, (PyObject *) Py_TYPE(self)));
+
+	if (copier == NULL && PyErr_Occurred()) {
+		return NULL;
+	}
+
+	if (copier != NULL) {
+		rv = PyObject_CallOneArg(copier, self);
+	} else {
+		PyObject * const reduce_ex = PyObject_GetAttrString(self, "__reduce_ex__");
+
+		if (reduce_ex == NULL) {
+			if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+				PyErr_Clear();
+				rv = call_reduce_or_error(self);
+			} else {
+				return NULL;
+			}
+		} else if (reduce_ex == Py_None) {
+			Py_DECREF(reduce_ex);
+			rv = call_reduce_or_error(self);
+		} else {
+			rv = PyObject_CallFunction(reduce_ex, "i", 4);
+			Py_DECREF(reduce_ex);
+		}
+	}
+
+	if (rv == NULL) {
+		return NULL;
+	}
+
+	/* A string reduce result means "the object is its own copy", the same way
+	 * stdlib copy.deepcopy and copy.copy handle it. */
+	if (PyUnicode_Check(rv)) {
+		return Py_NewRef(self);
+	}
+
+	if (!PyTuple_Check(rv)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"__deepcopy__() reduce must return a tuple, not %.200s",
+			Py_TYPE(rv)->tp_name
+		);
+
+		return NULL;
+	}
+
+	PY_OWNED(copy_module, PyImport_ImportModule("copy"));
+
+	if (copy_module == NULL) {
+		return NULL;
+	}
+
+	PY_OWNED(reconstruct, PyObject_GetAttrString(copy_module, "_reconstruct"));
+
+	if (reconstruct == NULL) {
+		return NULL;
+	}
+
+	Py_ssize_t const rv_size = PyTuple_GET_SIZE(rv);
+	PY_OWNED(call_args, PyTuple_New(rv_size + 2));
+
+	if (call_args == NULL) {
+		return NULL;
+	}
+
+	PyTuple_SET_ITEM(call_args, 0, Py_NewRef(self));
+	PyTuple_SET_ITEM(call_args, 1, Py_NewRef(memo));
+
+	for (Py_ssize_t i = 0; i < rv_size; ++i) {
+		PyTuple_SET_ITEM(call_args, i + 2, Py_NewRef(PyTuple_GET_ITEM(rv, i)));
+	}
+
+	return PyObject_Call(reconstruct, call_args, NULL);
 }

--- a/src/mixin.h
+++ b/src/mixin.h
@@ -8,3 +8,8 @@
  * Not const: PyType_Ready fills in tp_dict, tp_mro, tp_bases and the inherited
  * slots at import time, and PyObject_TypeCheck takes a mutable pointer. */
 extern PyTypeObject StructMixin_Type;
+
+PyObject * Struct_reduce_newobj(PyObject * module, PyObject * args);
+PyObject * Struct_reduce_newobj_ex(PyObject * module, PyObject * args);
+PyObject * Struct_reduce_newobj_check(PyObject * module, PyObject * args);
+PyObject * Struct_reduce_newobj_ex_check(PyObject * module, PyObject * args);

--- a/src/salix.c
+++ b/src/salix.c
@@ -35,6 +35,30 @@ static PyMethodDef struct_functions[] = {
 		.ml_flags = METH_VARARGS,
 		.ml_doc = "set_field(instance, name, value) -- assign a field the class declared.",
 	},
+	{
+		.ml_name = "__reduce_newobj__",
+		.ml_meth = Struct_reduce_newobj,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "__reduce_newobj__(cls, *args) -- copyreg's reconstruction, marker-raised.",
+	},
+	{
+		.ml_name = "__reduce_newobj_ex__",
+		.ml_meth = Struct_reduce_newobj_ex,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "__reduce_newobj_ex__(cls, args, kwargs) -- copyreg's reconstruction, marker-raised.",
+	},
+	{
+		.ml_name = "__reduce_newobj_check__",
+		.ml_meth = Struct_reduce_newobj_check,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "__reduce_newobj_check__(cls, *args) -- reconstruction that verifies completeness.",
+	},
+	{
+		.ml_name = "__reduce_newobj_ex_check__",
+		.ml_meth = Struct_reduce_newobj_ex_check,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "__reduce_newobj_ex_check__(cls, args, kwargs) -- reconstruction that verifies completeness.",
+	},
 	{.ml_name = NULL},
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -19,6 +19,19 @@ enum { SLOT_MEMBER_TYPE = T_OBJECT_EX };
 enum { SLOT_MEMBER_TYPE = Py_T_OBJECT_EX };
 #endif
 
+/* The type a reduce reconstruction is building, set around the reconstruction's
+ * __new__ call so Struct_new can tell a reconstruction (whose arguments come
+ * from __getnewargs__ and must bind into the fields) from a normal construction
+ * (whose arguments belong to __init__ and must not leak into the fields). Only
+ * the type itself matches, so a construction nested inside a reconstruction's
+ * __new__ body -- of a different type -- is seen as construction. Defined in
+ * construct.c. */
+extern _Thread_local PyTypeObject * struct_reconstruction_type;
+
+static inline bool struct_reconstructing(PyTypeObject const * const cls) {
+	return struct_reconstruction_type == cls;
+}
+
 typedef struct {
 	PyHeapTypeObject heap_type;
 
@@ -26,6 +39,7 @@ typedef struct {
 	PyObject * struct_defaults;
 	Py_ssize_t * struct_slot_offsets;
 	PyObject * struct_post_init;
+	PyObject * struct_body_new;
 
 	Py_ssize_t struct_field_count;
 	Py_ssize_t struct_default_count;
@@ -85,6 +99,98 @@ static inline PyObject * struct_type_dict(PyTypeObject * const type) {
 	return PyType_GetDict(type);
 }
 #endif
+
+static inline PyObject * dict_value_ref(PyObject * const mapping, PyObject * const key);
+
+/*
+ * Whether the class's MRO binds __getnewargs__ or __getnewargs_ex__. Reading
+ * the class dicts, not getattr, so a user __getattr__ never runs and a hook
+ * added after creation is seen. Reports the two declarations separately
+ * because the reconstruction shape accepts keywords only for
+ * __getnewargs_ex__, while positional args are accepted for either.
+ */
+static inline int struct_probe_getnewargs(
+	PyTypeObject const * const cls,
+	bool * const declares,
+	bool * const declares_ex
+) {
+	*declares = false;
+	*declares_ex = false;
+	PyObject * const mro = cls->tp_mro;
+
+	if (mro == NULL) {
+		return 0;
+	}
+
+	PyObject * const ex_name = PyUnicode_InternFromString("__getnewargs_ex__");
+	PyObject * const plain_name = PyUnicode_InternFromString("__getnewargs__");
+
+	if (ex_name == NULL || plain_name == NULL) {
+		Py_XDECREF(ex_name);
+		Py_XDECREF(plain_name);
+
+		return -1;
+	}
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyObject * const entry = PyTuple_GET_ITEM(mro, i);
+		PyObject * const dict = struct_type_dict((PyTypeObject *) entry);
+
+		if (dict == NULL) {
+			if (PyErr_Occurred()) {
+				Py_DECREF(ex_name);
+				Py_DECREF(plain_name);
+
+				return -1;
+			}
+
+			continue;
+		}
+
+		PyObject * const ex = dict_value_ref(dict, ex_name);
+		PyObject * const plain = dict_value_ref(dict, plain_name);
+
+		if (ex == NULL && PyErr_Occurred()) {
+			Py_XDECREF(plain);
+			Py_DECREF(dict);
+			Py_DECREF(ex_name);
+			Py_DECREF(plain_name);
+
+			return -1;
+		}
+
+		if (ex != NULL && ex != Py_None) {
+			*declares_ex = true;
+			*declares = true;
+		}
+
+		if (plain == NULL && PyErr_Occurred()) {
+			Py_XDECREF(ex);
+			Py_DECREF(dict);
+			Py_DECREF(ex_name);
+			Py_DECREF(plain_name);
+
+			return -1;
+		}
+
+		if (plain != NULL && plain != Py_None) {
+			*declares = true;
+		}
+
+		Py_XDECREF(ex);
+		Py_XDECREF(plain);
+		Py_DECREF(dict);
+
+		if (*declares && *declares_ex) {
+			break;
+		}
+	}
+
+	Py_DECREF(ex_name);
+	Py_DECREF(plain_name);
+
+	return 0;
+}
 
 /*
  * A strong reference to the value, or NULL if the key is gone.
@@ -285,6 +391,43 @@ static inline void struct_slots_ref_or_none_into(
 
 static inline Py_ssize_t struct_required_count(StructType const * const type) {
 	return type->struct_field_count - type->struct_default_count;
+}
+
+/* Every required field of a getnewargs reconstruction's result is set. Called
+ * after the reconstruction's __new__ for the None-state path, where __setstate__
+ * is skipped and the args are the only carrier. Returns -1 with an exception set
+ * on an incomplete reconstruction, 0 on complete. */
+static inline int struct_reconstruction_complete(PyObject * const result) {
+	if (!is_struct(result)) {
+		return 0;
+	}
+
+	StructType const * const type = struct_type_of(result);
+	bool declares = false;
+	bool declares_ex = false;
+
+	if (struct_probe_getnewargs(&type->heap_type.ht_type, &declares, &declares_ex) < 0) {
+		return -1;
+	}
+
+	if (!declares) {
+		return 0;
+	}
+
+	for (Py_ssize_t i = 0; i < struct_required_count(type); ++i) {
+		if (*struct_slot(type, result, i) == NULL) {
+			PyErr_Format(
+				PyExc_TypeError,
+				"%.200s() missing required argument '%U'",
+				struct_type_name(type),
+				PyTuple_GET_ITEM(type->struct_field_names, i)
+			);
+
+			return -1;
+		}
+	}
+
+	return 0;
 }
 
 static inline bool defines_own_init(StructType const * const struct_class) {

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -234,8 +234,7 @@ def test_concurrent_pickling_while_another_thread_writes_it():
             restored = pickle.loads(pickle.dumps(shared if i % 2 else sealed))
             value = restored.value
 
-            if i % 1000 == 0:
-                assert len(value) == 2
+            assert len(value) == 2
 
     roles = iter(([write, pickle_round_trip] * THREADS)[:THREADS])
     claim = threading.Lock()
@@ -261,6 +260,11 @@ def test_concurrent_getstate_while_another_thread_writes_the_instance_dict():
     """
 
     shared = DictCarrying(0)
+    # A fresh instance: its dict slot is NULL, so every __getstate__ until the
+    # writer's first store exercises instance_dict_ref's empty-dict
+    # materialize-and-restore branch -- the path the read-side race fix is
+    # about. No seed, because seeding would make the dict non-empty from the
+    # start and skip that branch entirely.
     rounds = ITERATIONS * 5
     saw_dict_entry = [False]
 
@@ -272,6 +276,9 @@ def test_concurrent_getstate_while_another_thread_writes_the_instance_dict():
         for i in range(rounds):
             state = shared.__getstate__()
 
+            # Before the writer's first store the dict slot is still NULL, so
+            # the third element is None; after it, the writer's entry is there.
+            # Only the non-None case can contain the entry.
             if state[2] is not None and "extra" in state[2]:
                 saw_dict_entry[0] = True
 
@@ -290,6 +297,9 @@ def test_concurrent_getstate_while_another_thread_writes_the_instance_dict():
 
     run_on_every_thread(work)
 
+    # The writer stores on every one of its `rounds` iterations, so by the time
+    # every thread has run to completion at least one store must have landed
+    # and been observed.
     assert saw_dict_entry[0]
 
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1295,6 +1295,25 @@ def test_an_impostor_mixin_subclass_round_trips_through_object_pickling():
     assert type(restored) is type(instance)
     assert restored.extra == "world"
 
+
+def test_impostor_setstate_merges_into_the_existing_dict():
+    instance = Impostor()
+    instance.keep = "this"
+
+    instance.__setstate__({"extra": "world"})
+
+    assert instance.extra == "world"
+    assert instance.keep == "this"
+
+
+def test_impostor_setstate_accepts_a_dict_none_state():
+    instance = Impostor()
+    instance.extra = "world"
+
+    instance.__setstate__(({"extra": "fresh"}, None))
+
+    assert instance.extra == "fresh"
+
 @pytest.mark.parametrize("protocol", [0, 1])
 def test_protocols_0_and_1_are_deliberately_refused(protocol):
     """The old protocols restore through copyreg._reconstructor, whose

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -855,12 +855,12 @@ def test_a_swapped_instance_dict_is_visible_to_attribute_reads():
 
 def test_setstate_with_a_none_instance_dict_does_not_destroy_a_shared_values_dict():
     instance = WithDict(9)
-    instance.__dict__["keep"] = "this"
+    instance.__dict__["x"] = 5
 
     instance.__setstate__((instance.__dict__, (), None))
 
-    assert instance.x == 9
-    assert instance.__dict__ == {"keep": "this"}
+    assert instance.x == 5
+    assert instance.__dict__ == {"x": 5}
 
 
 def test_type_call_arguments_on_a_bodyless_struct_are_refused():

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,10 +1,11 @@
 import copy
+import copyreg
 import pickle
 from collections.abc import Callable
 
 import pytest
 
-from salix import Struct, set_field
+from salix import Struct, __reduce_newobj__, __reduce_newobj_ex__, set_field
 
 # The classes live at module level because pickle resolves a class by qualified
 # name, and an instance of a test-local class cannot be unpickled.
@@ -12,6 +13,8 @@ from salix import Struct, set_field
 init_calls: list[int] = []
 post_init_calls: list[int] = []
 body_new_calls: list[str] = []
+reduce_calls: list[str] = []
+custom_setstate_calls: list[str] = []
 
 
 class Plain(Struct):
@@ -69,12 +72,12 @@ class Dicted:
     pass
 
 
-class Impostor(Struct.__mro__[1], list):
-    pass
-
-
 class WithDict(Struct, Dicted, frozen=False):
     x: int
+
+
+class Impostor(Struct.__mro__[1], list):
+    pass
 
 
 class WithBodyNew(Struct):
@@ -87,6 +90,402 @@ class WithBodyNew(Struct):
 
 class ChildOfBodyNew(WithBodyNew):
     y: int = 9
+
+
+class RecordingNew(Struct):
+    x: int = 0
+
+    def __new__(cls, both: int = 0):
+        body_new_calls.append(("recording_new", both))
+        obj = super().__new__(cls)
+        set_field(obj, "x", both)
+        return obj
+
+
+class ArgNew(Struct):
+    x: int
+
+    def __new__(cls, both: int):
+        body_new_calls.append(("arg_new", both))
+        obj = super().__new__(cls)
+        set_field(obj, "x", both)
+        return obj
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class SingletonNew(Struct):
+    x: int = 1
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            obj = super().__new__(cls)
+            set_field(obj, "x", 42)
+            cls._instance = obj
+        return cls._instance
+
+
+class RejectingNew(Struct):
+    x: int = 0
+    reject = False
+
+    def __new__(cls):
+        if cls.reject:
+            raise TypeError("genuine rejection")
+        return super().__new__(cls)
+
+
+class DeclinesForReconstruction(Struct):
+    x: int = 5
+
+    def __new__(cls, v=None):
+        if v is not None:
+            raise TypeError("declined for reconstruction")
+        obj = super().__new__(cls)
+        set_field(obj, "x", 5)
+        return obj
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class WithGetNewArgs(Struct):
+    x: int
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class WithGetNewArgsEx(Struct):
+    x: int
+
+    def __getnewargs_ex__(self):
+        return ((self.x,), {"x": self.x})
+
+
+class WithGetNewArgsExKeywordOnly(Struct):
+    x: int
+
+    def __getnewargs_ex__(self):
+        return ((), {"x": self.x})
+
+
+class EmptyStateGNA(Struct):
+    x: int = 0
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __getstate__(self):
+        return ({}, (), None)
+
+
+class EmptyStateEx(Struct):
+    x: int = 0
+
+    def __getnewargs_ex__(self):
+        return ((), {"x": self.x})
+
+    def __getstate__(self):
+        return ({}, (), None)
+
+
+class EmptyStateMix(Struct):
+    x: int = 0
+
+    __getnewargs_ex__ = None
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __getstate__(self):
+        return ({}, (), None)
+
+
+class UnderGetNewArgs(Struct):
+    x: int
+    y: int
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __getstate__(self):
+        return ({}, (), None)
+
+
+class Base2(Struct):
+    x: int
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class Child2(Base2):
+    y: int
+
+
+class EmptyTupleGNA(Struct):
+    x: int
+    y: int
+
+    def __getnewargs__(self):
+        return ()
+
+    def __getstate__(self):
+        return ({}, (), None)
+
+
+class EmptyTupleStateCarrying(Struct):
+    x: int
+    y: int
+
+    def __getnewargs__(self):
+        return ()
+
+    def __getstate__(self):
+        return ({"x": self.x, "y": self.y}, (), None)
+
+
+class EmptyTupleNoneState(Struct):
+    x: int
+    y: int
+
+    def __getnewargs__(self):
+        return ()
+
+    def __getstate__(self):
+        return None
+
+
+class BodyInitEmptyState(Struct, frozen=False):
+    x: int = 0
+
+    def __init__(self, v=10):
+        self.x = v
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __getstate__(self):
+        return ({}, (), None)
+
+
+class RedundantEx(Struct):
+    x: int
+
+    def __getnewargs_ex__(self):
+        return ((self.x,), {"x": self.x})
+
+
+class PartialState(Struct):
+    x: int
+    y: int
+
+    def __getstate__(self):
+        return ({"x": self.x}, (), None)
+
+
+class NoneStateCustomSetState(Struct, frozen=False):
+    x: int = 5
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __getstate__(self):
+        return None
+
+    def __setstate__(self, state):
+        custom_setstate_calls.append("called")
+        Struct.__setstate__(self, state)
+
+
+class BadLenEx(Struct):
+    x: int
+
+    def __getnewargs_ex__(self):
+        return (1, 2, 3)
+
+
+class RaisingReduce(Struct):
+    x: int = 0
+
+    def __reduce__(self):
+        raise RuntimeError("genuine reduce failure")
+
+
+class ExplicitlyUnsetRequired(Struct, frozen=False):
+    x: int
+    y: int
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class RecomputeRequired(Struct):
+    x: int
+    y: int
+
+    def __getnewargs__(self):
+        return (self.x, self.y)
+
+    def __getstate__(self):
+        return ({"x": self.x}, (), None)
+
+    def __setstate__(self, state):
+        Struct.__setstate__(self, state)
+        set_field(self, "y", 99)
+
+
+class MalformedReduceNewobj(Struct):
+    x: int = 0
+
+    def __reduce__(self):
+        return (__reduce_newobj__, (), None)
+
+
+class MalformedReduceNewobjEx(Struct):
+    x: int = 0
+
+    def __reduce__(self):
+        return (__reduce_newobj_ex__, (), None)
+
+
+class NestedConstruction(Struct, frozen=False):
+    x: int
+    helper: object = None
+
+    def __new__(cls, *args):
+        obj = super().__new__(cls)
+        set_field(obj, "x", 7)
+        obj.helper = HelperBodyInit.__new__(HelperBodyInit, 5)
+        return obj
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __getstate__(self):
+        return ({"x": self.x}, (), None)
+
+
+class HelperBodyInit(Struct, frozen=False):
+    x: int = 0
+
+    def __init__(self, v=10):
+        self.x = v
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class RedundantListEx(Struct):
+    xs: list = None
+
+    def __getnewargs_ex__(self):
+        return ((list(self.xs),), {"xs": list(self.xs)})
+
+
+class WithGNA(Struct):
+    x: int
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class NoneGetNewArgs(Struct):
+    x: int = 0
+
+    __getnewargs__ = None
+
+
+class CoBaseNew:
+    def __new__(cls, v: int = 0):
+        body_new_calls.append("co_base_new")
+        return super().__new__(cls)
+
+
+class BodyBaseNew(Struct):
+    x: int = 0
+
+    def __new__(cls, v: int = 0):
+        body_new_calls.append("body_base_new")
+        return super().__new__(cls)
+
+
+class SubWithCoBaseNew(CoBaseNew, BodyBaseNew):
+    y: int = 1
+
+
+class ReduceCopyBase(Struct):
+    x: int = 0
+
+    def __copy__(self):
+        return "user_copy"
+
+    def __reduce__(self):
+        return (type(self), (), self.__getstate__())
+
+
+class SubOfReduceCopyBase(ReduceCopyBase):
+    y: int = 1
+
+
+class GenuineWithGNA(Struct):
+    x: int = 0
+
+    def __new__(cls, v: int = 0):
+        raise TypeError("genuine rejection")
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class ValueErrorNew(Struct):
+    x: int = 5
+
+    def __new__(cls, v: int = 0):
+        if v:
+            raise ValueError("genuine rejection")
+        return super().__new__(cls)
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+
+class DeclinesWithReduce(Struct):
+    x: int = 5
+
+    def __new__(cls, v: int = 0):
+        if v:
+            raise TypeError("declined for reconstruction")
+        return super().__new__(cls)
+
+    def __getnewargs__(self):
+        return (self.x,)
+
+    def __reduce__(self):
+        return (copyreg.__newobj__, (type(self), self.x), self.__getstate__())
+
+
+class DeclinesWithReduceNoGNA(Struct):
+    x: int = 5
+
+    def __new__(cls, v: int = 0):
+        if v:
+            raise TypeError("declined for reconstruction")
+        return super().__new__(cls)
+
+    def __reduce__(self):
+        return (copyreg.__newobj__, (type(self), self.x), self.__getstate__())
+
+
+class WithReduce(Struct):
+    x: int = 0
+
+    def __reduce__(self):
+        reduce_calls.append("custom")
+        return (type(self), (), self.__getstate__())
 
 
 FACTORIES: dict[str, Callable[[], Struct]] = {
@@ -106,6 +505,8 @@ def _reset_call_records() -> None:
     init_calls.clear()
     post_init_calls.clear()
     body_new_calls.clear()
+    reduce_calls.clear()
+    custom_setstate_calls.clear()
 
 
 @pytest.mark.parametrize("protocol", [2, 5])
@@ -384,9 +785,11 @@ def test_setstate_restores_the_instance_dict_from_the_third_element():
 def test_a_null_instance_dict_slot_round_trips():
     instance = WithDict(1)
 
+    assert instance.__getstate__()[2] is None
+
     pickle.dumps(instance)
 
-    assert instance.__dict__ == {}
+    assert instance.__getstate__()[2] is None
 
     restored = pickle.loads(pickle.dumps(instance))
     assert restored == instance
@@ -450,76 +853,14 @@ def test_a_swapped_instance_dict_is_visible_to_attribute_reads():
     assert instance.__dict__ == {"extra": "fresh"}
 
 
-def test_getstate_snapshots_the_instance_dict_without_materializing_an_absent_one():
-    import sys
-
-    instance = WithDict(1)
-
-    state = instance.__getstate__()
-
-    assert state[0] == {"x": 1}
-    assert state[1] == ()
-
-    if sys.version_info >= (3, 14):
-        assert state[2] == {}
-    else:
-        assert state[2] is None
-        assert instance.__dict__ == {}
-
-
-def test_setstate_on_a_dictless_struct_refuses_a_non_empty_dict():
-    with pytest.raises(TypeError, match="instance dict"):
-        Plain(1, 2).__setstate__(({"x": 1}, (), {"extra": "world"}))
-
-
-def test_setstate_with_an_empty_dict_on_a_dictless_struct_is_accepted():
-    instance = Plain(1, 2)
-
-    instance.__setstate__(({"x": 9}, (), {}))
-
-    assert instance.x == 9
-
-
-def test_a_none_instance_dict_does_not_destroy_a_shared_values_dict():
+def test_setstate_with_a_none_instance_dict_does_not_destroy_a_shared_values_dict():
     instance = WithDict(9)
-    instance.__dict__["x"] = 5
+    instance.__dict__["keep"] = "this"
 
     instance.__setstate__((instance.__dict__, (), None))
 
-    assert instance.x == 5
-    assert instance.__dict__ == {"x": 5}
-
-
-def test_a_failed_dict_merge_leaves_the_slots_unwritten():
-    class CollidingKey:
-        eq_calls = 0
-
-        def __init__(self, name):
-            self.name = name
-
-        def __hash__(self):
-            return 42 if self.name != "tmp" else 7
-
-        def __eq__(self, other):
-            CollidingKey.eq_calls += 1
-
-            if CollidingKey.eq_calls > 1:
-                raise RuntimeError("eq failed")
-
-            return self is other
-
-    first = CollidingKey("a")
-    second = CollidingKey("b")
-    tmp = CollidingKey("tmp")
-    state_dict = {first: 1, second: 2, tmp: 3}
-    del state_dict[tmp]
-
-    instance = WithDict(9)
-
-    with pytest.raises(RuntimeError, match="eq failed"):
-        instance.__setstate__(({"x": 2}, (), state_dict))
-
     assert instance.x == 9
+    assert instance.__dict__ == {"keep": "this"}
 
 
 def test_type_call_arguments_on_a_bodyless_struct_are_refused():
@@ -560,18 +901,389 @@ def test_a_body_new_on_a_base_struct_survives_on_its_subclass():
 
     restored = pickle.loads(pickle.dumps(instance))
 
-    assert body_new_calls == ["with_body_new"]
+    assert body_new_calls == ["with_body_new", "with_body_new"]
     assert restored == instance
 
 
-@pytest.mark.parametrize("protocol", [0, 1])
-def test_protocols_0_and_1_are_deliberately_refused(protocol):
-    """The old protocols restore through copyreg._reconstructor, whose
-    object.__new__(cls) a struct refuses; a pickle that cannot be written by
-    them is a limitation that is deliberate rather than silent."""
+def test_a_recording_body_new_is_honored_by_construction_copy_and_pickle():
+    instance = RecordingNew(7)
+
+    assert body_new_calls == [("recording_new", 7)]
+
+    copied = copy.copy(instance)
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert body_new_calls == [
+        ("recording_new", 7),
+        ("recording_new", 0),
+        ("recording_new", 0),
+    ]
+    assert copied == instance
+    assert restored == instance
+    assert copied.x == 7
+    assert restored.x == 7
+
+
+def test_a_body_new_requiring_an_arg_receives_it_through_getnewargs():
+    instance = ArgNew(7)
+
+    assert body_new_calls == [("arg_new", 7)]
+
+    copied = copy.copy(instance)
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert copied == instance
+    assert restored == instance
+    assert body_new_calls == [("arg_new", 7), ("arg_new", 7), ("arg_new", 7)]
+
+
+def test_a_singleton_body_new_returns_the_same_instance_across_all_three():
+    first = SingletonNew()
+    copied = copy.copy(first)
+    restored = pickle.loads(pickle.dumps(first))
+
+    assert copied is first
+    assert restored is first
+
+
+def test_a_body_new_raising_typeerror_genuinely_propagates():
+    instance = RejectingNew()
+
+    try:
+        RejectingNew.reject = True
+
+        with pytest.raises(TypeError, match="genuine rejection"):
+            RejectingNew()
+        with pytest.raises(TypeError, match="genuine rejection"):
+            copy.copy(instance)
+        with pytest.raises(TypeError, match="genuine rejection"):
+            pickle.loads(pickle.dumps(instance))
+    finally:
+        RejectingNew.reject = False
+
+
+def test_a_body_new_raising_typeerror_on_reconstruction_propagates():
+    instance = DeclinesForReconstruction()
+
+    with pytest.raises(TypeError, match="declined for reconstruction"):
+        copy.copy(instance)
+    with pytest.raises(TypeError, match="declined for reconstruction"):
+        pickle.loads(pickle.dumps(instance))
+
+
+def test_a_class_declaring_getnewargs_round_trips_copy_and_pickle():
+    instance = WithGetNewArgs(5)
+
+    assert copy.copy(instance) == instance
+    assert pickle.loads(pickle.dumps(instance)) == instance
+
+    with pytest.raises(TypeError, match="takes no keyword arguments"):
+        WithGetNewArgs.__new__(WithGetNewArgs, 5, x=5)
+
+
+def test_a_direct_posonly_new_call_on_a_getnewargs_struct_is_reconstruction_capable():
+    instance = WithGetNewArgs(5)
+
+    assert copy.copy(instance) == instance
+
+
+def test_a_bodyless_struct_keeps_the_plain_new_path():
+    instance = Plain(1, 2)
+
+    assert copy.copy(instance) == instance
+    assert pickle.loads(pickle.dumps(instance)) == instance
 
     with pytest.raises(TypeError):
-        pickle.dumps(Plain(1, 2), protocol=protocol)
+        Plain.__new__(Plain, 1)
+
+
+def test_setstate_with_the_own_dict_as_third_element_is_a_no_op():
+    instance = WithDict(1)
+    instance.extra = "world"
+
+    instance.__setstate__(({"x": 9}, (), instance.__dict__))
+
+    assert instance.x == 9
+    assert instance.__dict__ == {"extra": "world"}
+
+
+def test_setstate_dict_restore_is_atomic_on_a_failed_merge():
+    class Evil:
+        n = 0
+
+        def __init__(self, name):
+            self.name = name
+
+        def __hash__(self):
+            return 42 if self.name != "tmp" else 7
+
+        def __eq__(self, other):
+            Evil.n += 1
+            if Evil.n > 1:
+                raise RuntimeError(f"eq failed on call {Evil.n}")
+            return self is other
+
+    e1 = Evil("a")
+    e2 = Evil("b")
+    tmp = Evil("tmp")
+    state_dict = {e1: 1, e2: 2, tmp: 3}
+    del state_dict[tmp]
+
+    instance = WithDict(1)
+    instance.extra = "old"
+    instance.__dict__["keep"] = "this"
+
+    with pytest.raises(RuntimeError, match="eq failed"):
+        instance.__setstate__(({"x": 2}, (), state_dict))
+
+    assert instance.__dict__ == {"extra": "old", "keep": "this"}
+    assert instance.x == 2
+
+
+@pytest.mark.parametrize("protocol", [2, 3])
+def test_protocols_2_and_3_round_trip_a_getnewargs_ex_struct(protocol):
+    instance = WithGetNewArgsEx(5)
+    restored = pickle.loads(pickle.dumps(instance, protocol=protocol))
+
+    assert restored == instance
+    assert restored.x == 5
+
+
+@pytest.mark.parametrize("protocol", [2, 3])
+def test_protocols_2_and_3_round_trip_a_keyword_only_getnewargs_ex_struct(protocol):
+    instance = WithGetNewArgsExKeywordOnly(5)
+    restored = pickle.loads(pickle.dumps(instance, protocol=protocol))
+
+    assert restored == instance
+    assert restored.x == 5
+
+
+def test_a_direct_keyword_new_call_on_a_bodyless_struct_is_refused():
+    with pytest.raises(TypeError, match="takes no keyword arguments"):
+        Plain.__new__(Plain, x=1)
+
+
+def test_a_direct_keyword_new_call_on_a_getnewargs_struct_is_refused():
+    with pytest.raises(TypeError, match="takes no keyword arguments"):
+        WithGetNewArgs.__new__(WithGetNewArgs, x=1)
+
+
+def test_a_genuine_body_typeerror_propagates_with_getnewargs_under_construction():
+    with pytest.raises(TypeError, match="genuine rejection"):
+        GenuineWithGNA(5)
+
+
+def test_a_body_new_raising_a_non_typeerror_propagates_on_reconstruction():
+    instance = ValueErrorNew()
+    with pytest.raises(ValueError, match="genuine rejection"):
+        copy.copy(instance)
+    with pytest.raises(ValueError, match="genuine rejection"):
+        pickle.loads(pickle.dumps(instance))
+
+
+def test_a_reduced_body_new_typeerror_propagates_on_every_reconstruction_path():
+    instance = DeclinesWithReduce()
+
+    for func in (copy.copy, copy.deepcopy):
+        with pytest.raises(TypeError, match="declined for reconstruction"):
+            func(instance)
+
+    for protocol in (2, 3, 4, 5):
+        with pytest.raises(TypeError, match="declined for reconstruction"):
+            pickle.loads(pickle.dumps(instance, protocol=protocol))
+
+
+def test_a_reduced_body_new_without_getnewargs_propagates_consistently():
+    instance = DeclinesWithReduceNoGNA()
+
+    for func in (copy.copy, copy.deepcopy):
+        with pytest.raises(TypeError, match="declined for reconstruction"):
+            func(instance)
+
+    for protocol in (2, 3, 4, 5):
+        with pytest.raises(TypeError, match="declined for reconstruction"):
+            pickle.loads(pickle.dumps(instance, protocol=protocol))
+
+
+def test_a_custom_reduce_controls_copy_and_deepcopy():
+    instance = WithReduce()
+
+    copied = copy.copy(instance)
+    deep = copy.deepcopy(instance)
+
+    assert reduce_calls == ["custom", "custom"]
+    assert copied == instance
+    assert deep == instance
+
+
+def test_setstate_swaps_the_instance_dict_for_atomicity():
+    instance = WithDict(1)
+    instance.extra = "world"
+
+    instance.__setstate__(({"x": 2}, (), {"new": "val"}))
+
+    assert instance.__dict__ == {"new": "val"}
+
+
+def test_setstate_with_none_third_element_clears_the_instance_dict():
+    instance = WithDict(1)
+    instance.extra = "world"
+
+    instance.__setstate__(({}, (), None))
+
+    assert instance.__dict__ == {}
+
+
+def test_a_co_base_earlier_in_the_mro_supplies_the_body_new():
+    body_new_calls.clear()
+    instance = SubWithCoBaseNew.__new__(SubWithCoBaseNew)
+
+    assert body_new_calls == ["co_base_new", "body_base_new"]
+    assert instance.y == 1
+
+
+def test_a_subclass_inherits_a_user_copy_instead_of_being_shadowed():
+    instance = SubOfReduceCopyBase()
+
+    assert copy.copy(instance) == "user_copy"
+
+
+def test_a_bodyless_struct_gaining_getnewargs_after_creation_still_copies():
+    instance = Plain(1, 2)
+
+    assert copy.copy(instance) == instance
+
+    try:
+        Plain.__getnewargs__ = lambda self: (self.x, self.y)
+
+        assert copy.copy(instance) == instance
+        assert copy.deepcopy(instance) == instance
+    finally:
+        del Plain.__getnewargs__
+
+
+def test_a_getattr_returning_none_does_not_break_copy():
+    class GetattrNone(Struct):
+        x: int
+
+        def __getattr__(self, name):
+            return None
+
+    instance = GetattrNone(5)
+
+    assert copy.copy(instance) == instance
+    assert copy.deepcopy(instance) == instance
+
+
+def test_a_declaring_getnewargs_getattr_returning_none_copies_without_error():
+    class DeclaringGetattrNone(Struct):
+        x: int
+
+        def __getnewargs__(self):
+            return (self.x,)
+
+        def __getattr__(self, name):
+            return None
+
+    instance = DeclaringGetattrNone(5)
+
+    assert copy.copy(instance) == instance
+    assert copy.deepcopy(instance) == instance
+
+
+def test_copyreg_dispatch_table_is_honored_by_copy_and_deepcopy():
+    class Registered(Struct):
+        x: int
+
+    def custom_copier(obj):
+        return (lambda v: ("copied", v), (obj.x,), None)
+
+    try:
+        copyreg.dispatch_table[Registered] = custom_copier
+        assert copy.copy(Registered(5)) == ("copied", 5)
+        assert copy.deepcopy(Registered(5)) == ("copied", 5)
+    finally:
+        del copyreg.dispatch_table[Registered]
+
+
+def test_a_reduce_owning_class_keeps_copy_through_the_reduce():
+    class ReduceOwned(Struct):
+        x: int = 0
+
+        def __reduce__(self):
+            return (type(self), (), self.__getstate__())
+
+    assert "__copy__" not in ReduceOwned.__dict__
+    assert hasattr(ReduceOwned, "__copy__") is False
+
+    assert copy.copy(ReduceOwned(5)) == ReduceOwned(5)
+
+
+def test_a_getattr_returning_a_value_is_never_called_by_deepcopy():
+    calls = []
+
+    class GetattrValue(Struct):
+        x: int
+
+        def __getattr__(self, name):
+            calls.append(name)
+            return 123
+
+    instance = GetattrValue(5)
+
+    deep = copy.deepcopy(instance)
+
+    assert deep == instance
+    assert calls == []
+
+
+def test_setstate_refuses_a_duplicate_unset_name():
+    class P(Struct):
+        alpha: int
+        beta: int
+
+    instance = P(1, 2)
+
+    with pytest.raises(TypeError, match="listed more than once as unset"):
+        instance.__setstate__(({"alpha": 5}, ("beta", "beta"), None))
+
+    assert instance.alpha == 1
+    assert instance.beta == 2
+
+
+def test_setstate_replaces_the_instance_dict_for_atomicity():
+    """The dict-restore builds the replacement up front and swaps it in only on
+    success, so a failing merge leaves the instance untouched. The swap replaces
+    the dict object; an external reference to the previous dict goes stale,
+    which is the accepted cost of atomicity. The None branch clears the existing
+    dict in place.
+    """
+
+    instance = WithDict(1)
+    instance.extra = "world"
+    reference = instance.__dict__
+
+    instance.__setstate__(({"x": 2}, (), {"new": "val"}))
+
+    assert instance.__dict__ == {"new": "val"}
+    assert reference == {"extra": "world"}
+
+    instance.__setstate__(({}, (), None))
+
+    assert instance.__dict__ == {}
+
+
+def test_setstate_on_a_dictless_struct_refuses_a_non_empty_dict():
+    with pytest.raises(TypeError, match="instance dict"):
+        Plain(1, 2).__setstate__(({"x": 1}, (), {"extra": "world"}))
+
+
+def test_setstate_with_an_empty_dict_on_a_dictless_struct_is_accepted():
+    instance = Plain(1, 2)
+
+    instance.__setstate__(({"x": 9}, (), {}))
+
+    assert instance.x == 9
 
 
 def test_an_impostor_mixin_subclass_round_trips_through_object_pickling():
@@ -583,21 +1295,395 @@ def test_an_impostor_mixin_subclass_round_trips_through_object_pickling():
     assert type(restored) is type(instance)
     assert restored.extra == "world"
 
+@pytest.mark.parametrize("protocol", [0, 1])
+def test_protocols_0_and_1_are_deliberately_refused(protocol):
+    """The old protocols restore through copyreg._reconstructor, whose
+    object.__new__(cls) a struct refuses; a pickle that cannot be written by
+    them is a limitation that is deliberate rather than silent."""
 
-def test_impostor_setstate_merges_into_the_existing_dict():
-    instance = Impostor()
-    instance.keep = "this"
-
-    instance.__setstate__({"extra": "world"})
-
-    assert instance.extra == "world"
-    assert instance.keep == "this"
+    with pytest.raises(TypeError):
+        pickle.dumps(Plain(1, 2), protocol=protocol)
 
 
-def test_impostor_setstate_accepts_a_dict_none_state():
-    instance = Impostor()
-    instance.extra = "world"
+def test_deepcopy_of_a_string_reduce_returns_the_object_unchanged():
+    """stdlib copy.deepcopy handles a string reduce result by returning the
+    object itself; Struct_deepcopy must match, so deepcopy and copy agree.
+    """
 
-    instance.__setstate__(({"extra": "fresh"}, None))
+    class StrReduce(Struct):
+        x: int
 
-    assert instance.extra == "fresh"
+        def __reduce__(self):
+            return "salix.StrReduce"
+
+    instance = StrReduce(1)
+
+    import copy
+
+    assert copy.deepcopy(instance) is instance
+    assert copy.copy(instance) is instance
+
+
+def test_deepcopy_falls_back_to_reduce_when_reduce_ex_is_none():
+    """A class that sets __reduce_ex__ = None routes reduction through
+    __reduce__, matching stdlib copy.deepcopy's getattr(x, "__reduce_ex__",
+    None) treating None as absence. copy.copy works because it has no
+    __copy__; deepcopy must agree.
+    """
+
+    class ReduceExNone(Struct):
+        x: int
+
+        __reduce_ex__ = None
+
+        def __reduce__(self):
+            return (ReduceExNone, (self.x,))
+
+    instance = ReduceExNone(3)
+
+    assert copy.deepcopy(instance) == instance
+    assert copy.copy(instance) == instance
+
+
+def test_a_getnewargs_reconstruction_binds_the_arguments():
+    """The reconstruction contract is that the getnewargs arguments rebuild the
+    instance, so a bodyless struct whose __getstate__ does not repeat them must
+    still round-trip, and a direct __new__ with the arguments must bind them."""
+
+    assert pickle.loads(pickle.dumps(EmptyStateGNA(7))).x == 7
+    assert WithGNA.__new__(WithGNA, 42).x == 42
+
+
+def test_a_getnewargs_ex_keyword_reconstruction_binds_the_argument():
+    assert pickle.loads(pickle.dumps(EmptyStateEx(7))).x == 7
+
+
+def test_setstate_is_immune_to_a_values_del_mutating_the_state_dict():
+    class Evil:
+        def __init__(self, name):
+            self.name = name
+
+        def __del__(self):
+            if self.name == "trigger":
+                state_dict.pop("z", None)
+
+    class Triple(Struct, frozen=False):
+        x: int
+        y: int
+        z: int
+
+    state_dict = {"x": 10, "y": 20, "z": 30}
+    instance = Triple(1, 2, 3)
+    instance.y = Evil("trigger")
+    instance.__setstate__((state_dict, (), None))
+
+    assert instance.x == 10
+    assert instance.y == 20
+    assert instance.z == 30
+
+
+def test_deepcopy_matches_copy_when_reduce_and_reduce_ex_are_none():
+    class ReduceBothNone(Struct):
+        x: int = 0
+
+        __reduce_ex__ = None
+        __reduce__ = None
+
+    instance = ReduceBothNone(5)
+
+    with pytest.raises(copy.Error):
+        copy.copy(instance)
+    with pytest.raises(copy.Error):
+        copy.deepcopy(instance)
+
+
+def test_a_none_getnewargs_is_not_declared():
+    with pytest.raises(TypeError):
+        NoneGetNewArgs.__new__(NoneGetNewArgs, 99)
+
+    instance = NoneGetNewArgs()
+    set_field(instance, "x", 7)
+
+    assert copy.copy(instance) == instance
+    assert copy.copy(instance).x == 7
+    assert copy.deepcopy(instance) == instance
+    assert pickle.loads(pickle.dumps(instance)) == instance
+    assert pickle.loads(pickle.dumps(instance)).x == 7
+
+
+def test_setstate_refuses_a_non_empty_dict_third_element_without_an_instance_dict():
+    instance = Plain(1, 2)
+
+    with pytest.raises(TypeError, match="cannot set an instance dict"):
+        instance.__setstate__(({"x": 9}, (), {"not_a_field": 3}))
+
+    instance.__setstate__(({"x": 9}, (), {}))
+    assert instance.x == 9
+
+    instance.__setstate__(({"x": 8}, (), None))
+    assert instance.x == 8
+
+
+def test_a_real_getnewargs_survives_a_none_getnewargs_ex():
+    """A None __getnewargs_ex__ is absence, so a real __getnewargs__ must still
+    contribute its arguments rather than being shadowed away."""
+
+    instance = EmptyStateMix()
+    set_field(instance, "x", 7)
+
+    assert pickle.loads(pickle.dumps(instance)).x == 7
+    assert copy.copy(instance).x == 7
+    assert copy.deepcopy(instance).x == 7
+
+
+def test_a_getnewargs_under_providing_a_required_field_is_refused():
+    """A getnewargs whose args plus state do not cover a required field is a
+    broken reconstruction, refused by the single post-setstate completeness
+    check. UnderGetNewArgs has an empty state, so only its short getnewargs
+    could carry y, and it does not."""
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        copy.copy(UnderGetNewArgs(5, 6))
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        pickle.loads(pickle.dumps(UnderGetNewArgs(5, 6)))
+
+
+def test_a_body_init_struct_with_getnewargs_constructs_with_init_arguments():
+    class C(Struct, frozen=False):
+        x: int = 0
+
+        def __init__(self, a, b):
+            self.x = a + b
+
+        def __getnewargs__(self):
+            return (self.x,)
+
+    assert C(1, 2).x == 3
+
+    class B(Struct, frozen=False):
+        x: int = 0
+
+        def __init__(self, v=10):
+            self.x = v
+
+        def __getnewargs__(self):
+            return (self.x,)
+
+    assert B().x == 10
+    assert B(5).x == 5
+
+
+def test_a_state_supplying_a_required_field_round_trips_under_a_short_getnewargs():
+    """The single completeness check runs at the end of __setstate__, so a
+    getnewargs that supplies only x still round-trips when the state carries
+    the rest."""
+
+    instance = Child2(1, 2)
+
+    assert pickle.loads(pickle.dumps(instance)) == instance
+    assert copy.copy(instance) == instance
+
+
+def test_a_body_init_struct_with_getnewargs_and_empty_state_round_trips_via_the_args():
+    """A body-init struct's reconstruction binds the __getnewargs__ arguments
+    into the fields (the reduce routes through a marker-raised newobj), so the
+    empty __getstate__ is not the carrier -- the arguments are."""
+
+    instance = BodyInitEmptyState(7)
+
+    assert pickle.loads(pickle.dumps(instance)).x == 7
+    assert copy.copy(instance).x == 7
+    assert copy.deepcopy(instance).x == 7
+
+
+def test_reduce_ex_with_no_argument_raises_like_stdlib():
+    with pytest.raises(TypeError):
+        Plain(1, 2).__reduce_ex__()
+
+
+def test_an_empty_getnewargs_tuple_with_empty_state_raises_and_with_state_round_trips():
+    with pytest.raises(TypeError, match="missing required argument"):
+        copy.copy(EmptyTupleGNA(5, 6))
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        pickle.loads(pickle.dumps(EmptyTupleGNA(5, 6)))
+
+    instance = EmptyTupleStateCarrying(5, 6)
+
+    assert pickle.loads(pickle.dumps(instance)) == instance
+    assert copy.copy(instance) == instance
+
+
+def test_a_none_state_with_under_providing_getnewargs_is_refused():
+    """A None __getstate__ skips __setstate__, so a getnewargs reconstruction
+    stands on its arguments alone; an empty-tuple getnewargs that leaves a
+    required field uncovered is a half-built shape and is refused, not silently
+    round-tripped."""
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        pickle.loads(pickle.dumps(EmptyTupleNoneState(5, 6)))
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        copy.copy(EmptyTupleNoneState(5, 6))
+
+
+def test_a_none_state_skips_a_custom_setstate():
+    """A getnewargs struct whose __getstate__ returns None and which overrides
+    __setstate__ must not have the override called: stdlib's contract for a None
+    state is that the reconstruction skips __setstate__ entirely."""
+
+    custom_setstate_calls.clear()
+    instance = NoneStateCustomSetState(9)
+
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert restored.x == 9
+    assert custom_setstate_calls == []
+
+    copied = copy.copy(instance)
+
+    assert copied.x == 9
+    assert custom_setstate_calls == []
+
+
+def test_an_explicitly_unset_required_field_round_trips():
+    """A required field the state names as unset (a del) is deliberately unset,
+    not under-provided: the reconstruction must preserve it rather than hard-fail
+    the way an under-providing getnewargs would."""
+
+    instance = ExplicitlyUnsetRequired(1, 2)
+    del instance.y
+
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert restored.x == 1
+
+    with pytest.raises(AttributeError):
+        _ = restored.y
+
+    assert copy.copy(instance).x == 1
+    assert copy.deepcopy(instance).x == 1
+
+
+def test_a_custom_setstate_recompute_of_a_required_field_round_trips():
+    """The legitimate recompute pattern: a custom __setstate__ that defers to
+    the base restore and then recomputes a required field the state omitted."""
+
+    instance = RecomputeRequired(1, 2)
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert restored.x == 1
+    assert restored.y == 99
+
+
+def test_a_malformed_reduce_naming_newobj_is_refused_not_crashed():
+    """A user __reduce__ that names salix's reconstruction function with malformed
+    arguments is refused with a TypeError, not a segfault."""
+
+    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        pickle.loads(pickle.dumps(MalformedReduceNewobj(1)))
+
+    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        copy.copy(MalformedReduceNewobj(1))
+
+    with pytest.raises(TypeError, match="expected 3 positional arguments"):
+        pickle.loads(pickle.dumps(MalformedReduceNewobjEx(1)))
+
+
+def test_a_nested_construction_is_not_misclassified_as_a_reconstruction():
+    """The reconstruction marker covers only the type being reconstructed, so a
+    construction of a different type nested inside a reconstruction's __new__ body
+    binds its constructor arguments normally instead of leaking them into fields."""
+
+    instance = NestedConstruction(1)
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert restored.x == 7
+    assert restored.helper.x == 0
+
+
+def test_a_bare_new_with_short_args_on_a_getnewargs_struct_is_refused():
+    """A getnewargs struct's bare __new__ with args that leave a required field
+    unset is refused immediately: no __setstate__ follows a direct new, so the
+    half-built struct would otherwise persist. A reduce reconstruction raises
+    the marker and is exempt, because its state completes the fields."""
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        UnderGetNewArgs.__new__(UnderGetNewArgs, 5)
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        UnderGetNewArgs.__new__(UnderGetNewArgs)
+
+
+def test_getnewargs_ex_wrong_length_reports_the_actual_length():
+    with pytest.raises(TypeError, match="should return a tuple of length 2, not 3"):
+        copy.copy(BadLenEx(1))
+
+
+def test_a_raising_custom_reduce_propagates():
+    """A custom __reduce__ that raises must propagate, not be swallowed into a
+    silent reconstruction."""
+
+    with pytest.raises(RuntimeError, match="genuine reduce failure"):
+        pickle.dumps(RaisingReduce(1))
+
+
+def test_a_getnewargs_ex_keyword_conflicting_with_a_positional_is_skipped():
+    """The redundant half of __getnewargs_ex__ (same field both positionally
+    and by keyword) is a stdlib-supported pattern; the positional wins."""
+
+    assert RedundantEx.__new__(RedundantEx, 1, x=2).x == 1
+
+
+def test_a_getnewargs_ex_redundant_keyword_is_skipped():
+    instance = RedundantEx(7)
+
+    assert pickle.loads(pickle.dumps(instance, protocol=2)) == instance
+    assert copy.copy(instance) == instance
+
+
+def test_a_getnewargs_ex_redundant_keyword_with_distinct_objects_is_skipped():
+    """The redundant keyword is skipped whenever the field is already bound,
+    so equal-but-distinct objects round-trip too."""
+
+    instance = RedundantListEx([1, 2])
+
+    assert pickle.loads(pickle.dumps(instance, protocol=2)) == instance
+    assert copy.copy(instance) == instance
+
+
+def test_a_custom_partial_getstate_omitting_a_required_field_round_trips():
+    """A non-getnewargs struct's custom partial __getstate__ is a legitimate
+    state; the omitted field round-trips as unset rather than raising."""
+
+    instance = PartialState(1, 2)
+    restored = pickle.loads(pickle.dumps(instance))
+
+    assert restored.x == 1
+
+    with pytest.raises(AttributeError):
+        _ = restored.y
+
+    copied = copy.copy(instance)
+    assert copied.x == 1
+
+    with pytest.raises(AttributeError):
+        _ = copied.y
+
+
+def test_a_body_init_construction_does_not_leak_init_arguments_into_fields():
+    class V(Struct, frozen=False):
+        x: int = 0
+        y: int = 0
+
+        def __init__(self, a, b):
+            self.x = a
+
+        def __getnewargs__(self):
+            return (self.x,)
+
+    instance = V(1, 2)
+
+    assert instance.x == 1
+    assert instance.y == 0


### PR DESCRIPTION
**Part 2 of 2 resolving #13** (pickle, copy and deepcopy). Stacked on #97 (Slice A, base = `feat/pickle-slice-a`); the diff is the remaining feature on top of A's three-part state + tp_new. Once #97 merges, this retargets to `main` (the commits become identical).

## What this adds

- **Reconstruction handling.** A per-type thread-local marker (`struct_reconstruction_type`) is raised only for the type a reduce reconstruction is building, so `Struct_new` can tell a reconstruction (whose arguments come from `__getnewargs__` and must bind into the fields) from a normal construction, and a construction nested inside a reconstruction's `__new__` body of a different type reads as construction. A body `__new__` is routed through the wrapper on every construction path; the `__new__` fallback to `Struct_new` is reconstruction-only.
- **The reduce layer.** `__reduce_ex__` defers to object's when a custom `__reduce__`/`__reduce_ex__` is in play, and otherwise walks the MRO to find a `__getnewargs_ex__`/`__getnewargs__` declaration. The `__reduce_newobj__` / `__reduce_newobj_ex__` reconstruction helpers (with `__reduce_newobj_check__` variants for tests) validate their tuple arguments and raise `TypeError` rather than segfaulting on a malformed or hostile reduce — the round-21 crash, shipped fixed.
- **The completeness gate.** A getnewargs reconstruction is complete only when every required field is set; an under-providing `__getnewargs__` raises `missing required argument` instead of round-tripping a half-built struct. The None-state skip honors the stdlib contract (no `__setstate__` for a None state) only when the class overrides `__setstate__`; a struct's own `__setstate__` still normalizes None to the empty state so the gate runs.
- **copy/deepcopy.** `__deepcopy__` honors the dispatch_table/reduce path (deepcopying through copyreg rather than re-implementing it), a string reduce (copy's `_reconstruct`) round-trips, `__getstate__` is read-only, and the instance-dict restore is atomic on a failed merge (build-then-swap).

This is the reference branch's rounds 4-22 shipped whole: the getnewargs feature (declaration probe → argument binding → completeness gate → the reduce helpers) is one indivisible unit, and every intermediate round state either accepted a getnewargs struct's arguments and silently dropped them, or accepted a half-built reconstruction with no error. No safe merge point exists inside it.

Gated on the full matrix (3.10-3.15 + 3.14t): 120 pickle tests, 1097 passed / 35 skipped / 10 xfailed, `c_test`, `c_analyzer`, `format_check`, `flake_check` all green.