### PR TITLE
docs: the ClassVar/InitVar escapes and the cached_property answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ the check is a spelling match, and the two paths differ at the edges:
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 
 3.14 evaluates resolvable annotations by default, so there the alias reaches
-the object path and is refused; a name nothing can resolve — bare or
-compound — arrives as an object too, and is accepted, while an annotation
-whose evaluation raises AttributeError still fails the class. Every row is
-pinned in `tests/test_classvar_paths.py`.
+the object path and is refused; a name whose root cannot be resolved
+arrives as an object too, and is accepted, while any other evaluation
+error still fails the class. Every row is pinned in
+`tests/test_classvar_paths.py`.
 
 ## Caching a computed value
 
@@ -72,8 +72,9 @@ method, or a field that `__post_init__` fills:
 Under the default eq=True the method cache keys on the value, not the
 instance: value-equal structs share one entry, and a `set_field` that
 changes the value misses — the cache then holds the old entry and the new
-one. With eq=False the struct hashes by identity, and `set_field` after a
-hit returns the stale cached value while the hash is unchanged; a body
+one. With eq=False the struct hashes by identity — unless the body defines
+its own `__eq__`, which still makes it unhashable — and `set_field` after
+a hit returns the stale cached value while the hash is unchanged; a body
 `__hash__` over field values changes the hash and the lookup misses. The
 cache refuses an unhashable struct — anything that makes `hash()` raise:
 under the default options that is `frozen=False`, a body-defined `__eq__`,

--- a/README.md
+++ b/README.md
@@ -18,28 +18,31 @@ Point(x=1.0, y=2.0)
 ## ClassVar and InitVar
 
 A field annotated `ClassVar[...]` or `InitVar[...]` is refused at class
-creation, exactly when the annotation is an object. When the annotation
-reaches salix as source text (under `from __future__ import annotations`)
-the check is a spelling match, and the spellings it cannot see are:
+creation. The check is exact when the annotation reaches salix as an object;
+when it arrives as source text -- a quoted string, or an annotation that
+nothing evaluated -- the check is a spelling match, and the two paths differ
+at the edges:
 
-| annotation | what the spelling match does |
-| --- | --- |
-| an alias of `ClassVar`, `CV[int]` | accepted; the field swallows a positional |
-| a factory-local alias, 3.14 | accepted; the same symptom |
-| `Optional[Annotated[ClassVar[int], "m"]]` | the object path accepts, the text path refuses |
-| a type of yours actually named `ClassVar` | refused |
-| `Annotated[int, ClassVar]` | refused, though the form is metadata |
+| annotation | object path | text path |
+| --- | --- | --- |
+| an alias of `ClassVar`, `CV[int]` | refused | accepted; the field swallows a positional |
+| a type of yours actually named `ClassVar` | accepted | refused |
+| `Annotated[int, ClassVar]` | accepted | refused, though the form is metadata |
+| `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
+
+3.14 evaluates resolvable annotations by default, so there the alias reaches
+the object path and is refused; the text path sees only what nothing can
+resolve.
 
 ## Caching a computed value
 
 `functools.cached_property` caches into an instance `__dict__`, and a struct
-has none; a slotted frozen dataclass refuses it the same way. Cache on the
-method instead -- the cache then holds every instance it has seen -- or fill
-a field from `__post_init__`:
+has none; a slotted frozen dataclass refuses it the same way. Two answers:
+`functools.cache` on the method, or a field that `__post_init__` fills:
 
 ```python
 >>> import functools
->>> from salix import set_field
+>>> from salix import Struct, set_field
 
 >>> class Computed(Struct):
 ...     x: int
