### PR TITLE
chore: pay the split's cleanup debt — one name-table source, pruned includes

### DIFF
--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -1,15 +1,11 @@
 #include <Python.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <string.h>
 
-#include "../construct.h"
-#include "../fields.h"
 #include "meta.h"
 #include "../mixin.h"
 #include "../options.h"
 #include "../owned.h"
-#include "../result.h"
 #include "../types.h"
 
 struct definition {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -52,8 +52,8 @@ static enum result restore_stripped(
 	PyObject * class_dict,
 	char const * const * const * tables
 );
-static bool table_names(char const * const * names, char const * name);
-static bool settled_by_the_plan(char const * name, struct binding_plan plan);
+static bool table_names(char const * const * const names, char const * const name);
+static bool settled_by_the_plan(char const * const name, struct binding_plan const plan);
 static enum result refuse_unplanned(StructType const * struct_class);
 static enum result install_post_init(StructType * struct_class);
 static bool defines_own_init(StructType const * struct_class);
@@ -82,7 +82,7 @@ char const * const rebind_not_equal[] = {"__ne__", NULL};
 char const * const rebind_representation[] = {"__repr__", NULL};
 char const * const rebind_mutability[] = {"__setattr__", "__delattr__", NULL};
 char const * const rebind_hash[] = {"__hash__", NULL};
-char const * const rebind_never[] = {"__init__", "__post_init__", "__new__", NULL};
+static char const * const rebind_never[] = {"__init__", "__post_init__", "__new__", NULL};
 
 static char const * const * const settle_tables[] = {
 	rebind_comparison,
@@ -119,6 +119,10 @@ static bool settled_by_the_plan(char const * const name, struct binding_plan con
 
 	if (table_names(rebind_mutability, name)) {
 		return plan.rebind_mutability;
+	}
+
+	if (table_names(rebind_hash, name)) {
+		return plan.hash == HASH_BIND || plan.hash == HASH_NONE;
 	}
 
 	if (table_names(rebind_never, name)) {
@@ -423,7 +427,7 @@ static enum result settle_planned(
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,
-		PyDict_GetItemString(original_namespace, "__hash__") != NULL
+		PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL
 	);
 
 	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
@@ -460,19 +464,14 @@ static enum result settle_planned(
 		return RESULT_ERROR;
 	}
 
-	if (bindings.answered_by_body && PyDict_GetItemString(original_namespace, "__ne__") == NULL) {
-		/* bind_not_equal's answered case on a live class: the fresh build
-		 * binds object's __ne__ when the body answered equality itself. */
-		PY_OWNED(object_ne, PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, "__ne__"));
-		PY_OWNED(ne_name, PyUnicode_FromString("__ne__"));
-
-		if (
-			object_ne == NULL ||
-			ne_name == NULL ||
-			PyType_Type.tp_setattro((PyObject *) struct_class, ne_name, object_ne) < 0
-		) {
-			return RESULT_ERROR;
-		}
+	/* bind_not_equal's answered case on a live class: the fresh build binds
+	 * object's __ne__ when the body answered equality itself. */
+	if (
+		bindings.answered_by_body &&
+		PyDict_GetItemString(original_namespace, rebind_not_equal[0]) == NULL &&
+		settle_rebind(struct_class, original_namespace, rebind_not_equal, false) != RESULT_OK
+	) {
+		return RESULT_ERROR;
 	}
 
 	if (
@@ -496,7 +495,7 @@ static enum result settle_planned(
 		case HASH_INHERITED_EQ:
 			break;
 		case HASH_NONE: {
-			PY_OWNED(hash_name_obj, PyUnicode_FromString("__hash__"));
+			PY_OWNED(hash_name_obj, PyUnicode_FromString(rebind_hash[0]));
 
 			if (
 				hash_name_obj == NULL ||

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -50,8 +50,10 @@ static enum result restore_stripped(
 	StructType * struct_class,
 	PyObject * original_namespace,
 	PyObject * class_dict,
-	char const * const * names
+	char const * const * const * tables
 );
+static bool table_names(char const * const * names, char const * name);
+static bool settled_by_the_plan(char const * name, struct binding_plan plan);
 static enum result refuse_unplanned(StructType const * struct_class);
 static enum result install_post_init(StructType * struct_class);
 static bool defines_own_init(StructType const * struct_class);
@@ -67,6 +69,64 @@ static Py_ssize_t * resolve_member_offsets(
 	Py_ssize_t field_count,
 	Py_ssize_t * member_count
 );
+
+char const * const rebind_comparison[] = {
+	"__eq__",
+	"__lt__",
+	"__le__",
+	"__gt__",
+	"__ge__",
+	NULL,
+};
+char const * const rebind_not_equal[] = {"__ne__", NULL};
+char const * const rebind_representation[] = {"__repr__", NULL};
+char const * const rebind_mutability[] = {"__setattr__", "__delattr__", NULL};
+char const * const rebind_hash[] = {"__hash__", NULL};
+char const * const rebind_never[] = {"__init__", "__post_init__", "__new__", NULL};
+
+static char const * const * const settle_tables[] = {
+	rebind_comparison,
+	rebind_not_equal,
+	rebind_representation,
+	rebind_mutability,
+	rebind_hash,
+	rebind_never,
+	NULL,
+};
+
+static bool table_names(char const * const * const names, char const * const name) {
+	for (char const * const * entry = names; *entry != NULL; entry += 1) {
+		if (strcmp(*entry, name) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool settled_by_the_plan(char const * const name, struct binding_plan const plan) {
+	if (table_names(rebind_comparison, name)) {
+		return plan.rebind_comparison;
+	}
+
+	if (table_names(rebind_not_equal, name)) {
+		return plan.rebind_not_equal || plan.answered_by_body;
+	}
+
+	if (table_names(rebind_representation, name)) {
+		return plan.rebind_representation;
+	}
+
+	if (table_names(rebind_mutability, name)) {
+		return plan.rebind_mutability;
+	}
+
+	if (table_names(rebind_never, name)) {
+		return false;
+	}
+
+	return plan.hash == HASH_BIND || plan.hash == HASH_NONE;
+}
 
 PyObject * build_struct_class(
 	PyTypeObject * const metatype,
@@ -302,34 +362,6 @@ static enum result settle_planned(
 	bool const inherits_body_eq,
 	bool const derive_not_equal
 ) {
-	static char const * const comparison[] = {
-		"__eq__",
-		"__lt__",
-		"__le__",
-		"__gt__",
-		"__ge__",
-		NULL,
-	};
-	static char const * const not_equal[] = {"__ne__", NULL};
-	static char const * const representation[] = {"__repr__", NULL};
-	static char const * const mutability[] = {"__setattr__", "__delattr__", NULL};
-	static char const * const hash_name[] = {"__hash__", NULL};
-	static char const * const body_dunders[] = {
-		"__eq__",
-		"__ne__",
-		"__lt__",
-		"__le__",
-		"__gt__",
-		"__ge__",
-		"__repr__",
-		"__setattr__",
-		"__delattr__",
-		"__hash__",
-		"__init__",
-		"__post_init__",
-		"__new__",
-		NULL,
-	};
 	PY_OWNED(planned, PyList_AsTuple(plan->all_names));
 
 	if (planned == NULL) {
@@ -394,30 +426,36 @@ static enum result settle_planned(
 		PyDict_GetItemString(original_namespace, "__hash__") != NULL
 	);
 
-	for (char const * const * name = body_dunders; *name != NULL; name += 1) {
-		if (
-			PyDict_GetItemString(class_dict, *name) != NULL &&
-			PyDict_GetItemString(original_namespace, *name) == NULL &&
-			!settled_by_the_plan(*name, bindings)
-		) {
-			return refuse_unplanned(struct_class);
+	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
+		for (char const * const * name = *tables; *name != NULL; name += 1) {
+			if (
+				PyDict_GetItemString(class_dict, *name) != NULL &&
+				PyDict_GetItemString(original_namespace, *name) == NULL &&
+				!settled_by_the_plan(*name, bindings)
+			) {
+				return refuse_unplanned(struct_class);
+			}
 		}
 	}
 
-	if (restore_stripped(struct_class, original_namespace, class_dict, body_dunders) != RESULT_OK) {
+	if (
+		restore_stripped(struct_class, original_namespace, class_dict, settle_tables) !=
+		RESULT_OK
+	) {
 		return RESULT_ERROR;
 	}
 
 	if (
 		bindings.rebind_comparison &&
-		settle_rebind(struct_class, original_namespace, comparison, options.eq) != RESULT_OK
+		settle_rebind(struct_class, original_namespace, rebind_comparison, options.eq) !=
+			RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
 	if (
 		bindings.rebind_not_equal &&
-		settle_rebind(struct_class, original_namespace, not_equal, options.eq) != RESULT_OK
+		settle_rebind(struct_class, original_namespace, rebind_not_equal, options.eq) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
@@ -439,14 +477,16 @@ static enum result settle_planned(
 
 	if (
 		bindings.rebind_representation &&
-		settle_rebind(struct_class, original_namespace, representation, options.repr) != RESULT_OK
+		settle_rebind(struct_class, original_namespace, rebind_representation, options.repr) !=
+			RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
 	if (
 		bindings.rebind_mutability &&
-		settle_rebind(struct_class, original_namespace, mutability, options.frozen) != RESULT_OK
+		settle_rebind(struct_class, original_namespace, rebind_mutability, options.frozen) !=
+			RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
@@ -469,7 +509,7 @@ static enum result settle_planned(
 		}
 		case HASH_BIND:
 			if (
-				settle_rebind(struct_class, original_namespace, hash_name, options.eq) !=
+				settle_rebind(struct_class, original_namespace, rebind_hash, options.eq) !=
 				RESULT_OK
 			) {
 				return RESULT_ERROR;
@@ -520,22 +560,24 @@ static enum result restore_stripped(
 	StructType * const struct_class,
 	PyObject * const original_namespace,
 	PyObject * const class_dict,
-	char const * const * const names
+	char const * const * const * const tables
 ) {
-	for (char const * const * name = names; *name != NULL; name += 1) {
-		PyObject * const body_value = PyDict_GetItemString(original_namespace, *name);
+	for (char const * const * const * table = tables; *table != NULL; table += 1) {
+		for (char const * const * name = *table; *name != NULL; name += 1) {
+			PyObject * const body_value = PyDict_GetItemString(original_namespace, *name);
 
-		if (body_value == NULL || PyDict_GetItemString(class_dict, *name) == body_value) {
-			continue;
-		}
+			if (body_value == NULL || PyDict_GetItemString(class_dict, *name) == body_value) {
+				continue;
+			}
 
-		PY_OWNED(unicode_name, PyUnicode_FromString(*name));
+			PY_OWNED(unicode_name, PyUnicode_FromString(*name));
 
-		if (
-			unicode_name == NULL ||
-			PyType_Type.tp_setattro((PyObject *) struct_class, unicode_name, body_value) < 0
-		) {
-			return RESULT_ERROR;
+			if (
+				unicode_name == NULL ||
+				PyType_Type.tp_setattro((PyObject *) struct_class, unicode_name, body_value) < 0
+			) {
+				return RESULT_ERROR;
+			}
 		}
 	}
 

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -1,20 +1,10 @@
 #include <Python.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
-#include "../construct.h"
-#include "../fields.h"
 #include "meta.h"
-#include "../mixin.h"
-#include "../options.h"
-#include "../owned.h"
 #include "../result.h"
 #include "../types.h"
-
-#ifndef Py_TPFLAGS_HAVE_VECTORCALL
-#	define Py_TPFLAGS_HAVE_VECTORCALL _Py_TPFLAGS_HAVE_VECTORCALL
-#endif
 
 static int StructMeta_traverse(PyObject * self, visitproc visit, void * arg);
 static int StructMeta_clear(PyObject * self);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -75,7 +75,6 @@ extern char const * const rebind_not_equal[];
 extern char const * const rebind_representation[];
 extern char const * const rebind_mutability[];
 extern char const * const rebind_hash[];
-extern char const * const rebind_never[];
 
 PyObject * build_class_namespace(
 	PyObject * original_namespace,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -70,7 +70,12 @@ struct binding_plan binding_plan(
 	bool body_defines_hash
 );
 
-bool settled_by_the_plan(char const * name, struct binding_plan plan);
+extern char const * const rebind_comparison[];
+extern char const * const rebind_not_equal[];
+extern char const * const rebind_representation[];
+extern char const * const rebind_mutability[];
+extern char const * const rebind_hash[];
+extern char const * const rebind_never[];
 
 PyObject * build_class_namespace(
 	PyObject * original_namespace,

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -1,10 +1,7 @@
 #include <Python.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <string.h>
 
-#include "../construct.h"
-#include "../fields.h"
 #include "meta.h"
 #include "../mixin.h"
 #include "../options.h"
@@ -220,40 +217,6 @@ struct binding_plan binding_plan(
 	return plan;
 }
 
-bool settled_by_the_plan(char const * const name, struct binding_plan const plan) {
-	if (
-		strcmp(name, "__eq__") == 0 ||
-		strcmp(name, "__lt__") == 0 ||
-		strcmp(name, "__le__") == 0 ||
-		strcmp(name, "__gt__") == 0 ||
-		strcmp(name, "__ge__") == 0
-	) {
-		return plan.rebind_comparison;
-	}
-
-	if (strcmp(name, "__ne__") == 0) {
-		return plan.rebind_not_equal || plan.answered_by_body;
-	}
-
-	if (
-		strcmp(name, "__init__") == 0 ||
-		strcmp(name, "__post_init__") == 0 ||
-		strcmp(name, "__new__") == 0
-	) {
-		return false;
-	}
-
-	if (strcmp(name, "__repr__") == 0) {
-		return plan.rebind_representation;
-	}
-
-	if (strcmp(name, "__setattr__") == 0 || strcmp(name, "__delattr__") == 0) {
-		return plan.rebind_mutability;
-	}
-
-	return plan.hash == HASH_BIND || plan.hash == HASH_NONE;
-}
-
 static enum result apply_options(
 	PyObject * const namespace,
 	struct options const options,
@@ -263,18 +226,6 @@ static enum result apply_options(
 	bool const inherits_body_eq,
 	bool const derive_not_equal
 ) {
-	static char const * const comparison[] = {
-		"__eq__",
-		"__lt__",
-		"__le__",
-		"__gt__",
-		"__ge__",
-		NULL,
-	};
-	static char const * const not_equal[] = {"__ne__", NULL};
-	static char const * const representation[] = {"__repr__", NULL};
-	static char const * const mutability[] = {"__setattr__", "__delattr__", NULL};
-	static char const * const hash_name[] = {"__hash__", NULL};
 	struct binding_plan const plan = binding_plan(
 		options,
 		inherited,
@@ -288,27 +239,30 @@ static enum result apply_options(
 	if (
 		plan.answered_by_body &&
 		PyDict_GetItemString(namespace, "__ne__") == NULL &&
-		rebind(namespace, not_equal, false) != RESULT_OK
+		rebind(namespace, rebind_not_equal, false) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
-	if (plan.rebind_comparison && rebind(namespace, comparison, options.eq) != RESULT_OK) {
+	if (plan.rebind_comparison && rebind(namespace, rebind_comparison, options.eq) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
 
-	if (plan.rebind_not_equal && rebind(namespace, not_equal, options.eq) != RESULT_OK) {
+	if (plan.rebind_not_equal && rebind(namespace, rebind_not_equal, options.eq) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
 
 	if (
 		plan.rebind_representation &&
-		rebind(namespace, representation, options.repr) != RESULT_OK
+		rebind(namespace, rebind_representation, options.repr) != RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}
 
-	if (plan.rebind_mutability && rebind(namespace, mutability, options.frozen) != RESULT_OK) {
+	if (
+		plan.rebind_mutability &&
+		rebind(namespace, rebind_mutability, options.frozen) != RESULT_OK
+	) {
 		return RESULT_ERROR;
 	}
 
@@ -323,7 +277,7 @@ static enum result apply_options(
 
 			break;
 		case HASH_BIND:
-			if (rebind(namespace, hash_name, options.eq) != RESULT_OK) {
+			if (rebind(namespace, rebind_hash, options.eq) != RESULT_OK) {
 				return RESULT_ERROR;
 			}
 


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was to act on the #104 review's convergence note: it converged at score 1 with one minor (the rebind name tables duplicated across the split) and four nits (dead includes, a dead vectorcall shim, one misplaced function, and a note on lost inlining), and recommended one follow-up cleanup commit addressing them all at once.

The #68 review converged with a cleanup list; this is the follow-up it asked for.

<details>

**Summary of the changes**

- **One source for the name tables** — the rebind tables (`comparison`, `not_equal`, `representation`, `mutability`, `hash`) and the never-bound dunders now have one definition in `class.c`, shared through `meta.h`. The settle's refuse/restore walks and `settled_by_the_plan` all derive from them — adding a dunder now touches one list instead of four encodings.
- **Seam fixed** — `settled_by_the_plan` moved to `class.c`, its only consumer, and is `static` again. `binding_plan` stays in `namespace.c` (`apply_options` consumes it too).
- **Includes pruned** — per file, to what each actually uses.
- **Dead shim gone** — `Py_TPFLAGS_HAVE_VECTORCALL` is public on every supported interpreter; the 3.10–3.15 matrix builds and tests without the shim.
- **Inlining nit answered with a measurement** — the benchmark reads **10.5 µs/type before the split and 10.5 µs/type after**; the predicted tens of nanoseconds do not move the number this project treats as noise. `static inline` in the header is also impossible for these predicates (`meta.h` is read before `types.h` defines `StructType`).

**The gate caught a real regression in this very cleanup** — the first encoding of `settled_by_the_plan` fell through listed names to the hash branch, and the settle pin suite refused nothing for a delegate that injects `__eq__`; it failed on every interpreter. The final form returns the plan member for the table the name is in, which is exactly the old strcmp chain's per-name semantics.

**Verification** — full matrix gate green (3.10–3.15, free-threaded, in-file C tests, analyzers).

</details>