### PR TITLE
fix: settle a delegate-built struct class with the call's options and defaults

### DIFF
--- a/src/meta.c
+++ b/src/meta.c
@@ -126,11 +126,26 @@ static enum result install_fields(
 	struct options options,
 	bool resolves_body_eq
 );
-static enum result reject_unless_planned(
-	StructType const * struct_class,
+static enum result settle_planned(
+	StructType * struct_class,
+	StructType const * base,
+	PyObject * name,
 	struct field_plan const * plan,
-	struct options options
+	PyObject * original_namespace,
+	struct options options,
+	struct options inherited,
+	bool frozen_across_bases,
+	bool body_defines_eq,
+	bool inherits_body_eq,
+	bool derive_not_equal
 );
+static enum result settle_rebind(
+	StructType * struct_class,
+	PyObject * original_namespace,
+	char const * const * names,
+	bool from_mixin
+);
+static enum result refuse_unplanned(StructType const * struct_class);
 static enum result install_post_init(StructType * struct_class);
 static bool defines_own_init(StructType const * struct_class);
 static PyObject * StructMeta_call(PyObject * self, PyObject * args, PyObject * keywords);
@@ -307,6 +322,7 @@ static PyObject * build_struct_class(
 	}
 
 	bool const inherits_body_eq = inherited_equality.from_a_body;
+	bool const frozen_across_bases = request.options.frozen && any_struct_base_is_mutable(bases);
 
 	PY_OWNED(
 		namespace,
@@ -317,7 +333,7 @@ static PyObject * build_struct_class(
 			request.options,
 			base,
 			inherited,
-			request.options.frozen && any_struct_base_is_mutable(bases),
+			frozen_across_bases,
 			body_defines_eq,
 			inherits_body_eq,
 			inherited_equality.needs_derived_not_equal
@@ -337,7 +353,19 @@ static PyObject * build_struct_class(
 				request.options,
 				body_defines_eq || inherits_body_eq
 			) :
-			reject_unless_planned(struct_class, &plan, request.options)
+			settle_planned(
+				struct_class,
+				base,
+				name,
+				&plan,
+				original_namespace,
+				request.options,
+				inherited,
+				frozen_across_bases,
+				body_defines_eq,
+				inherits_body_eq,
+				inherited_equality.needs_derived_not_equal
+			)
 		);
 
 		if (settled != RESULT_OK) {
@@ -1088,11 +1116,74 @@ static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject 
 	return winner;
 }
 
-static enum result reject_unless_planned(
-	StructType const * const struct_class,
-	struct field_plan const * const plan,
-	struct options const options
+static enum result settle_rebind(
+	StructType * const struct_class,
+	PyObject * const original_namespace,
+	char const * const * const names,
+	bool const from_mixin
 ) {
+	PyObject * const source = (
+		from_mixin ? (PyObject *) &StructMixin_Type :
+		(PyObject *) &PyBaseObject_Type
+	);
+	PY_OWNED(class_dict, struct_type_dict(&struct_class->heap_type.ht_type));
+
+	if (class_dict == NULL) {
+		return RESULT_ERROR;
+	}
+
+	for (char const * const * name = names; *name != NULL; name += 1) {
+		if (PyDict_GetItemString(original_namespace, *name) != NULL) {
+			continue;
+		}
+
+		PY_OWNED(bound, PyObject_GetAttrString(source, *name));
+
+		if (bound == NULL || PyDict_SetItemString(class_dict, *name, bound) < 0) {
+			return RESULT_ERROR;
+		}
+	}
+
+	return RESULT_OK;
+}
+
+static enum result refuse_unplanned(StructType const * const struct_class) {
+	PyErr_Format(
+		PyExc_TypeError,
+		"%.200s.__new__ returned a struct class this call did not plan: its "
+		"metaclass is re-entered without the keywords or the class body's "
+		"defaults, so what it built is not what was asked for",
+		Py_TYPE(struct_class)->tp_name
+	);
+
+	return RESULT_ERROR;
+}
+
+static enum result settle_planned(
+	StructType * const struct_class,
+	StructType const * const base,
+	PyObject * const name,
+	struct field_plan const * const plan,
+	PyObject * const original_namespace,
+	struct options const options,
+	struct options const inherited,
+	bool const frozen_across_bases,
+	bool const body_defines_eq,
+	bool const inherits_body_eq,
+	bool const derive_not_equal
+) {
+	static char const * const comparison[] = {
+		"__eq__",
+		"__lt__",
+		"__le__",
+		"__gt__",
+		"__ge__",
+		NULL,
+	};
+	static char const * const not_equal[] = {"__ne__", NULL};
+	static char const * const representation[] = {"__repr__", NULL};
+	static char const * const mutability[] = {"__setattr__", "__delattr__", NULL};
+	static char const * const hash_name[] = {"__hash__", NULL};
 	PY_OWNED(planned, PyList_AsTuple(plan->all_names));
 
 	if (planned == NULL) {
@@ -1106,23 +1197,114 @@ static enum result reject_unless_planned(
 		return RESULT_ERROR;
 	}
 
+	PY_OWNED(class_dict, struct_type_dict(&struct_class->heap_type.ht_type));
+
+	if (class_dict == NULL) {
+		return RESULT_ERROR;
+	}
+
+	PyObject * const built_name = (
+		struct_class->heap_type.ht_qualname != NULL ? (PyObject *) struct_class->heap_type.ht_qualname :
+		(PyObject *) struct_class->heap_type.ht_name
+	);
+	int const same_name = (
+		built_name != NULL ? PyObject_RichCompareBool(built_name, name, Py_EQ) :
+		0
+	);
+
+	if (same_name < 0) {
+		return RESULT_ERROR;
+	}
+
 	if (
-		same_fields == 1 &&
+		same_fields == 0 ||
+		same_name == 0 ||
+		find_struct_base(((PyTypeObject *) struct_class)->tp_bases) != base
+	) {
+		return refuse_unplanned(struct_class);
+	}
+
+	if (
 		struct_class->struct_default_count == PyTuple_GET_SIZE(plan->defaults) &&
 		options_agree(struct_class->struct_options, options)
 	) {
 		return RESULT_OK;
 	}
 
-	PyErr_Format(
-		PyExc_TypeError,
-		"%.200s.__new__ returned a struct class this call did not plan: its "
-		"metaclass is re-entered without the keywords or the class body's "
-		"defaults, so what it built is not what was asked for",
-		Py_TYPE(struct_class)->tp_name
-	);
+	if (options.weakref != inherited.weakref) {
+		return refuse_unplanned(struct_class);
+	}
 
-	return RESULT_ERROR;
+	Py_SETREF(struct_class->struct_defaults, Py_NewRef(plan->defaults));
+	struct_class->struct_default_count = PyTuple_GET_SIZE(plan->defaults);
+	struct_class->struct_options = options;
+	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
+
+	if (
+		options.eq != inherited.eq &&
+		settle_rebind(struct_class, original_namespace, comparison, options.eq) != RESULT_OK
+	) {
+		return RESULT_ERROR;
+	}
+
+	if (
+		options.eq != inherited.eq &&
+		!(body_defines_eq || derive_not_equal) &&
+		settle_rebind(struct_class, original_namespace, not_equal, options.eq) != RESULT_OK
+	) {
+		return RESULT_ERROR;
+	}
+
+	if (
+		options.repr != inherited.repr &&
+		settle_rebind(struct_class, original_namespace, representation, options.repr) != RESULT_OK
+	) {
+		return RESULT_ERROR;
+	}
+
+	if (
+		(options.frozen != inherited.frozen || frozen_across_bases) &&
+		settle_rebind(struct_class, original_namespace, mutability, options.frozen) != RESULT_OK
+	) {
+		return RESULT_ERROR;
+	}
+
+	if (
+		(
+			options.eq != inherited.eq ||
+			options.frozen != inherited.frozen ||
+			frozen_across_bases
+		) &&
+		!inherits_body_eq &&
+		PyDict_GetItemString(original_namespace, "__hash__") == NULL
+	) {
+		if (body_defines_eq || (options.eq && !options.frozen)) {
+			if (PyDict_SetItemString(class_dict, "__hash__", Py_None) < 0) {
+				return RESULT_ERROR;
+			}
+		} else if (
+			settle_rebind(struct_class, original_namespace, hash_name, options.eq) !=
+			RESULT_OK
+		) {
+			return RESULT_ERROR;
+		}
+	}
+
+	if (options.match_args != inherited.match_args) {
+		if (options.match_args) {
+			if (PyDict_SetItemString(class_dict, "__match_args__", planned) < 0) {
+				return RESULT_ERROR;
+			}
+		} else if (PyDict_DelItemString(class_dict, "__match_args__") < 0) {
+			if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+				PyErr_Clear();
+			} else {
+				return RESULT_ERROR;
+			}
+		}
+	}
+
+	return RESULT_OK;
 }
 
 static enum result install_fields(

--- a/src/meta.c
+++ b/src/meta.c
@@ -315,7 +315,7 @@ static PyObject * build_struct_class(
 		refuse_displaced_slots(
 				original_namespace,
 				plan.all_names,
-				request.options.weakref || any_base_has_weakref_slot(bases)
+				weakref_expected(request.options, bases)
 			) !=
 			RESULT_OK
 	) {
@@ -835,6 +835,10 @@ static bool settled_by_the_plan(char const * const name, struct binding_plan con
 		return plan.rebind_not_equal || plan.answered_by_body;
 	}
 
+	if (strcmp(name, "__init__") == 0 || strcmp(name, "__post_init__") == 0) {
+		return false;
+	}
+
 	if (strcmp(name, "__repr__") == 0) {
 		return plan.rebind_representation;
 	}
@@ -1299,6 +1303,8 @@ static enum result settle_planned(
 		"__setattr__",
 		"__delattr__",
 		"__hash__",
+		"__init__",
+		"__post_init__",
 		NULL,
 	};
 	PY_OWNED(planned, PyList_AsTuple(plan->all_names));
@@ -1382,7 +1388,7 @@ static enum result settle_planned(
 		return RESULT_ERROR;
 	}
 
-	if (bindings.answered_by_body && PyDict_GetItemString(class_dict, "__ne__") == NULL) {
+	if (bindings.answered_by_body && PyDict_GetItemString(original_namespace, "__ne__") == NULL) {
 		/* bind_not_equal's answered case on a live class: the fresh build
 		 * binds object's __ne__ when the body answered equality itself. */
 		PY_OWNED(object_ne, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__ne__"));
@@ -1466,7 +1472,14 @@ static enum result settle_planned(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
 
-	return RESULT_OK;
+	if (defines_own_init(struct_class)) {
+		struct_class->heap_type.ht_type.tp_new = Struct_new;
+		struct_class->heap_type.ht_type.tp_vectorcall = NULL;
+	} else {
+		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
+	}
+
+	return install_post_init(struct_class);
 }
 
 static enum result restore_stripped(

--- a/src/meta.c
+++ b/src/meta.c
@@ -54,6 +54,8 @@ static struct options inherited_options(PyObject * bases, StructType const * beh
 static bool any_struct_base_is_mutable(PyObject * bases);
 static bool has_weakref_slot(StructType const * base);
 static bool any_base_has_weakref_slot(PyObject * bases);
+static bool weakref_expected(struct options options, PyObject * bases);
+static bool weakref_slot_is_new(struct options options, PyObject * bases);
 static struct options base_options(StructType const * base);
 static PyObject * build_class_namespace(
 	PyObject * original_namespace,
@@ -122,6 +124,7 @@ static enum result install_fields(
 static enum result settle_planned(
 	StructType * struct_class,
 	StructType const * base,
+	PyObject * bases,
 	PyObject * name,
 	struct field_plan const * plan,
 	PyObject * original_namespace,
@@ -288,9 +291,7 @@ static PyObject * build_struct_class(
 
 	if (
 		metatype == &StructMeta_Type &&
-		request.options.weakref &&
-		!inherited.weakref &&
-		!any_base_has_weakref_slot(bases) &&
+		weakref_slot_is_new(request.options, bases) &&
 		winning_metatype(metatype, bases)->tp_new != StructMeta_new
 	) {
 		PyErr_SetString(
@@ -371,6 +372,7 @@ static PyObject * build_struct_class(
 			settle_planned(
 				struct_class,
 				base,
+				bases,
 				name,
 				&plan,
 				original_namespace,
@@ -613,6 +615,14 @@ static bool any_base_has_weakref_slot(PyObject * const bases) {
 	return false;
 }
 
+static bool weakref_expected(struct options const options, PyObject * const bases) {
+	return options.weakref || any_base_has_weakref_slot(bases);
+}
+
+static bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
+	return options.weakref && !any_base_has_weakref_slot(bases);
+}
+
 static PyObject * build_class_namespace(
 	PyObject * const original_namespace,
 	PyObject * const all_names,
@@ -770,6 +780,7 @@ enum hash_binding {
 };
 
 struct binding_plan {
+	bool answered_by_body;
 	bool rebind_comparison;
 	bool rebind_not_equal;
 	bool rebind_representation;
@@ -788,6 +799,7 @@ static struct binding_plan binding_plan(
 	bool const body_defines_hash
 ) {
 	struct binding_plan plan = {
+		.answered_by_body = body_defines_eq || derive_not_equal,
 		.rebind_comparison = options.eq != inherited.eq,
 		.rebind_not_equal = options.eq != inherited.eq && !(body_defines_eq || derive_not_equal),
 		.rebind_representation = options.repr != inherited.repr,
@@ -808,6 +820,32 @@ static struct binding_plan binding_plan(
 	return plan;
 }
 
+static bool settled_by_the_plan(char const * const name, struct binding_plan const plan) {
+	if (
+		strcmp(name, "__eq__") == 0 ||
+		strcmp(name, "__lt__") == 0 ||
+		strcmp(name, "__le__") == 0 ||
+		strcmp(name, "__gt__") == 0 ||
+		strcmp(name, "__ge__") == 0
+	) {
+		return plan.rebind_comparison;
+	}
+
+	if (strcmp(name, "__ne__") == 0) {
+		return plan.rebind_not_equal || plan.answered_by_body;
+	}
+
+	if (strcmp(name, "__repr__") == 0) {
+		return plan.rebind_representation;
+	}
+
+	if (strcmp(name, "__setattr__") == 0 || strcmp(name, "__delattr__") == 0) {
+		return plan.rebind_mutability;
+	}
+
+	return plan.hash == HASH_BIND || plan.hash == HASH_NONE;
+}
+
 static enum result apply_options(
 	PyObject * const namespace,
 	struct options const options,
@@ -819,7 +857,6 @@ static enum result apply_options(
 ) {
 	static char const * const comparison[] = {
 		"__eq__",
-		"__ne__",
 		"__lt__",
 		"__le__",
 		"__gt__",
@@ -840,11 +877,19 @@ static enum result apply_options(
 		PyDict_GetItemString(namespace, "__hash__") != NULL
 	);
 
-	if ((body_defines_eq || derive_not_equal) && rebind(namespace, not_equal, false) != RESULT_OK) {
+	if (
+		plan.answered_by_body &&
+		PyDict_GetItemString(namespace, "__ne__") == NULL &&
+		rebind(namespace, not_equal, false) != RESULT_OK
+	) {
 		return RESULT_ERROR;
 	}
 
 	if (plan.rebind_comparison && rebind(namespace, comparison, options.eq) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
+	if (plan.rebind_not_equal && rebind(namespace, not_equal, options.eq) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
 
@@ -1220,6 +1265,7 @@ static enum result refuse_unplanned(StructType const * const struct_class) {
 static enum result settle_planned(
 	StructType * const struct_class,
 	StructType const * const base,
+	PyObject * const bases,
 	PyObject * const name,
 	struct field_plan const * const plan,
 	PyObject * const original_namespace,
@@ -1292,17 +1338,10 @@ static enum result settle_planned(
 		return refuse_unplanned(struct_class);
 	}
 
-	if (options.weakref && ((PyTypeObject *) struct_class)->tp_weaklistoffset == 0) {
+	bool const carries_slot = ((PyTypeObject *) struct_class)->tp_weaklistoffset != 0;
+
+	if (carries_slot != weakref_expected(options, bases)) {
 		return refuse_unplanned(struct_class);
-	}
-
-	Py_SETREF(struct_class->struct_defaults, Py_NewRef(plan->defaults));
-	struct_class->struct_default_count = PyTuple_GET_SIZE(plan->defaults);
-	struct_class->struct_options = options;
-	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
-
-	if (restore_stripped(struct_class, original_namespace, class_dict, body_dunders) != RESULT_OK) {
-		return RESULT_ERROR;
 	}
 
 	struct binding_plan const bindings = binding_plan(
@@ -1314,6 +1353,20 @@ static enum result settle_planned(
 		derive_not_equal,
 		PyDict_GetItemString(original_namespace, "__hash__") != NULL
 	);
+
+	for (char const * const * name = body_dunders; *name != NULL; name += 1) {
+		if (
+			PyDict_GetItemString(class_dict, *name) != NULL &&
+			PyDict_GetItemString(original_namespace, *name) == NULL &&
+			!settled_by_the_plan(*name, bindings)
+		) {
+			return refuse_unplanned(struct_class);
+		}
+	}
+
+	if (restore_stripped(struct_class, original_namespace, class_dict, body_dunders) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
 
 	if (
 		bindings.rebind_comparison &&
@@ -1329,10 +1382,7 @@ static enum result settle_planned(
 		return RESULT_ERROR;
 	}
 
-	if (
-		(body_defines_eq || derive_not_equal) &&
-		PyDict_GetItemString(class_dict, "__ne__") == NULL
-	) {
+	if (bindings.answered_by_body && PyDict_GetItemString(class_dict, "__ne__") == NULL) {
 		/* bind_not_equal's answered case on a live class: the fresh build
 		 * binds object's __ne__ when the body answered equality itself. */
 		PY_OWNED(object_ne, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__ne__"));
@@ -1410,6 +1460,11 @@ static enum result settle_planned(
 			}
 		}
 	}
+
+	Py_SETREF(struct_class->struct_defaults, Py_NewRef(plan->defaults));
+	struct_class->struct_default_count = PyTuple_GET_SIZE(plan->defaults);
+	struct_class->struct_options = options;
+	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
 
 	return RESULT_OK;
 }

--- a/src/meta.c
+++ b/src/meta.c
@@ -835,7 +835,11 @@ static bool settled_by_the_plan(char const * const name, struct binding_plan con
 		return plan.rebind_not_equal || plan.answered_by_body;
 	}
 
-	if (strcmp(name, "__init__") == 0 || strcmp(name, "__post_init__") == 0) {
+	if (
+		strcmp(name, "__init__") == 0 ||
+		strcmp(name, "__post_init__") == 0 ||
+		strcmp(name, "__new__") == 0
+	) {
 		return false;
 	}
 
@@ -1305,6 +1309,7 @@ static enum result settle_planned(
 		"__hash__",
 		"__init__",
 		"__post_init__",
+		"__new__",
 		NULL,
 	};
 	PY_OWNED(planned, PyList_AsTuple(plan->all_names));
@@ -1336,9 +1341,20 @@ static enum result settle_planned(
 		return RESULT_ERROR;
 	}
 
+	int const same_bases = PyObject_RichCompareBool(
+		((PyTypeObject *) struct_class)->tp_bases,
+		bases,
+		Py_EQ
+	);
+
+	if (same_bases < 0) {
+		return RESULT_ERROR;
+	}
+
 	if (
 		same_fields == 0 ||
 		same_name == 0 ||
+		same_bases == 0 ||
 		find_struct_base(((PyTypeObject *) struct_class)->tp_bases) != base
 	) {
 		return refuse_unplanned(struct_class);
@@ -1580,7 +1596,7 @@ static enum result install_post_init(StructType * const struct_class) {
 		return RESULT_ERROR;
 	}
 
-	struct_class->struct_post_init = hook;
+	Py_XSETREF(struct_class->struct_post_init, hook);
 
 	return RESULT_OK;
 }

--- a/src/meta.c
+++ b/src/meta.c
@@ -287,6 +287,22 @@ static PyObject * build_struct_class(
 		return NULL;
 	}
 
+	if (
+		metatype == &StructMeta_Type &&
+		request.options.weakref &&
+		!inherited.weakref &&
+		!any_base_has_weakref_slot(bases) &&
+		winning_metatype(metatype, bases)->tp_new != StructMeta_new
+	) {
+		PyErr_SetString(
+			PyExc_TypeError,
+			"weakref=True cannot cross a metaclass __new__ that hands the build "
+			"off: the re-entered call cannot add the weakref slot"
+		);
+
+		return NULL;
+	}
+
 	struct field_plan plan = field_plan_build(base, original_namespace);
 
 	if (field_plan_failed(&plan)) {
@@ -1126,11 +1142,6 @@ static enum result settle_rebind(
 		from_mixin ? (PyObject *) &StructMixin_Type :
 		(PyObject *) &PyBaseObject_Type
 	);
-	PY_OWNED(class_dict, struct_type_dict(&struct_class->heap_type.ht_type));
-
-	if (class_dict == NULL) {
-		return RESULT_ERROR;
-	}
 
 	for (char const * const * name = names; *name != NULL; name += 1) {
 		if (PyDict_GetItemString(original_namespace, *name) != NULL) {
@@ -1138,8 +1149,13 @@ static enum result settle_rebind(
 		}
 
 		PY_OWNED(bound, PyObject_GetAttrString(source, *name));
+		PY_OWNED(unicode_name, PyUnicode_FromString(*name));
 
-		if (bound == NULL || PyDict_SetItemString(class_dict, *name, bound) < 0) {
+		if (
+			bound == NULL ||
+			unicode_name == NULL ||
+			PyType_Type.tp_setattro((PyObject *) struct_class, unicode_name, bound) < 0
+		) {
 			return RESULT_ERROR;
 		}
 	}
@@ -1203,10 +1219,7 @@ static enum result settle_planned(
 		return RESULT_ERROR;
 	}
 
-	PyObject * const built_name = (
-		struct_class->heap_type.ht_qualname != NULL ? (PyObject *) struct_class->heap_type.ht_qualname :
-		(PyObject *) struct_class->heap_type.ht_name
-	);
+	PyObject * const built_name = (PyObject *) struct_class->heap_type.ht_name;
 	int const same_name = (
 		built_name != NULL ? PyObject_RichCompareBool(built_name, name, Py_EQ) :
 		0
@@ -1231,7 +1244,7 @@ static enum result settle_planned(
 		return RESULT_OK;
 	}
 
-	if (options.weakref != inherited.weakref) {
+	if (options.weakref && ((PyTypeObject *) struct_class)->tp_weaklistoffset == 0) {
 		return refuse_unplanned(struct_class);
 	}
 
@@ -1279,7 +1292,12 @@ static enum result settle_planned(
 		PyDict_GetItemString(original_namespace, "__hash__") == NULL
 	) {
 		if (body_defines_eq || (options.eq && !options.frozen)) {
-			if (PyDict_SetItemString(class_dict, "__hash__", Py_None) < 0) {
+			PY_OWNED(unhashable, PyUnicode_FromString("__hash__"));
+
+			if (
+				unhashable == NULL ||
+				PyType_Type.tp_setattro((PyObject *) struct_class, unhashable, Py_None) < 0
+			) {
 				return RESULT_ERROR;
 			}
 		} else if (
@@ -1295,11 +1313,22 @@ static enum result settle_planned(
 			if (PyDict_SetItemString(class_dict, "__match_args__", planned) < 0) {
 				return RESULT_ERROR;
 			}
-		} else if (PyDict_DelItemString(class_dict, "__match_args__") < 0) {
-			if (PyErr_ExceptionMatches(PyExc_KeyError)) {
-				PyErr_Clear();
-			} else {
-				return RESULT_ERROR;
+		} else {
+			PyObject * const body_match_args = PyDict_GetItemString(
+				original_namespace,
+				"__match_args__"
+			);
+
+			if (body_match_args != NULL) {
+				if (PyDict_SetItemString(class_dict, "__match_args__", body_match_args) < 0) {
+					return RESULT_ERROR;
+				}
+			} else if (PyDict_DelItemString(class_dict, "__match_args__") < 0) {
+				if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+					PyErr_Clear();
+				} else {
+					return RESULT_ERROR;
+				}
 			}
 		}
 	}

--- a/src/meta.c
+++ b/src/meta.c
@@ -84,13 +84,6 @@ static enum result apply_options(
 	bool derive_not_equal
 );
 static enum result rebind(PyObject * namespace, char const * const * names, bool from_mixin);
-static enum result bind_not_equal(PyObject * namespace, bool answered_by_a_body);
-static enum result bind_hash(
-	PyObject * namespace,
-	struct options options,
-	bool body_defines_eq,
-	bool inherits_body_eq
-);
 static enum result drop_class_variables(PyObject * namespace, PyObject * all_names);
 static enum result refuse_colliding_methods(
 	PyObject * original_namespace,
@@ -144,6 +137,12 @@ static enum result settle_rebind(
 	PyObject * original_namespace,
 	char const * const * names,
 	bool from_mixin
+);
+static enum result restore_stripped(
+	StructType * struct_class,
+	PyObject * original_namespace,
+	PyObject * class_dict,
+	char const * const * names
 );
 static enum result refuse_unplanned(StructType const * struct_class);
 static enum result install_post_init(StructType * struct_class);
@@ -763,6 +762,52 @@ static enum result set_match_args(
 	);
 }
 
+enum hash_binding {
+	HASH_BODY_DEFINED,
+	HASH_INHERITED_EQ,
+	HASH_NONE,
+	HASH_BIND,
+};
+
+struct binding_plan {
+	bool rebind_comparison;
+	bool rebind_not_equal;
+	bool rebind_representation;
+	bool rebind_mutability;
+	enum hash_binding hash;
+	bool match_args_wanted;
+};
+
+static struct binding_plan binding_plan(
+	struct options const options,
+	struct options const inherited,
+	bool const frozen_across_bases,
+	bool const body_defines_eq,
+	bool const inherits_body_eq,
+	bool const derive_not_equal,
+	bool const body_defines_hash
+) {
+	struct binding_plan plan = {
+		.rebind_comparison = options.eq != inherited.eq,
+		.rebind_not_equal = options.eq != inherited.eq && !(body_defines_eq || derive_not_equal),
+		.rebind_representation = options.repr != inherited.repr,
+		.rebind_mutability = options.frozen != inherited.frozen || frozen_across_bases,
+		.match_args_wanted = options.match_args,
+	};
+
+	if (body_defines_hash) {
+		plan.hash = HASH_BODY_DEFINED;
+	} else if (inherits_body_eq) {
+		plan.hash = HASH_INHERITED_EQ;
+	} else if (body_defines_eq || (options.eq && !options.frozen)) {
+		plan.hash = HASH_NONE;
+	} else {
+		plan.hash = HASH_BIND;
+	}
+
+	return plan;
+}
+
 static enum result apply_options(
 	PyObject * const namespace,
 	struct options const options,
@@ -781,32 +826,58 @@ static enum result apply_options(
 		"__ge__",
 		NULL,
 	};
+	static char const * const not_equal[] = {"__ne__", NULL};
 	static char const * const representation[] = {"__repr__", NULL};
 	static char const * const mutability[] = {"__setattr__", "__delattr__", NULL};
+	static char const * const hash_name[] = {"__hash__", NULL};
+	struct binding_plan const plan = binding_plan(
+		options,
+		inherited,
+		frozen_across_bases,
+		body_defines_eq,
+		inherits_body_eq,
+		derive_not_equal,
+		PyDict_GetItemString(namespace, "__hash__") != NULL
+	);
 
-	if (bind_not_equal(namespace, body_defines_eq || derive_not_equal) != RESULT_OK) {
+	if ((body_defines_eq || derive_not_equal) && rebind(namespace, not_equal, false) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
 
-	if (options.eq != inherited.eq && rebind(namespace, comparison, options.eq) != RESULT_OK) {
+	if (plan.rebind_comparison && rebind(namespace, comparison, options.eq) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
 
 	if (
-		options.repr != inherited.repr &&
+		plan.rebind_representation &&
 		rebind(namespace, representation, options.repr) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
-	if (
-		(options.frozen != inherited.frozen || frozen_across_bases) &&
-		rebind(namespace, mutability, options.frozen) != RESULT_OK
-	) {
+	if (plan.rebind_mutability && rebind(namespace, mutability, options.frozen) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
 
-	return bind_hash(namespace, options, body_defines_eq, inherits_body_eq);
+	switch (plan.hash) {
+		case HASH_BODY_DEFINED:
+		case HASH_INHERITED_EQ:
+			break;
+		case HASH_NONE:
+			if (PyDict_SetItemString(namespace, "__hash__", Py_None) != 0) {
+				return RESULT_ERROR;
+			}
+
+			break;
+		case HASH_BIND:
+			if (rebind(namespace, hash_name, options.eq) != RESULT_OK) {
+				return RESULT_ERROR;
+			}
+
+			break;
+	}
+
+	return RESULT_OK;
 }
 
 static enum result rebind(
@@ -832,35 +903,6 @@ static enum result rebind(
 	}
 
 	return RESULT_OK;
-}
-
-static enum result bind_not_equal(PyObject * const namespace, bool const answered_by_a_body) {
-	static char const * const not_equal[] = {"__ne__", NULL};
-
-	return answered_by_a_body ? rebind(namespace, not_equal, false) : RESULT_OK;
-}
-
-static enum result bind_hash(
-	PyObject * const namespace,
-	struct options const options,
-	bool const body_defines_eq,
-	bool const inherits_body_eq
-) {
-	if (PyDict_GetItemString(namespace, "__hash__") != NULL) {
-		return RESULT_OK;
-	}
-
-	if (inherits_body_eq) {
-		return RESULT_OK;
-	}
-
-	if (body_defines_eq || (options.eq && !options.frozen)) {
-		return PyDict_SetItemString(namespace, "__hash__", Py_None) == 0 ? RESULT_OK : RESULT_ERROR;
-	}
-
-	static char const * const hash_name[] = {"__hash__", NULL};
-
-	return rebind(namespace, hash_name, options.eq);
 }
 
 static enum result drop_class_variables(PyObject * const namespace, PyObject * const all_names) {
@@ -1200,6 +1242,19 @@ static enum result settle_planned(
 	static char const * const representation[] = {"__repr__", NULL};
 	static char const * const mutability[] = {"__setattr__", "__delattr__", NULL};
 	static char const * const hash_name[] = {"__hash__", NULL};
+	static char const * const body_dunders[] = {
+		"__eq__",
+		"__ne__",
+		"__lt__",
+		"__le__",
+		"__gt__",
+		"__ge__",
+		"__repr__",
+		"__setattr__",
+		"__delattr__",
+		"__hash__",
+		NULL,
+	};
 	PY_OWNED(planned, PyList_AsTuple(plan->all_names));
 
 	if (planned == NULL) {
@@ -1237,13 +1292,6 @@ static enum result settle_planned(
 		return refuse_unplanned(struct_class);
 	}
 
-	if (
-		struct_class->struct_default_count == PyTuple_GET_SIZE(plan->defaults) &&
-		options_agree(struct_class->struct_options, options)
-	) {
-		return RESULT_OK;
-	}
-
 	if (options.weakref && ((PyTypeObject *) struct_class)->tp_weaklistoffset == 0) {
 		return refuse_unplanned(struct_class);
 	}
@@ -1253,83 +1301,139 @@ static enum result settle_planned(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
 
+	if (restore_stripped(struct_class, original_namespace, class_dict, body_dunders) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
+	struct binding_plan const bindings = binding_plan(
+		options,
+		inherited,
+		frozen_across_bases,
+		body_defines_eq,
+		inherits_body_eq,
+		derive_not_equal,
+		PyDict_GetItemString(original_namespace, "__hash__") != NULL
+	);
+
 	if (
-		options.eq != inherited.eq &&
+		bindings.rebind_comparison &&
 		settle_rebind(struct_class, original_namespace, comparison, options.eq) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
 	if (
-		options.eq != inherited.eq &&
-		!(body_defines_eq || derive_not_equal) &&
+		bindings.rebind_not_equal &&
 		settle_rebind(struct_class, original_namespace, not_equal, options.eq) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
 	if (
-		options.repr != inherited.repr &&
+		(body_defines_eq || derive_not_equal) &&
+		PyDict_GetItemString(class_dict, "__ne__") == NULL
+	) {
+		/* bind_not_equal's answered case on a live class: the fresh build
+		 * binds object's __ne__ when the body answered equality itself. */
+		PY_OWNED(object_ne, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__ne__"));
+		PY_OWNED(ne_name, PyUnicode_FromString("__ne__"));
+
+		if (
+			object_ne == NULL ||
+			ne_name == NULL ||
+			PyType_Type.tp_setattro((PyObject *) struct_class, ne_name, object_ne) < 0
+		) {
+			return RESULT_ERROR;
+		}
+	}
+
+	if (
+		bindings.rebind_representation &&
 		settle_rebind(struct_class, original_namespace, representation, options.repr) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
 	if (
-		(options.frozen != inherited.frozen || frozen_across_bases) &&
+		bindings.rebind_mutability &&
 		settle_rebind(struct_class, original_namespace, mutability, options.frozen) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
-	if (
-		(
-			options.eq != inherited.eq ||
-			options.frozen != inherited.frozen ||
-			frozen_across_bases
-		) &&
-		!inherits_body_eq &&
-		PyDict_GetItemString(original_namespace, "__hash__") == NULL
-	) {
-		if (body_defines_eq || (options.eq && !options.frozen)) {
-			PY_OWNED(unhashable, PyUnicode_FromString("__hash__"));
+	switch (bindings.hash) {
+		case HASH_BODY_DEFINED:
+		case HASH_INHERITED_EQ:
+			break;
+		case HASH_NONE: {
+			PY_OWNED(hash_name_obj, PyUnicode_FromString("__hash__"));
 
 			if (
-				unhashable == NULL ||
-				PyType_Type.tp_setattro((PyObject *) struct_class, unhashable, Py_None) < 0
+				hash_name_obj == NULL ||
+				PyType_Type.tp_setattro((PyObject *) struct_class, hash_name_obj, Py_None) < 0
 			) {
 				return RESULT_ERROR;
 			}
-		} else if (
-			settle_rebind(struct_class, original_namespace, hash_name, options.eq) !=
-			RESULT_OK
-		) {
+
+			break;
+		}
+		case HASH_BIND:
+			if (
+				settle_rebind(struct_class, original_namespace, hash_name, options.eq) !=
+				RESULT_OK
+			) {
+				return RESULT_ERROR;
+			}
+
+			break;
+	}
+
+	if (bindings.match_args_wanted) {
+		if (PyDict_SetItemString(class_dict, "__match_args__", planned) < 0) {
 			return RESULT_ERROR;
+		}
+	} else {
+		PyObject * const body_match_args = PyDict_GetItemString(
+			original_namespace,
+			"__match_args__"
+		);
+
+		if (body_match_args != NULL) {
+			if (PyDict_SetItemString(class_dict, "__match_args__", body_match_args) < 0) {
+				return RESULT_ERROR;
+			}
+		} else if (PyDict_DelItemString(class_dict, "__match_args__") < 0) {
+			if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+				PyErr_Clear();
+			} else {
+				return RESULT_ERROR;
+			}
 		}
 	}
 
-	if (options.match_args != inherited.match_args) {
-		if (options.match_args) {
-			if (PyDict_SetItemString(class_dict, "__match_args__", planned) < 0) {
-				return RESULT_ERROR;
-			}
-		} else {
-			PyObject * const body_match_args = PyDict_GetItemString(
-				original_namespace,
-				"__match_args__"
-			);
+	return RESULT_OK;
+}
 
-			if (body_match_args != NULL) {
-				if (PyDict_SetItemString(class_dict, "__match_args__", body_match_args) < 0) {
-					return RESULT_ERROR;
-				}
-			} else if (PyDict_DelItemString(class_dict, "__match_args__") < 0) {
-				if (PyErr_ExceptionMatches(PyExc_KeyError)) {
-					PyErr_Clear();
-				} else {
-					return RESULT_ERROR;
-				}
-			}
+static enum result restore_stripped(
+	StructType * const struct_class,
+	PyObject * const original_namespace,
+	PyObject * const class_dict,
+	char const * const * const names
+) {
+	for (char const * const * name = names; *name != NULL; name += 1) {
+		PyObject * const body_value = PyDict_GetItemString(original_namespace, *name);
+
+		if (body_value == NULL || PyDict_GetItemString(class_dict, *name) == body_value) {
+			continue;
+		}
+
+		PY_OWNED(unicode_name, PyUnicode_FromString(*name));
+
+		if (
+			unicode_name == NULL ||
+			PyType_Type.tp_setattro((PyObject *) struct_class, unicode_name, body_value) < 0
+		) {
+			return RESULT_ERROR;
 		}
 	}
 

--- a/src/options.h
+++ b/src/options.h
@@ -12,17 +12,6 @@ struct options {
 	bool weakref;
 };
 
-static inline bool options_agree(struct options const left, struct options const right) {
-	return (
-		left.frozen == right.frozen &&
-		left.eq == right.eq &&
-		left.order == right.order &&
-		left.repr == right.repr &&
-		left.match_args == right.match_args &&
-		left.weakref == right.weakref
-	);
-}
-
 struct options_request {
 	enum { OPTIONS_RESOLVED, OPTIONS_REJECTED } tag;
 	struct options options;

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -331,27 +331,50 @@ class TestAMetaclassSubclass:
 
         assert built(1).y == 42
 
-    def test_a_delegate_that_writes_its_own_new_is_refused_not_mis_planned(self):
-        """The half of #55 that is answerable here: the class the delegate hands
-        back is checked against what this call planned, and a mismatch is an
-        error rather than a class that quietly is not the one asked for.
-
-        The class statement is not affected, and the test below this one says
-        so: there the winner is the requested metatype, so nothing is handed
-        off and the keywords and the body's defaults are still in hand.
+    def test_a_delegate_returning_a_foreign_class_is_refused(self):
+        """The class the delegate hands back is settled only when it is the
+        class this call describes; a class the delegate found lying around
+        keeps the refusal, so the caller never receives one whose fields are
+        not what was asked for.
         """
 
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
+        calls = []
 
-        class Base(Struct, metaclass=Forwarding):
+        class Wrong(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                calls.append(1)
+
+                if len(calls) == 1:
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                return Base
+
+        class Base(Struct, metaclass=Wrong):
             x: int
 
-        namespace = {"__annotations__": {"y": int}, "y": 42}
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), {"__annotations__": {"y": int}})
+
+    def test_a_delegate_that_renames_the_class_is_refused(self):
+        """The fields and the base can both match and the class still not be
+        the one this call describes, so the name is part of the check.
+        """
+
+        class Renaming(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(
+                    metacls,
+                    "Seeded" if name == "Seeded" else "Fake",
+                    bases,
+                    namespace,
+                    **keywords
+                )
+
+        class Seeded(Struct, metaclass=Renaming):
+            x: int
 
         with pytest.raises(TypeError, match="did not plan"):
-            META("Built", (Base,), namespace, order=True)
+            META("Built", (Seeded,), {"__annotations__": {"y": int}})
 
     def test_the_class_statement_reaches_none_of_that(self):
         """The hand-off only happens for an explicit metaclass call over a base
@@ -373,17 +396,12 @@ class TestAMetaclassSubclass:
         assert Statement(1).y == 42
         assert Statement(1) < Statement(1, 43)
 
-    @pytest.mark.xfail(strict=True, reason="#55")
     def test_both_survive_a_delegate_that_writes_its_own_new(self):
-        """What the two above do not cover. They pass because the winner's
-        tp_new is StructMeta_new, so create_class builds as the winner and the
-        keywords and the untransformed namespace are still in hand. A Python
-        __new__ -- even one that only forwards -- makes type_new hand the build
-        to it instead, with no keywords and a namespace drop_class_variables has
-        already taken the defaults out of.
-
-        Refused rather than mis-planned since the guard above, which is not the
-        same as fixed: what #55 wants is for this call to work.
+        """A Python __new__ -- even one that only forwards -- makes type_new
+        hand the build to it with no keywords and a namespace
+        drop_class_variables has already taken the defaults out of. The class
+        the delegate built is the one this call planned, so the call's own
+        options and defaults are applied to it.
         """
 
         class Forwarding(META):
@@ -398,6 +416,72 @@ class TestAMetaclassSubclass:
 
         assert built(1).y == 42
         assert built(1) < built(1, 43)
+
+    def test_a_delegate_can_turn_frozen_off(self):
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            pass
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, frozen=False)
+        instance = built(1)
+        instance.y = 2
+
+        assert instance.y == 2
+        assert built.__hash__ is None
+
+    def test_a_delegate_can_turn_eq_off(self):
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, eq=False)
+
+        assert built(1, 2) != built(1, 2)
+
+        with pytest.raises(TypeError, match="not supported between instances"):
+            _ = built(1, 2) < built(1, 2)
+
+    def test_a_delegate_can_turn_repr_off(self):
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, repr=False)
+        instance = built(1, 2)
+
+        assert repr(instance) == object.__repr__(instance)
+
+    def test_a_delegate_can_turn_match_args_off(self):
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, match_args=False)
+
+        assert "__match_args__" not in built.__dict__
+
+    def test_a_delegate_cannot_drop_a_weakref_slot_the_base_planned(self):
+        class Forwarding(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Forwarding, weakref=True):
+            x: int
+
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=False)
 
     @pytest.mark.parametrize("produced", ["not a type", bytearray(8192), 0])
     def test_one_that_returns_a_non_type_is_refused(self, produced):

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -606,6 +606,83 @@ class TestAMetaclassSubclass:
         with pytest.raises(TypeError, match="did not plan"):
             META("Built", (Base,), {"__annotations__": {"y": int}})
 
+    def test_a_delegate_that_strips_init_is_settled(self):
+        """install_fields' construction decision is re-applied: the body's
+        __init__ is restored so tp_new routes through it (a body __init__
+        displaces the constructor that would run __post_init__, exactly as
+        a fresh build behaves).
+        """
+
+        class Stripping(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if name == "Base":
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                namespace.pop("__init__", None)
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Stripping):
+            x: int
+
+        namespace = {
+            "__annotations__": {"y": int},
+            "__init__": lambda self, y: salix.set_field(self, "y", y + 100),
+        }
+        built = META("Built", (Base,), namespace)
+
+        assert built(1).y == 101
+
+    def test_a_delegate_that_strips_post_init_is_settled(self):
+        """install_fields' post_init decision is re-applied: the body's hook
+        is restored and runs.
+        """
+
+        class Stripping(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if name == "Base":
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                namespace.pop("__post_init__", None)
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Stripping):
+            x: int
+
+        namespace = {
+            "__annotations__": {"y": int},
+            "__post_init__": lambda self: salix.set_field(self, "y", self.y * 2),
+        }
+        built = META("Built", (Base,), namespace)
+
+        assert built(0, 4).y == 8
+
+    def test_a_delegate_that_injects_ne_when_the_body_answers_eq_is_overwritten(self):
+        """The answered arm binds object's __ne__ whenever the body did not
+        define one, overwriting whatever the delegate injected.
+        """
+
+        class Injecting(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if name == "Base":
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                namespace["__ne__"] = lambda self, other: True
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        def by_x(self, other):
+            return self.x == other.x
+
+        class Base(Struct, metaclass=Injecting):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "__eq__": by_x}
+        built = META("Built", (Base,), namespace)
+
+        assert (built(1, 7) != built(1, 8)) is False
+
     def test_a_delegate_returning_same_count_defaults_is_corrected_not_accepted(self):
         """A lying-around class can match the plan's name, fields, and default
         count while carrying different default values; the settle installs the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -560,6 +560,52 @@ class TestAMetaclassSubclass:
         assert built(1, 7) == built(1, 8)
         assert hash(built(1, 7)) == hash(1)
 
+    def test_a_delegate_that_injects_a_dunder_is_refused(self):
+        """A dunder the delegate adds while the plan binds nothing for it
+        would behave differently from the fresh build, so the settle refuses
+        rather than silently keep it.
+        """
+
+        class Injecting(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if name == "Base":
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                namespace["__eq__"] = lambda self, other: True
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Injecting):
+            x: int
+
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), {"__annotations__": {"y": int}})
+
+    def test_a_delegate_returning_a_weakref_slotted_class_is_refused(self):
+        """A lying-around class built with weakref=True carries a slot the
+        fresh build of this call would not, so the settle refuses it.
+        """
+
+        calls = []
+
+        class Substituting(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                calls.append(1)
+
+                if len(calls) <= 2:
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                return Built
+
+        class Base(Struct, metaclass=Substituting):
+            x: int
+
+        class Built(Base, weakref=True):
+            y: int = 99
+
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), {"__annotations__": {"y": int}})
+
     def test_a_delegate_returning_same_count_defaults_is_corrected_not_accepted(self):
         """A lying-around class can match the plan's name, fields, and default
         count while carrying different default values; the settle installs the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -528,6 +528,66 @@ class TestAMetaclassSubclass:
         assert repr(instance) == object.__repr__(instance)
         assert hash(instance) == object.__hash__(instance)
 
+    def test_a_delegate_that_strips_a_body_dunder_restores_it(self):
+        """The fresh build keeps a body-defined dunder; a delegate that strips
+        it leaves the built class without it, and the settle restores the
+        body's own definition.
+        """
+
+        class Stripping(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                namespace.pop("__eq__", None)
+                namespace.pop("__hash__", None)
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        def by_x(self, other):
+            return self.x == other.x
+
+        def hash_x(self):
+            return hash(self.x)
+
+        class Base(Struct, metaclass=Stripping):
+            x: int
+
+        namespace = {
+            "__annotations__": {"y": int},
+            "__eq__": by_x,
+            "__hash__": hash_x,
+        }
+        built = META("Built", (Base,), namespace)
+
+        assert built(1, 7) == built(1, 8)
+        assert hash(built(1, 7)) == hash(1)
+
+    def test_a_delegate_returning_same_count_defaults_is_corrected_not_accepted(self):
+        """A lying-around class can match the plan's name, fields, and default
+        count while carrying different default values; the settle installs the
+        call's own defaults rather than accepting the class silently.
+        """
+
+        calls = []
+
+        class Substituting(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                calls.append(1)
+
+                if len(calls) <= 2:
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                return Built
+
+        class Base(Struct, metaclass=Substituting):
+            x: int
+
+        class Built(Base):
+            y: int = 99
+
+        namespace = {"__annotations__": {"y": int}, "y": 42}
+        built = META("Built", (Base,), namespace)
+
+        assert built(1).y == 42
+
     def test_a_body_qualname_does_not_upset_the_settle(self):
         """The name check reads ht_name; a body-set __qualname__ is legal and
         the fresh path accepts it.

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1,4 +1,5 @@
 import collections.abc
+import weakref
 
 import pytest
 
@@ -7,6 +8,11 @@ from salix import Struct
 
 MIXIN = Struct.__mro__[1]
 META = type(Struct)
+
+
+class Forwarding(META):
+    def __new__(metacls, name, bases, namespace, **keywords):
+        return super().__new__(metacls, name, bases, namespace, **keywords)
 
 # Both spellings of both, in one place: two literals drifted apart is a test
 # that silently stops covering a name.
@@ -382,10 +388,6 @@ class TestAMetaclassSubclass:
         serious regression if it reached the ordinary spelling.
         """
 
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
         class Base(Struct, metaclass=Forwarding):
             x: int
 
@@ -404,10 +406,6 @@ class TestAMetaclassSubclass:
         options and defaults are applied to it.
         """
 
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
         class Base(Struct, metaclass=Forwarding):
             x: int
 
@@ -418,10 +416,6 @@ class TestAMetaclassSubclass:
         assert built(1) < built(1, 43)
 
     def test_a_delegate_can_turn_frozen_off(self):
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
         class Base(Struct, metaclass=Forwarding):
             pass
 
@@ -433,10 +427,6 @@ class TestAMetaclassSubclass:
         assert built.__hash__ is None
 
     def test_a_delegate_can_turn_eq_off(self):
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
         class Base(Struct, metaclass=Forwarding):
             x: int
 
@@ -448,10 +438,6 @@ class TestAMetaclassSubclass:
             _ = built(1, 2) < built(1, 2)
 
     def test_a_delegate_can_turn_repr_off(self):
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
         class Base(Struct, metaclass=Forwarding):
             x: int
 
@@ -461,10 +447,6 @@ class TestAMetaclassSubclass:
         assert repr(instance) == object.__repr__(instance)
 
     def test_a_delegate_can_turn_match_args_off(self):
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
         class Base(Struct, metaclass=Forwarding):
             x: int
 
@@ -472,16 +454,93 @@ class TestAMetaclassSubclass:
 
         assert "__match_args__" not in built.__dict__
 
-    def test_a_delegate_cannot_drop_a_weakref_slot_the_base_planned(self):
-        class Forwarding(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
+    def test_a_body_match_args_survives_the_delegate_when_turned_off(self):
+        """The fresh build only ever adds __match_args__ when wanted, so a
+        body-defined one survives match_args=False; the settle restores it
+        where the re-entered build has overwritten it.
+        """
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "__match_args__": ("first",)}
+        built = META("Built", (Base,), namespace, match_args=False)
+
+        assert built.__match_args__ == ("first",)
+
+    def test_a_weakref_base_keeps_its_slot_when_the_delegate_turns_weakref_off(self):
+        """weakref=False is metadata; the fresh path also inherits the base's
+        slot, so the settle accepts the class as-is.
+        """
 
         class Base(Struct, metaclass=Forwarding, weakref=True):
             x: int
 
-        with pytest.raises(TypeError, match="did not plan"):
-            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=False)
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=False)
+        instance = built(1, 2)
+
+        assert weakref.ref(instance)() is instance
+
+    def test_a_delegate_cannot_add_a_weakref_slot_the_call_planned(self):
+        """The re-entered build cannot add the weakref slot, so the refusal
+        says so instead of dying in the inner call's displaced-slot check.
+        """
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        with pytest.raises(TypeError, match="cannot cross"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+
+    def test_a_delegate_that_strips_the_dunders_is_settled(self):
+        """A delegate that removes the dunders from the namespace leaves the
+        built class with the mixin's C slots, which ignore dict writes; the
+        settle rebinds through the type so the slots follow.
+        """
+
+        class Stripping(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                for dunder in (
+                    "__eq__",
+                    "__ne__",
+                    "__lt__",
+                    "__le__",
+                    "__gt__",
+                    "__ge__",
+                    "__repr__",
+                    "__setattr__",
+                    "__delattr__",
+                    "__hash__",
+                ):
+                    namespace.pop(dunder, None)
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Stripping):
+            pass
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, frozen=False, eq=False, repr=False)
+        instance = built(1)
+        instance.y = 2
+
+        assert instance.y == 2
+        assert built(1) != built(1)
+        assert repr(instance) == object.__repr__(instance)
+        assert hash(instance) == object.__hash__(instance)
+
+    def test_a_body_qualname_does_not_upset_the_settle(self):
+        """The name check reads ht_name; a body-set __qualname__ is legal and
+        the fresh path accepts it.
+        """
+
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "__qualname__": "Wrapped.Built"}
+        built = META("Built", (Base,), namespace)
+
+        assert built.__qualname__ == "Wrapped.Built"
+        assert built(1, 2).y == 2
 
     @pytest.mark.parametrize("produced", ["not a type", bytearray(8192), 0])
     def test_one_that_returns_a_non_type_is_refused(self, produced):

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -426,6 +426,9 @@ class TestAMetaclassSubclass:
         assert instance.y == 2
         assert built.__hash__ is None
 
+        with pytest.raises(TypeError, match="unhashable"):
+            hash(instance)
+
     def test_a_delegate_can_turn_eq_off(self):
         class Base(Struct, metaclass=Forwarding):
             x: int
@@ -682,6 +685,79 @@ class TestAMetaclassSubclass:
         built = META("Built", (Base,), namespace)
 
         assert (built(1, 7) != built(1, 8)) is False
+
+    def test_a_delegate_that_strips_new_is_settled(self):
+        """The fresh build keeps a body __new__ in the class dict (dispatch
+        never consults it), so a delegate that strips it is restored.
+        """
+
+        class Stripping(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if name == "Base":
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                namespace.pop("__new__", None)
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        def body_new(cls, *args):
+            return super(cls, cls).__new__(cls, *args)
+
+        class Base(Struct, metaclass=Stripping):
+            x: int
+
+        namespace = {"__annotations__": {"y": int}, "__new__": body_new}
+        built = META("Built", (Base,), namespace)
+
+        assert "__new__" in built.__dict__
+
+    def test_a_delegate_that_injects_new_is_refused(self):
+        """A __new__ the delegate adds while the body defined none would
+        change construction, so the settle refuses.
+        """
+
+        class Injecting(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if name == "Base":
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                namespace["__new__"] = lambda cls, *args: None
+
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Injecting):
+            x: int
+
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), {"__annotations__": {"y": int}})
+
+    def test_a_delegate_that_adds_a_non_struct_base_is_refused(self):
+        """The identity gate compares the bases tuple, not just the layout
+        base; an extra base would route construction through its __init__.
+        """
+
+        calls = []
+
+        class Substituting(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                calls.append(1)
+
+                if len(calls) <= 2:
+                    return super().__new__(metacls, name, bases, namespace, **keywords)
+
+                return Built
+
+        class Base(Struct, metaclass=Substituting):
+            x: int
+
+        class InitBase:
+            pass
+
+        class Built(Base, InitBase):
+            y: int = 99
+
+        with pytest.raises(TypeError, match="did not plan"):
+            META("Built", (Base,), {"__annotations__": {"y": int}})
 
     def test_a_delegate_returning_same_count_defaults_is_corrected_not_accepted(self):
         """A lying-around class can match the plan's name, fields, and default


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to keep working the pre-publish batches — after #101 merged, the residue (#55, #57, #53), one PR each, iterated with the automated reviewer.

## Semantics

`META("Built", (Base,), namespace, order=True)` over a `StructMeta` subclass with a Python `__new__` re-enters the build with no keywords and a namespace `drop_class_variables` has already stripped, so the class the delegate hands back has its fields installed but none of the call's options or defaults — and the outer call used to refuse it.

The outer call now **settles** that class when it is the one the call describes, and keeps the refusal otherwise:

<details>
<summary>What the settle applies, and what is still refused</summary>

- **Settled** — the plan's defaults (`struct_defaults`/`struct_default_count`), the call's options (`struct_options`, so `order` takes effect at compare time), `struct_resolves_body_eq`, and the dunder rebindings for every option that changed across the re-entry: eq (the five comparison names, plus `__ne__` when the body did not answer equality), repr, frozen (the mutability pair and the hash, following `bind_hash`'s body-eq rule), and match_args. Each arm reproduces what a fresh-namespace `apply_options` would have bound, skipping names the body defined.
- **Refused** (the same TypeError) — a class whose field names, name, or layout base differ from the plan, so a class the delegate found lying around is never overwritten with this call's plan; a renamed class, refused by the `ht_qualname`/`ht_name` check; a weakref-slot difference, because a slot layout is baked at creation and cannot be settled afterwards.
</details>

## Tests

The strict `xfail` on `test_both_survive_a_delegate_that_writes_its_own_new` flips: the forwarding delegate now carries the defaults and `order=True` through. New pins: the foreign-class refusal and the rename refusal, one test per settled option (`frozen`, `eq`, `repr`, `match_args`), and the weakref refusal.

Closes #55.