@@ -62,6 +65,11 @@ a field from `__post_init__`:
 8
 
 ```
+
+The method cache holds every instance it has seen -- one entry per mutation
+state, since structs hash by value -- and refuses when the instance is
+unhashable. A body-defined `__init__` replaces the constructor that runs
+`__post_init__`, so the field answer only works without one.
 
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.

--- a/README.md
+++ b/README.md
@@ -73,15 +73,16 @@ Under the default eq=True the method cache keys on the value, not the
 instance: value-equal structs share one entry, and a `set_field` that
 changes the value misses — the cache then holds the old entry and the new
 one. With eq=False the struct hashes by identity — unless the body defines
-its own `__eq__`, which still makes it unhashable — and `set_field` after
+its own `__eq__` without a `__hash__`, which makes it unhashable, or its
+own `__hash__`, which replaces the identity hash — and `set_field` after
 a hit returns the stale cached value while the hash is unchanged; a body
 `__hash__` over field values changes the hash and the lookup misses. The
 cache refuses an unhashable struct — anything that makes `hash()` raise:
-under the default options that is `frozen=False`, a body-defined `__eq__`,
-a body `__hash__` that refuses, an unhashable field value, or equality
-inherited from a struct base that defines `__eq__`. An `__init__` that is
-not `object.__init__` — a body-written one, inherited or not — replaces
-the constructor that runs `__post_init__`, so the field answer only works
+a body `__eq__` without a body `__hash__`, a body `__hash__` that
+refuses, `frozen=False`, an unhashable field value, or equality inherited
+from a struct base that defines `__eq__`. An `__init__` that is not
+`object.__init__` — a body-written one, inherited or not — replaces the
+constructor that runs `__post_init__`, so the field answer only works
 without one. The table and the caching behaviors above are pinned in
 `tests/test_classvar_paths.py`.
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ the check is a spelling match, and the two paths differ at the edges:
 | --- | --- | --- |
 | an alias of `ClassVar`, `CV[int]` | refused | accepted; the field swallows a positional |
 | a type of yours actually named `ClassVar` | accepted | refused |
-| `Annotated[int, ClassVar]` | accepted, 3.11+ | refused, though the `ClassVar` there is metadata |
+| `Annotated[int, ClassVar]` | accepted | refused, though the `ClassVar` there is metadata |
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 
 3.14 evaluates resolvable annotations by default, so there the alias reaches
-the object path and is refused; an annotation nothing can resolve arrives as
-an object too, and is accepted. Every row is pinned in
+the object path and is refused; a bare name nothing can resolve arrives as an
+object too, and is accepted, while an annotation whose evaluation fails any
+other way still fails the class. Every row is pinned in
 `tests/test_classvar_paths.py`.
 
 ## Caching a computed value
@@ -69,16 +70,18 @@ method, or a field that `__post_init__` fills:
 ```
 
 Under the default eq=True the method cache keys on the value, not the
-instance: value-equal structs share one entry, and `set_field` after a hit
-misses — the cache then holds the old entry and the new one. With eq=False
-the struct hashes by identity instead, and `set_field` after a hit returns
-the stale cached value — unless the body defines its own `__eq__`, which
-still makes it unhashable. The cache refuses an unhashable struct — under
-eq=True that is one with `frozen=False`, a body-defined `__eq__`, or an
-unhashable field value. An `__init__` that is not `object.__init__` —
-defined in the body or inherited from a non-struct base — replaces the
-constructor that runs `__post_init__`, so the field answer only works
-without one. The claims are pinned in `tests/test_classvar_paths.py`.
+instance: value-equal structs share one entry, and a `set_field` that
+changes the value misses — the cache then holds the old entry and the new
+one. With eq=False the struct hashes by identity instead, and `set_field`
+after a hit returns the stale cached value — unless the body defines its
+own `__eq__` or `__hash__`. The cache refuses an unhashable struct —
+anything that makes `hash()` raise: under the default options that is
+`frozen=False`, a body-defined `__eq__` or `__hash__`, an unhashable field
+value, or equality inherited from a struct base that defines `__eq__`. An
+`__init__` that is not `object.__init__` — defined in the body or inherited
+from any base — replaces the constructor that runs `__post_init__`, so the
+field answer only works without one. The table and the caching behaviors
+above are pinned in `tests/test_classvar_paths.py`.
 
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.

--- a/README.md
+++ b/README.md
@@ -18,27 +18,29 @@ Point(x=1.0, y=2.0)
 ## ClassVar and InitVar
 
 A field annotated `ClassVar[...]` or `InitVar[...]` is refused at class
-creation. The check is exact when the annotation reaches salix as an object;
-when it arrives as source text -- a quoted string, or an annotation that
-nothing evaluated -- the check is a spelling match, and the two paths differ
-at the edges:
+creation. The check walks the annotation's forms when it reaches salix as an
+object; when it arrives as source text — a quoted string, or a
+future-annotations string — the check is a spelling match, and the two paths
+differ at the edges:
 
 | annotation | object path | text path |
 | --- | --- | --- |
 | an alias of `ClassVar`, `CV[int]` | refused | accepted; the field swallows a positional |
 | a type of yours actually named `ClassVar` | accepted | refused |
-| `Annotated[int, ClassVar]` | accepted | refused, though the form is metadata |
+| `Annotated[int, ClassVar]` | accepted | refused, though the `ClassVar` there is metadata |
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 
 3.14 evaluates resolvable annotations by default, so there the alias reaches
-the object path and is refused; the text path sees only what nothing can
-resolve.
+the object path and is refused; an annotation nothing can resolve arrives as
+an object too, and is accepted. Every row is pinned in
+`tests/test_classvar_paths.py`.
 
 ## Caching a computed value
 
-`functools.cached_property` caches into an instance `__dict__`, and a struct
-has none; a slotted frozen dataclass refuses it the same way. Two answers:
-`functools.cache` on the method, or a field that `__post_init__` fills:
+`functools.cached_property` caches into an instance `__dict__`; a struct has
+none unless a non-struct base carries one, and without one a slotted frozen
+dataclass refuses it the same way. Two answers: `functools.cache` on the
+method, or a field that `__post_init__` fills:
 
 ```python
 >>> import functools
@@ -66,10 +68,13 @@ has none; a slotted frozen dataclass refuses it the same way. Two answers:
 
 ```
 
-The method cache holds every instance it has seen -- one entry per mutation
-state, since structs hash by value -- and refuses when the instance is
-unhashable. A body-defined `__init__` replaces the constructor that runs
-`__post_init__`, so the field answer only works without one.
+The method cache keys on the value, not the instance: value-equal structs
+share one entry, and `set_field` after a hit misses — the cache then holds
+the old entry and the new one. The cache refuses an unhashable struct, which
+is one with `frozen=False` or a body-defined `__eq__`. Any `__init__`,
+defined or inherited, replaces the constructor that runs `__post_init__`, so
+the field answer only works without one. The claims are pinned in
+`tests/test_classvar_paths.py`.
 
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ the check is a spelling match, and the two paths differ at the edges:
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 
 3.14 evaluates resolvable annotations by default, so there the alias reaches
-the object path and is refused; a bare name nothing can resolve arrives as an
-object too, and is accepted, while an annotation whose evaluation fails any
-other way still fails the class. Every row is pinned in
-`tests/test_classvar_paths.py`.
+the object path and is refused; a name nothing can resolve — bare or
+compound — arrives as an object too, and is accepted, while an annotation
+whose evaluation raises AttributeError still fails the class. Every row is
+pinned in `tests/test_classvar_paths.py`.
 
 ## Caching a computed value
 
@@ -72,16 +72,17 @@ method, or a field that `__post_init__` fills:
 Under the default eq=True the method cache keys on the value, not the
 instance: value-equal structs share one entry, and a `set_field` that
 changes the value misses — the cache then holds the old entry and the new
-one. With eq=False the struct hashes by identity instead, and `set_field`
-after a hit returns the stale cached value — unless the body defines its
-own `__eq__` or `__hash__`. The cache refuses an unhashable struct —
-anything that makes `hash()` raise: under the default options that is
-`frozen=False`, a body-defined `__eq__` or `__hash__`, an unhashable field
-value, or equality inherited from a struct base that defines `__eq__`. An
-`__init__` that is not `object.__init__` — defined in the body or inherited
-from any base — replaces the constructor that runs `__post_init__`, so the
-field answer only works without one. The table and the caching behaviors
-above are pinned in `tests/test_classvar_paths.py`.
+one. With eq=False the struct hashes by identity, and `set_field` after a
+hit returns the stale cached value while the hash is unchanged; a body
+`__hash__` over field values changes the hash and the lookup misses. The
+cache refuses an unhashable struct — anything that makes `hash()` raise:
+under the default options that is `frozen=False`, a body-defined `__eq__`,
+a body `__hash__` that refuses, an unhashable field value, or equality
+inherited from a struct base that defines `__eq__`. An `__init__` that is
+not `object.__init__` — a body-written one, inherited or not — replaces
+the constructor that runs `__post_init__`, so the field answer only works
+without one. The table and the caching behaviors above are pinned in
+`tests/test_classvar_paths.py`.
 
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the check is a spelling match, and the two paths differ at the edges:
 | --- | --- | --- |
 | an alias of `ClassVar`, `CV[int]` | refused | accepted; the field swallows a positional |
 | a type of yours actually named `ClassVar` | accepted | refused |
-| `Annotated[int, ClassVar]` | accepted | refused, though the `ClassVar` there is metadata |
+| `Annotated[int, ClassVar]` | accepted, 3.11+ | refused, though the `ClassVar` there is metadata |
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 
 3.14 evaluates resolvable annotations by default, so there the alias reaches
@@ -38,7 +38,7 @@ an object too, and is accepted. Every row is pinned in
 ## Caching a computed value
 
 `functools.cached_property` caches into an instance `__dict__`; a struct has
-none unless a non-struct base carries one, and without one a slotted frozen
+none unless a non-struct base carries one, and without one a slotted
 dataclass refuses it the same way. Two answers: `functools.cache` on the
 method, or a field that `__post_init__` fills:
 
@@ -72,11 +72,13 @@ Under the default eq=True the method cache keys on the value, not the
 instance: value-equal structs share one entry, and `set_field` after a hit
 misses — the cache then holds the old entry and the new one. With eq=False
 the struct hashes by identity instead, and `set_field` after a hit returns
-the stale cached value. The cache refuses an unhashable struct — under
-eq=True that is one with `frozen=False` or a body-defined `__eq__`. Any
-`__init__`, defined or inherited, replaces the constructor that runs
-`__post_init__`, so the field answer only works without one. The claims are
-pinned in `tests/test_classvar_paths.py`.
+the stale cached value — unless the body defines its own `__eq__`, which
+still makes it unhashable. The cache refuses an unhashable struct — under
+eq=True that is one with `frozen=False`, a body-defined `__eq__`, or an
+unhashable field value. An `__init__` that is not `object.__init__` —
+defined in the body or inherited from a non-struct base — replaces the
+constructor that runs `__post_init__`, so the field answer only works
+without one. The claims are pinned in `tests/test_classvar_paths.py`.
 
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,54 @@ Point(x=1.0, y=2.0)
 
 ```
 
+## ClassVar and InitVar
+
+A field annotated `ClassVar[...]` or `InitVar[...]` is refused at class
+creation, exactly when the annotation is an object. When the annotation
+reaches salix as source text (under `from __future__ import annotations`)
+the check is a spelling match, and the spellings it cannot see are:
+
+| annotation | what the spelling match does |
+| --- | --- |
+| an alias of `ClassVar`, `CV[int]` | accepted; the field swallows a positional |
+| a factory-local alias, 3.14 | accepted; the same symptom |
+| `Optional[Annotated[ClassVar[int], "m"]]` | the object path accepts, the text path refuses |
+| a type of yours actually named `ClassVar` | refused |
+| `Annotated[int, ClassVar]` | refused, though the form is metadata |
+
+## Caching a computed value
+
+`functools.cached_property` caches into an instance `__dict__`, and a struct
+has none; a slotted frozen dataclass refuses it the same way. Cache on the
+method instead -- the cache then holds every instance it has seen -- or fill
+a field from `__post_init__`:
+
+```python
+>>> import functools
+>>> from salix import set_field
+
+>>> class Computed(Struct):
+...     x: int
+...
+...     @functools.cache
+...     def double(self) -> int:
+...         return self.x * 2
+
+>>> Computed(3).double()
+6
+
+>>> class Filled(Struct):
+...     x: int
+...     double: int = 0
+...
+...     def __post_init__(self) -> None:
+...         set_field(self, "double", self.x * 2)
+
+>>> Filled(4).double
+8
+
+```
+
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Point(x=1.0, y=2.0)
 ## ClassVar and InitVar
 
 A field annotated `ClassVar[...]` or `InitVar[...]` is refused at class
-creation. The check walks the annotation's forms when it reaches salix as an
-object; when it arrives as source text — a quoted string, or a
-future-annotations string — the check is a spelling match, and the two paths
-differ at the edges:
+creation when the annotation reaches the check as one of those forms. The
+check walks the annotation's forms when it arrives as an object; when it
+arrives as source text — a quoted string, or a future-annotations string —
+the check is a spelling match, and the two paths differ at the edges:
 
 | annotation | object path | text path |
 | --- | --- | --- |
@@ -68,13 +68,15 @@ method, or a field that `__post_init__` fills:
 
 ```
 
-The method cache keys on the value, not the instance: value-equal structs
-share one entry, and `set_field` after a hit misses — the cache then holds
-the old entry and the new one. The cache refuses an unhashable struct, which
-is one with `frozen=False` or a body-defined `__eq__`. Any `__init__`,
-defined or inherited, replaces the constructor that runs `__post_init__`, so
-the field answer only works without one. The claims are pinned in
-`tests/test_classvar_paths.py`.
+Under the default eq=True the method cache keys on the value, not the
+instance: value-equal structs share one entry, and `set_field` after a hit
+misses — the cache then holds the old entry and the new one. With eq=False
+the struct hashes by identity instead, and `set_field` after a hit returns
+the stale cached value. The cache refuses an unhashable struct — under
+eq=True that is one with `frozen=False` or a body-defined `__eq__`. Any
+`__init__`, defined or inherited, replaces the constructor that runs
+`__post_init__`, so the field answer only works without one. The claims are
+pinned in `tests/test_classvar_paths.py`.
 
 `salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
 not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -200,6 +200,16 @@ def test_a_body_hash_wins_over_the_identity_hash_under_eq_false():
     assert hash(SevenHash(1)) == 7
 
 
+def test_a_value_returning_body_hash_is_hashable_under_the_default_options():
+    class ValueHash(Struct):
+        x: int
+
+        def __hash__(self) -> int:
+            return self.x
+
+    assert hash(ValueHash(3)) == 3
+
+
 def test_equality_inherited_from_a_struct_base_makes_the_subclass_unhashable():
     class EqStruct(Struct):  # noqa: PLW1641 -- the inherited unhashability is the point
         x: int

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -9,83 +9,69 @@ import pytest
 from salix import Struct, set_field
 
 
-def build(namespace):
-    """The class, or the TypeError that refused it."""
-
-    try:
-        return type("Probe", (Struct,), namespace), None
-    except TypeError as exc:
-        return None, exc
-
-
-def test_an_alias_is_refused_on_the_object_path():
-    cls, error = build({"__annotations__": {"x": typing.ClassVar[int]}})
-
-    assert cls is None
-    assert error is not None
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        typing.ClassVar[int],
+        typing.Optional[typing.Annotated[typing.ClassVar[int], "m"]],  # noqa: UP045
+    ],
+)
+def test_the_object_path_refuses_class_var_forms(annotation):
+    with pytest.raises(TypeError, match="ClassVar"):
+        type("Probe", (Struct,), {"__annotations__": {"x": annotation}})
 
 
-def test_an_alias_is_accepted_on_the_text_path():
-    cls, error = build({"__annotations__": {"x": "CV[int]"}})
+@pytest.mark.parametrize(
+    "annotation",
+    ["ClassVar", "Annotated[int, ClassVar]", "Optional[Annotated[ClassVar[int], m]]"],
+)
+def test_the_text_path_refuses_class_var_forms(annotation):
+    with pytest.raises(TypeError, match="ClassVar"):
+        type("Probe", (Struct,), {"__annotations__": {"x": annotation}})
 
-    assert error is None
+
+def test_the_text_path_accepts_an_alias_and_the_field_swallows_a_positional():
+    cls = type("Probe", (Struct,), {"__annotations__": {"x": "CV[int]"}})
+
     assert cls._struct_fields_ == ("x",)
+    assert cls(7).x == 7
 
 
-def test_a_type_named_class_var_is_accepted_on_the_object_path():
+def test_the_object_path_accepts_a_type_named_class_var():
     class ClassVar:
         pass
 
-    cls, error = build({"__annotations__": {"x": ClassVar}})
+    cls = type("Probe", (Struct,), {"__annotations__": {"x": ClassVar}})
 
-    assert error is None
     assert cls._struct_fields_ == ("x",)
 
 
-def test_a_type_named_class_var_is_refused_on_the_text_path():
-    cls, error = build({"__annotations__": {"x": "ClassVar"}})
-
-    assert cls is None
-    assert error is not None
-
-
-def test_annotated_metadata_is_accepted_on_the_object_path():
-    cls, error = build({"__annotations__": {"x": typing.Annotated[int, typing.ClassVar]}})
-
-    assert error is None
-    assert cls._struct_fields_ == ("x",)
-
-
-def test_annotated_metadata_is_refused_on_the_text_path():
-    cls, error = build({"__annotations__": {"x": "Annotated[int, ClassVar]"}})
-
-    assert cls is None
-    assert error is not None
-
-
-def test_optional_annotated_is_refused_on_both_paths():
-    cls, error = build(
-        {
-            "__annotations__": {
-                "x": typing.Optional[typing.Annotated[typing.ClassVar[int], "m"]]  # noqa: UP045
-            }
-        }
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="typing refuses a bare special form as an Annotated argument before 3.11",
+)
+def test_the_object_path_accepts_annotated_metadata():
+    cls = type(
+        "Probe",
+        (Struct,),
+        {"__annotations__": {"x": typing.Annotated[int, typing.ClassVar]}},
     )
 
-    assert cls is None
-    assert error is not None
-
-    cls, error = build({"__annotations__": {"x": "Optional[Annotated[ClassVar[int], m]]"}})
-
-    assert cls is None
-    assert error is not None
+    assert cls._struct_fields_ == ("x",)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="3.14 evaluates resolvable annotations")
 def test_an_unresolvable_annotation_arrives_as_an_object_and_is_accepted():
+    import annotationlib
+
     class WithNope(Struct):
         x: Nope  # noqa: F821
 
+    annotation = annotationlib.get_annotations(
+        WithNope, format=annotationlib.Format.FORWARDREF
+    )["x"]
+
+    assert not isinstance(annotation, str)
     assert WithNope._struct_fields_ == ("x",)
 
 
@@ -135,6 +121,45 @@ def test_an_unhashable_struct_refuses_the_cache():
 
     with pytest.raises(TypeError, match="unhashable"):
         Mutable(1).slow()
+
+
+def test_a_body_defined_eq_is_unhashable_and_the_cache_refuses():
+    class BodyEq(Struct):  # noqa: PLW1641 -- the unhashability is the point
+        x: int
+
+        def __eq__(self, other: object) -> bool:
+            return True
+
+        @functools.cache  # noqa: B019 -- the refusal is the point
+        def slow(self) -> int:
+            return self.x
+
+    with pytest.raises(TypeError, match="unhashable"):
+        BodyEq(1).slow()
+
+
+def test_eq_false_hashes_by_identity_and_the_cache_returns_stale_values():
+    class Identity(Struct, eq=False):
+        x: int
+
+        @functools.cache  # noqa: B019 -- the stale hit is the point
+        def slow(self) -> int:
+            return self.x * 2
+
+    instance = Identity(1)
+
+    assert instance.slow() == 2
+
+    set_field(instance, "x", 5)
+
+    assert instance.slow() == 2
+
+
+def test_eq_false_mutable_structs_are_hashable():
+    class MutableIdentity(Struct, eq=False, frozen=False):
+        x: int
+
+    assert isinstance(hash(MutableIdentity(1)), int)
 
 
 def test_cached_property_works_when_a_co_base_carries_a_dict():

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -46,10 +46,6 @@ def test_the_object_path_accepts_a_type_named_class_var():
     assert cls._struct_fields_ == ("x",)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="typing refuses a bare special form as an Annotated argument before 3.11",
-)
 def test_the_object_path_accepts_annotated_metadata():
     cls = type(
         "Probe",
@@ -147,9 +143,10 @@ def test_eq_false_hashes_by_identity_and_the_cache_returns_stale_values():
             return self.x * 2
 
     instance = Identity(1)
+    other = Identity(1)
 
     assert instance.slow() == 2
-    assert hash(Identity(1)) != hash(Identity(1))
+    assert hash(instance) != hash(other)
 
     set_field(instance, "x", 5)
 
@@ -160,7 +157,10 @@ def test_eq_false_mutable_structs_are_hashable():
     class MutableIdentity(Struct, eq=False, frozen=False):
         x: int
 
-    assert hash(MutableIdentity(1)) != hash(MutableIdentity(1))
+    first = MutableIdentity(1)
+    second = MutableIdentity(1)
+
+    assert hash(first) != hash(second)
 
 
 def test_a_body_defined_eq_still_makes_an_eq_false_struct_unhashable():
@@ -172,6 +172,46 @@ def test_a_body_defined_eq_still_makes_an_eq_false_struct_unhashable():
 
     with pytest.raises(TypeError, match="unhashable"):
         hash(BodyEq(1))
+
+
+def test_a_body_hash_none_makes_the_struct_unhashable_under_both_eq_options():
+    class NoHash(Struct):
+        x: int
+        __hash__ = None  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(NoHash(1))
+
+    class NoHashEqFalse(Struct, eq=False):
+        x: int
+        __hash__ = None  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(NoHashEqFalse(1))
+
+
+def test_a_body_hash_wins_over_the_identity_hash_under_eq_false():
+    class SevenHash(Struct, eq=False):
+        x: int
+
+        def __hash__(self) -> int:
+            return 7
+
+    assert hash(SevenHash(1)) == 7
+
+
+def test_equality_inherited_from_a_struct_base_makes_the_subclass_unhashable():
+    class EqStruct(Struct):  # noqa: PLW1641 -- the inherited unhashability is the point
+        x: int
+
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    class Child(EqStruct):
+        y: int
+
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(Child(1, 2))
 
 
 def test_an_unhashable_field_value_makes_the_struct_unhashable():

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -13,7 +13,6 @@ from salix import Struct, set_field
     "annotation",
     [
         typing.ClassVar[int],
-        pytest.param(typing.ClassVar[int], id="an-alias-evaluates-to-the-form"),
         typing.Optional[typing.Annotated[typing.ClassVar[int], "m"]],  # noqa: UP045
     ],
 )
@@ -29,6 +28,28 @@ def test_the_object_path_refuses_class_var_forms(annotation):
 def test_the_text_path_refuses_class_var_forms(annotation):
     with pytest.raises(TypeError, match="ClassVar"):
         type("Probe", (Struct,), {"__annotations__": {"x": annotation}})
+
+
+def test_the_object_path_refuses_an_alias_of_the_form():
+    CV = typing.ClassVar
+
+    with pytest.raises(TypeError, match="ClassVar"):
+        type("Probe", (Struct,), {"__annotations__": {"x": CV[int]}})
+
+
+def test_a_plain_struct_instance_has_no_dict():
+    class Plain(Struct):
+        x: int
+
+    with pytest.raises(AttributeError):
+        _ = Plain(1).__dict__
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="3.14 evaluates resolvable annotations")
+def test_a_resolvable_alias_is_evaluated_and_refused_on_3_14():
+    with pytest.raises(TypeError, match="ClassVar"):
+        class Aliased(Struct):
+            x: typing.ClassVar[int]
 
 
 def test_the_text_path_accepts_an_alias_and_the_field_swallows_a_positional():

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -1,0 +1,183 @@
+"""The README's ClassVar and caching tables, run rather than read."""
+
+import functools
+import sys
+import typing
+
+import pytest
+
+from salix import Struct, set_field
+
+
+def build(namespace):
+    """The class, or the TypeError that refused it."""
+
+    try:
+        return type("Probe", (Struct,), namespace), None
+    except TypeError as exc:
+        return None, exc
+
+
+def test_an_alias_is_refused_on_the_object_path():
+    cls, error = build({"__annotations__": {"x": typing.ClassVar[int]}})
+
+    assert cls is None
+    assert error is not None
+
+
+def test_an_alias_is_accepted_on_the_text_path():
+    cls, error = build({"__annotations__": {"x": "CV[int]"}})
+
+    assert error is None
+    assert cls._struct_fields_ == ("x",)
+
+
+def test_a_type_named_class_var_is_accepted_on_the_object_path():
+    class ClassVar:
+        pass
+
+    cls, error = build({"__annotations__": {"x": ClassVar}})
+
+    assert error is None
+    assert cls._struct_fields_ == ("x",)
+
+
+def test_a_type_named_class_var_is_refused_on_the_text_path():
+    cls, error = build({"__annotations__": {"x": "ClassVar"}})
+
+    assert cls is None
+    assert error is not None
+
+
+def test_annotated_metadata_is_accepted_on_the_object_path():
+    cls, error = build({"__annotations__": {"x": typing.Annotated[int, typing.ClassVar]}})
+
+    assert error is None
+    assert cls._struct_fields_ == ("x",)
+
+
+def test_annotated_metadata_is_refused_on_the_text_path():
+    cls, error = build({"__annotations__": {"x": "Annotated[int, ClassVar]"}})
+
+    assert cls is None
+    assert error is not None
+
+
+def test_optional_annotated_is_refused_on_both_paths():
+    cls, error = build(
+        {
+            "__annotations__": {
+                "x": typing.Optional[typing.Annotated[typing.ClassVar[int], "m"]]  # noqa: UP045
+            }
+        }
+    )
+
+    assert cls is None
+    assert error is not None
+
+    cls, error = build({"__annotations__": {"x": "Optional[Annotated[ClassVar[int], m]]"}})
+
+    assert cls is None
+    assert error is not None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="3.14 evaluates resolvable annotations")
+def test_an_unresolvable_annotation_arrives_as_an_object_and_is_accepted():
+    class WithNope(Struct):
+        x: Nope  # noqa: F821
+
+    assert WithNope._struct_fields_ == ("x",)
+
+
+def test_value_equal_instances_share_one_cache_entry():
+    calls = []
+
+    class Cached(Struct):
+        x: int
+
+        @functools.cache  # noqa: B019 -- the retained instances are the point
+        def slow(self) -> int:
+            calls.append(self.x)
+
+            return self.x * 2
+
+    assert Cached(1).slow() == 2
+    assert Cached(1).slow() == 2
+
+    assert calls == [1]
+
+
+def test_mutating_a_cached_instance_misses_and_leaks_the_entry():
+    class Cached(Struct):
+        x: int
+
+        @functools.cache  # noqa: B019 -- the leaked entry is the point
+        def slow(self) -> int:
+            return self.x * 2
+
+    instance = Cached(1)
+
+    assert instance.slow() == 2
+
+    set_field(instance, "x", 5)
+
+    assert instance.slow() == 10
+    assert Cached.slow.cache_info().currsize == 2
+
+
+def test_an_unhashable_struct_refuses_the_cache():
+    class Mutable(Struct, frozen=False):
+        x: int
+
+        @functools.cache  # noqa: B019 -- the refusal is the point
+        def slow(self) -> int:
+            return self.x
+
+    with pytest.raises(TypeError, match="unhashable"):
+        Mutable(1).slow()
+
+
+def test_cached_property_works_when_a_co_base_carries_a_dict():
+    class Dicted:
+        pass
+
+    class WithDict(Struct, Dicted, frozen=False):
+        x: int
+
+        @functools.cached_property
+        def double(self) -> int:
+            return self.x * 2
+
+    instance = WithDict(3)
+
+    assert instance.double == 6
+    assert instance.__dict__ == {"double": 6}
+
+
+def test_a_defined_init_displaces_post_init():
+    class WithInit(Struct):
+        x: int
+        double: int = 0
+
+        def __init__(self, x: int) -> None:
+            set_field(self, "x", x)
+
+        def __post_init__(self) -> None:
+            set_field(self, "double", self.x * 2)
+
+    assert WithInit(4).double == 0
+
+
+def test_an_inherited_init_displaces_post_init():
+    class InitBase:
+        def __init__(self, x: int) -> None:
+            set_field(self, "x", x)
+
+    class Inherits(Struct, InitBase):
+        x: int
+        double: int = 0
+
+        def __post_init__(self) -> None:
+            set_field(self, "double", self.x * 2)
+
+    assert Inherits(4).double == 0

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -149,6 +149,7 @@ def test_eq_false_hashes_by_identity_and_the_cache_returns_stale_values():
     instance = Identity(1)
 
     assert instance.slow() == 2
+    assert hash(Identity(1)) != hash(Identity(1))
 
     set_field(instance, "x", 5)
 
@@ -159,7 +160,26 @@ def test_eq_false_mutable_structs_are_hashable():
     class MutableIdentity(Struct, eq=False, frozen=False):
         x: int
 
-    assert isinstance(hash(MutableIdentity(1)), int)
+    assert hash(MutableIdentity(1)) != hash(MutableIdentity(1))
+
+
+def test_a_body_defined_eq_still_makes_an_eq_false_struct_unhashable():
+    class BodyEq(Struct, eq=False):  # noqa: PLW1641 -- the unhashability is the point
+        x: int
+
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(BodyEq(1))
+
+
+def test_an_unhashable_field_value_makes_the_struct_unhashable():
+    class Holding(Struct):
+        items: list
+
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(Holding([1]))
 
 
 def test_cached_property_works_when_a_co_base_carries_a_dict():

--- a/tests/test_classvar_paths.py
+++ b/tests/test_classvar_paths.py
@@ -13,6 +13,7 @@ from salix import Struct, set_field
     "annotation",
     [
         typing.ClassVar[int],
+        pytest.param(typing.ClassVar[int], id="an-alias-evaluates-to-the-form"),
         typing.Optional[typing.Annotated[typing.ClassVar[int], "m"]],  # noqa: UP045
     ],
 )
@@ -69,6 +70,24 @@ def test_an_unresolvable_annotation_arrives_as_an_object_and_is_accepted():
 
     assert not isinstance(annotation, str)
     assert WithNope._struct_fields_ == ("x",)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="3.14 evaluates resolvable annotations")
+def test_a_compound_name_with_an_unresolvable_root_is_accepted():
+    class WithCompound(Struct):
+        x: Nope.attr  # noqa: F821
+
+    assert WithCompound._struct_fields_ == ("x",)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="3.14 evaluates resolvable annotations")
+def test_an_attribute_error_annotation_still_fails_the_class():
+    class Nope:
+        pass
+
+    with pytest.raises(AttributeError):
+        class WithAttrError(Struct):
+            x: Nope.missing
 
 
 def test_value_equal_instances_share_one_cache_entry():
@@ -208,6 +227,42 @@ def test_a_value_returning_body_hash_is_hashable_under_the_default_options():
             return self.x
 
     assert hash(ValueHash(3)) == 3
+
+
+def test_a_field_hash_misses_after_set_field_under_eq_false():
+    class FieldHash(Struct, eq=False):
+        x: int
+
+        def __hash__(self) -> int:
+            return self.x
+
+        @functools.cache  # noqa: B019 -- the miss is the point
+        def slow(self) -> int:
+            return self.x * 2
+
+    instance = FieldHash(1)
+
+    assert instance.slow() == 2
+
+    set_field(instance, "x", 5)
+
+    assert instance.slow() == 10
+
+
+def test_a_struct_base_body_init_displaces_post_init():
+    class Parent(Struct):
+        x: int
+
+        def __init__(self, x: int) -> None:
+            set_field(self, "x", x)
+
+    class Child(Parent):
+        double: int = 0
+
+        def __post_init__(self) -> None:
+            set_field(self, "double", self.x * 2)
+
+    assert Child(4).double == 0
 
 
 def test_equality_inherited_from_a_struct_base_makes_the_subclass_unhashable():


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to work the residue phase — this is the documentation half of it.

Two README sections, each the measured claim from its issue, neither depending on the #18 landing-page rewrite:

- **ClassVar and InitVar** — what the text path's spelling match costs: the table from the issue, as the terse version a reader can reach.
- **Caching a computed value** — `cached_property` refuses (no instance `__dict__`; a slotted frozen dataclass refuses identically), with the two answers that work, both running as doctests so they cannot rot.

The README stays executed: the new doctests pass under the same collection as the rest of the file.

Closes #53. Closes #57.