### PR TITLE
fix: the __slots__ refusal residues — hand-off keywords, dict advice, slot-name fields

### DIFF
--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -219,15 +219,19 @@ struct options inherited_options(PyObject * const bases, StructType const * cons
 	};
 }
 
-bool has_weakref_slot(StructType const * const base) {
-	return base != NULL && base->heap_type.ht_type.tp_weaklistoffset != 0;
-}
-
-static bool carries_weakref_slot(PyTypeObject * const base) {
+static bool carries_weakref_slot(PyTypeObject const * const base) {
+#if PY_VERSION_HEX < 0x030C0000
 	return base->tp_weaklistoffset != 0;
+#else
+	return base->tp_weaklistoffset != 0 || (base->tp_flags & Py_TPFLAGS_MANAGED_WEAKREF) != 0;
+#endif
 }
 
-static bool carries_instance_dict(PyTypeObject * const base) {
+bool has_weakref_slot(StructType const * const base) {
+	return base != NULL && carries_weakref_slot(&base->heap_type.ht_type);
+}
+
+static bool carries_instance_dict(PyTypeObject const * const base) {
 #if PY_VERSION_HEX < 0x030C0000
 	return base->tp_dictoffset != 0;
 #else
@@ -235,7 +239,7 @@ static bool carries_instance_dict(PyTypeObject * const base) {
 #endif
 }
 
-static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObject *)) {
+static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObject const *)) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
 

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -220,18 +220,28 @@ struct options inherited_options(PyObject * const bases, StructType const * cons
 }
 
 static bool carries_weakref_slot(PyTypeObject const * const base) {
-#if PY_VERSION_HEX < 0x030C0000
-	return base->tp_weaklistoffset != 0;
+	if (base->tp_weaklistoffset != 0) {
+		return true;
+	}
+
+#if PY_VERSION_HEX >= 0x030C0000
+	return (base->tp_flags & Py_TPFLAGS_HEAPTYPE) != 0 &&
+		(base->tp_flags & Py_TPFLAGS_MANAGED_WEAKREF) != 0;
 #else
-	return base->tp_weaklistoffset != 0 || (base->tp_flags & Py_TPFLAGS_MANAGED_WEAKREF) != 0;
+	return false;
 #endif
 }
 
 static bool carries_instance_dict(PyTypeObject const * const base) {
-#if PY_VERSION_HEX < 0x030C0000
-	return base->tp_dictoffset != 0;
+	if (base->tp_dictoffset != 0) {
+		return true;
+	}
+
+#if PY_VERSION_HEX >= 0x030C0000
+	return (base->tp_flags & Py_TPFLAGS_HEAPTYPE) != 0 &&
+		(base->tp_flags & Py_TPFLAGS_MANAGED_DICT) != 0;
 #else
-	return base->tp_dictoffset != 0 || (base->tp_flags & Py_TPFLAGS_MANAGED_DICT) != 0;
+	return false;
 #endif
 }
 

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -240,6 +240,14 @@ bool weakref_expected(struct options const options, PyObject * const bases) {
 	return options.weakref || any_base_has_weakref_slot(bases);
 }
 
-bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
-	return options.weakref && !any_base_has_weakref_slot(bases);
+bool any_base_has_instance_dict(PyObject * const bases) {
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+
+		if (PyType_Check(base) && ((PyTypeObject *) base)->tp_dictoffset != 0) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -227,10 +227,6 @@ static bool carries_weakref_slot(PyTypeObject const * const base) {
 #endif
 }
 
-bool has_weakref_slot(StructType const * const base) {
-	return base != NULL && carries_weakref_slot(&base->heap_type.ht_type);
-}
-
 static bool carries_instance_dict(PyTypeObject const * const base) {
 #if PY_VERSION_HEX < 0x030C0000
 	return base->tp_dictoffset != 0;
@@ -249,6 +245,10 @@ static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObj
 	}
 
 	return false;
+}
+
+bool any_base_has_weakref_slot(PyObject * const bases) {
+	return any_base_satisfies(bases, carries_weakref_slot);
 }
 
 bool weakref_expected(struct options const options, PyObject * const bases) {

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -17,7 +17,6 @@ static struct equality_source equality_from_the_co_bases(PyObject * bases, Py_ss
 static struct definition base_defines(PyObject * base, PyObject * name);
 static struct definition any_base_defines(PyObject * bases, Py_ssize_t first, PyObject * name);
 static struct options base_options(StructType const * base);
-static bool any_base_has_weakref_slot(PyObject * bases);
 
 StructType * find_struct_base(PyObject * const bases) {
 	StructType * widest = NULL;
@@ -224,11 +223,19 @@ bool has_weakref_slot(StructType const * const base) {
 	return base != NULL && base->heap_type.ht_type.tp_weaklistoffset != 0;
 }
 
-static bool any_base_has_weakref_slot(PyObject * const bases) {
+static bool carries_weakref_slot(PyTypeObject * const base) {
+	return base->tp_weaklistoffset != 0;
+}
+
+static bool carries_instance_dict(PyTypeObject * const base) {
+	return base->tp_dictoffset != 0;
+}
+
+static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObject *)) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
 
-		if (PyType_Check(base) && ((PyTypeObject *) base)->tp_weaklistoffset != 0) {
+		if (PyType_Check(base) && carries((PyTypeObject *) base)) {
 			return true;
 		}
 	}
@@ -237,21 +244,13 @@ static bool any_base_has_weakref_slot(PyObject * const bases) {
 }
 
 bool weakref_expected(struct options const options, PyObject * const bases) {
-	return options.weakref || any_base_has_weakref_slot(bases);
+	return options.weakref || any_base_satisfies(bases, carries_weakref_slot);
 }
 
 bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
-	return options.weakref && !any_base_has_weakref_slot(bases);
+	return options.weakref && !any_base_satisfies(bases, carries_weakref_slot);
 }
 
 bool any_base_has_instance_dict(PyObject * const bases) {
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
-		PyObject * const base = PyTuple_GET_ITEM(bases, i);
-
-		if (PyType_Check(base) && ((PyTypeObject *) base)->tp_dictoffset != 0) {
-			return true;
-		}
-	}
-
-	return false;
+	return any_base_satisfies(bases, carries_instance_dict);
 }

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -240,6 +240,10 @@ bool weakref_expected(struct options const options, PyObject * const bases) {
 	return options.weakref || any_base_has_weakref_slot(bases);
 }
 
+bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
+	return options.weakref && !any_base_has_weakref_slot(bases);
+}
+
 bool any_base_has_instance_dict(PyObject * const bases) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -219,7 +219,7 @@ struct options inherited_options(PyObject * const bases, StructType const * cons
 	};
 }
 
-static bool carries_weakref_slot(PyTypeObject const * const base) {
+bool carries_weakref_slot(PyTypeObject const * const base) {
 	if (base->tp_weaklistoffset != 0) {
 		return true;
 	}

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -228,7 +228,11 @@ static bool carries_weakref_slot(PyTypeObject * const base) {
 }
 
 static bool carries_instance_dict(PyTypeObject * const base) {
+#if PY_VERSION_HEX < 0x030C0000
 	return base->tp_dictoffset != 0;
+#else
+	return base->tp_dictoffset != 0 || (base->tp_flags & Py_TPFLAGS_MANAGED_DICT) != 0;
+#endif
 }
 
 static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObject *)) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -189,14 +189,14 @@ PyObject * build_struct_class(
 
 		if (accepts_all == 1) {
 			forwarded_keywords = keywords;
-		} else {
+		} else if (request.options.weakref) {
 			accepts_weakref = chain_accepts_keyword(chain, option_keywords[OPTION_WEAKREF]);
 
 			if (accepts_weakref < 0) {
 				return NULL;
 			}
 
-			if (accepts_weakref == 1 && request.options.weakref) {
+			if (accepts_weakref == 1) {
 				weakref_only = PyDict_New();
 
 				if (
@@ -213,10 +213,8 @@ PyObject * build_struct_class(
 	}
 
 	if (
-		metatype == &StructMeta_Type &&
 		weakref_slot_is_new(request.options, bases) &&
 		handoff->tp_new != StructMeta_new &&
-		accepts_all == 0 &&
 		accepts_weakref == 0
 	) {
 		PyErr_SetString(

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -160,7 +160,11 @@ PyObject * build_struct_class(
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 
-	if (weakref_slot_is_new(request.options, bases) && handoff->tp_new != StructMeta_new) {
+	if (
+		metatype == &StructMeta_Type &&
+		weakref_slot_is_new(request.options, bases) &&
+		handoff->tp_new != StructMeta_new
+	) {
 		int const accepts = metaclass_chain_accepts_keywords(handoff);
 
 		if (accepts < 0) {
@@ -187,7 +191,7 @@ PyObject * build_struct_class(
 	if (
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
 		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||
-		refuse_slot_name_fields(plan.all_names) != RESULT_OK ||
+		refuse_slot_name_fields(plan.new_names) != RESULT_OK ||
 		refuse_displaced_slots(
 				original_namespace,
 				plan.all_names,

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -16,7 +16,8 @@ static StructType * create_class(
 	PyTypeObject * metatype,
 	PyObject * name,
 	PyObject * bases,
-	PyObject * namespace
+	PyObject * namespace,
+	PyObject * keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
 static enum result install_fields(
@@ -172,6 +173,7 @@ PyObject * build_struct_class(
 	if (
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
 		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||
+		refuse_slot_name_fields(plan.all_names) != RESULT_OK ||
 		refuse_displaced_slots(
 				original_namespace,
 				plan.all_names,
@@ -216,7 +218,7 @@ PyObject * build_struct_class(
 		)
 	);
 	StructType * struct_class = (
-		namespace != NULL ? create_class(metatype, name, bases, namespace) :
+		namespace != NULL ? create_class(metatype, name, bases, namespace, keywords) :
 		NULL
 	);
 
@@ -259,7 +261,8 @@ static StructType * create_class(
 	PyTypeObject * const metatype,
 	PyObject * const name,
 	PyObject * const bases,
-	PyObject * const namespace
+	PyObject * const namespace,
+	PyObject * const keywords
 ) {
 	PY_OWNED(type_args, PyTuple_Pack(3, name, bases, namespace));
 
@@ -269,7 +272,10 @@ static StructType * create_class(
 
 	PyTypeObject * const winner = winning_metatype(metatype, bases);
 	PyTypeObject * const builder = winner->tp_new == StructMeta_new ? winner : metatype;
-	PY_MOVABLE(created, PyType_Type.tp_new(builder, type_args, NULL));
+	PY_MOVABLE(
+		created,
+		PyType_Type.tp_new(builder, type_args, builder == winner ? NULL : keywords)
+	);
 
 	if (created == NULL) {
 		return NULL;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -633,7 +633,7 @@ static enum result settle_planned(
 		return refuse_unplanned(struct_class);
 	}
 
-	bool const carries_slot = ((PyTypeObject *) struct_class)->tp_weaklistoffset != 0;
+	bool const carries_slot = carries_weakref_slot((PyTypeObject *) struct_class);
 
 	if (carries_slot != weakref_expected(options, bases)) {
 		return refuse_unplanned(struct_class);

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -27,8 +27,11 @@ static StructType * create_class(
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
 static int callable_accepts_keyword(PyObject * new, char const * keyword);
+static int callable_accepts_keywords(PyObject * new, PyObject * keywords);
+static int code_accepts_keyword(PyCodeObject * code, PyObject * varnames, char const * keyword);
 static PyObject * metaclass_chain(PyTypeObject * winner);
 static int chain_accepts_keywords(PyTypeObject * winner, PyObject * keywords);
+static int chain_accepts_keyword(PyTypeObject * winner, char const * keyword);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -161,7 +164,9 @@ PyObject * build_struct_class(
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;
-	int accepts = 1;
+	PY_MOVABLE(weakref_only, NULL);
+	int accepts_all = 1;
+	int accepts_weakref = 1;
 
 	if (
 		handoff != metatype &&
@@ -169,14 +174,34 @@ PyObject * build_struct_class(
 		keywords != NULL &&
 		PyDict_GET_SIZE(keywords) > 0
 	) {
-		accepts = chain_accepts_keywords(handoff, keywords);
+		accepts_all = chain_accepts_keywords(handoff, keywords);
 
-		if (accepts < 0) {
+		if (accepts_all < 0) {
 			return NULL;
 		}
 
-		if (accepts == 1) {
+		if (accepts_all == 1) {
 			forwarded_keywords = keywords;
+		} else {
+			accepts_weakref = chain_accepts_keyword(handoff, option_keywords[OPTION_WEAKREF]);
+
+			if (accepts_weakref < 0) {
+				return NULL;
+			}
+
+			if (accepts_weakref == 1 && request.options.weakref) {
+				weakref_only = PyDict_New();
+
+				if (
+					weakref_only == NULL ||
+					PyDict_SetItemString(weakref_only, option_keywords[OPTION_WEAKREF], Py_True) <
+						0
+				) {
+					return NULL;
+				}
+
+				forwarded_keywords = weakref_only;
+			}
 		}
 	}
 
@@ -184,7 +209,8 @@ PyObject * build_struct_class(
 		metatype == &StructMeta_Type &&
 		weakref_slot_is_new(request.options, bases) &&
 		handoff->tp_new != StructMeta_new &&
-		accepts == 0
+		accepts_all == 0 &&
+		accepts_weakref == 0
 	) {
 		PyErr_SetString(
 			PyExc_TypeError,
@@ -205,13 +231,7 @@ PyObject * build_struct_class(
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
 		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||
 		refuse_slot_name_fields(plan.new_names) != RESULT_OK ||
-		refuse_displaced_slots(
-				original_namespace,
-				plan.all_names,
-				weakref_expected(request.options, bases),
-				PyDict_GetItemString(original_namespace, "__slots__") != NULL &&
-				any_base_has_instance_dict(bases)
-			) !=
+		refuse_displaced_slots(original_namespace, plan.all_names, bases, request.options) !=
 			RESULT_OK
 	) {
 		field_plan_clear(&plan);
@@ -329,23 +349,11 @@ static StructType * create_class(
 	return (StructType *) py_move(&created);
 }
 
-static int callable_accepts_keyword(PyObject * const new, char const * const keyword) {
-	if (!PyFunction_Check(new)) {
-		return 0;
-	}
-
-	PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
-
-	if ((code->co_flags & CO_VARKEYWORDS) != 0) {
-		return 1;
-	}
-
-	PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
-
-	if (varnames == NULL) {
-		return -1;
-	}
-
+static int code_accepts_keyword(
+	PyCodeObject * const code,
+	PyObject * const varnames,
+	char const * const keyword
+) {
 	Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
 
 	for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
@@ -364,6 +372,68 @@ static int callable_accepts_keyword(PyObject * const new, char const * const key
 	}
 
 	return 0;
+}
+
+static int callable_accepts_keyword(PyObject * const new, char const * const keyword) {
+	if (!PyFunction_Check(new)) {
+		return 0;
+	}
+
+	PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
+
+	if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+		return 1;
+	}
+
+	PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
+
+	if (varnames == NULL) {
+		return -1;
+	}
+
+	return code_accepts_keyword(code, varnames, keyword);
+}
+
+static int callable_accepts_keywords(PyObject * const new, PyObject * const keywords) {
+	if (!PyFunction_Check(new)) {
+		return 0;
+	}
+
+	PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
+
+	if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+		return 1;
+	}
+
+	PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
+
+	if (varnames == NULL) {
+		return -1;
+	}
+
+	Py_ssize_t position = 0;
+	PyObject * key;
+	PyObject * value;
+
+	while (PyDict_Next(keywords, &position, &key, &value)) {
+		char const * const name = PyUnicode_AsUTF8(key);
+
+		if (name == NULL) {
+			return -1;
+		}
+
+		int const accepts = code_accepts_keyword(code, varnames, name);
+
+		if (accepts < 0) {
+			return -1;
+		}
+
+		if (accepts == 0) {
+			return 0;
+		}
+	}
+
+	return 1;
 }
 
 static PyObject * metaclass_chain(PyTypeObject * const winner) {
@@ -399,27 +469,33 @@ static int chain_accepts_keywords(PyTypeObject * const winner, PyObject * const 
 		return -1;
 	}
 
-	Py_ssize_t position = 0;
-	PyObject * key;
-	PyObject * value;
+	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
+		int const accepts = callable_accepts_keywords(PyList_GET_ITEM(chain, i), keywords);
 
-	while (PyDict_Next(keywords, &position, &key, &value)) {
-		char const * const name = PyUnicode_AsUTF8(key);
-
-		if (name == NULL) {
+		if (accepts < 0) {
 			return -1;
 		}
 
-		for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
-			int const accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), name);
+		if (accepts == 0) {
+			return 0;
+		}
+	}
 
-			if (accepts < 0) {
-				return -1;
-			}
+	return 1;
+}
 
-			if (accepts == 0) {
-				return 0;
-			}
+static int chain_accepts_keyword(PyTypeObject * const winner, char const * const keyword) {
+	PY_OWNED(chain, metaclass_chain(winner));
+
+	if (chain == NULL) {
+		return -1;
+	}
+
+	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
+		int const accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), keyword);
+
+		if (accepts <= 0) {
+			return accepts;
 		}
 	}
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -30,8 +30,8 @@ static int callable_accepts_keyword(PyObject * new, char const * keyword);
 static int callable_accepts_keywords(PyObject * new, PyObject * keywords);
 static int code_accepts_keyword(PyCodeObject * code, PyObject * varnames, char const * keyword);
 static PyObject * metaclass_chain(PyTypeObject * winner);
-static int chain_accepts_keywords(PyTypeObject * winner, PyObject * keywords);
-static int chain_accepts_keyword(PyTypeObject * winner, char const * keyword);
+static int chain_accepts_keywords(PyObject * chain, PyObject * keywords);
+static int chain_accepts_keyword(PyObject * chain, char const * keyword);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -165,6 +165,7 @@ PyObject * build_struct_class(
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;
 	PY_MOVABLE(weakref_only, NULL);
+	PY_MOVABLE(chain, NULL);
 	int accepts_all = 1;
 	int accepts_weakref = 1;
 
@@ -174,7 +175,13 @@ PyObject * build_struct_class(
 		keywords != NULL &&
 		PyDict_GET_SIZE(keywords) > 0
 	) {
-		accepts_all = chain_accepts_keywords(handoff, keywords);
+		chain = metaclass_chain(handoff);
+
+		if (chain == NULL) {
+			return NULL;
+		}
+
+		accepts_all = chain_accepts_keywords(chain, keywords);
 
 		if (accepts_all < 0) {
 			return NULL;
@@ -183,7 +190,7 @@ PyObject * build_struct_class(
 		if (accepts_all == 1) {
 			forwarded_keywords = keywords;
 		} else {
-			accepts_weakref = chain_accepts_keyword(handoff, option_keywords[OPTION_WEAKREF]);
+			accepts_weakref = chain_accepts_keyword(chain, option_keywords[OPTION_WEAKREF]);
 
 			if (accepts_weakref < 0) {
 				return NULL;
@@ -263,6 +270,7 @@ PyObject * build_struct_class(
 			plan.new_names,
 			request.options,
 			base,
+			bases,
 			inherited,
 			frozen_across_bases,
 			body_defines_eq,
@@ -452,6 +460,10 @@ static PyObject * metaclass_chain(PyTypeObject * const winner) {
 			break;
 		}
 
+		if (link->tp_new == StructMeta_new) {
+			continue;
+		}
+
 		PY_OWNED(new, PyObject_GetAttrString((PyObject *) link, "__new__"));
 
 		if (new == NULL || PyList_Append(chain, new) < 0) {
@@ -462,13 +474,7 @@ static PyObject * metaclass_chain(PyTypeObject * const winner) {
 	return py_move(&chain);
 }
 
-static int chain_accepts_keywords(PyTypeObject * const winner, PyObject * const keywords) {
-	PY_OWNED(chain, metaclass_chain(winner));
-
-	if (chain == NULL) {
-		return -1;
-	}
-
+static int chain_accepts_keywords(PyObject * const chain, PyObject * const keywords) {
 	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
 		int const accepts = callable_accepts_keywords(PyList_GET_ITEM(chain, i), keywords);
 
@@ -484,13 +490,7 @@ static int chain_accepts_keywords(PyTypeObject * const winner, PyObject * const 
 	return 1;
 }
 
-static int chain_accepts_keyword(PyTypeObject * const winner, char const * const keyword) {
-	PY_OWNED(chain, metaclass_chain(winner));
-
-	if (chain == NULL) {
-		return -1;
-	}
-
+static int chain_accepts_keyword(PyObject * const chain, char const * const keyword) {
 	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
 		int const accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), keyword);
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -399,7 +399,11 @@ static int callable_accepts_keyword(PyObject * const new, char const * const key
 		return 1;
 	}
 
-	PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
+#if PY_VERSION_HEX >= 0x030B0000
+	PY_OWNED(varnames, PyCode_GetVarnames(code));
+#else
+	PyObject * const varnames = code->co_varnames;
+#endif
 
 	if (varnames == NULL) {
 		return -1;
@@ -419,7 +423,11 @@ static int callable_accepts_keywords(PyObject * const new, PyObject * const keyw
 		return 1;
 	}
 
-	PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
+#if PY_VERSION_HEX >= 0x030B0000
+	PY_OWNED(varnames, PyCode_GetVarnames(code));
+#else
+	PyObject * const varnames = code->co_varnames;
+#endif
 
 	if (varnames == NULL) {
 		return -1;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -27,12 +27,14 @@ static StructType * create_class(
 	PyObject * forwarded_keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
-static int callable_accepts_keyword(PyObject * new, char const * keyword);
-static int callable_accepts_keywords(PyObject * new, PyObject * keywords);
+struct chain_verdict {
+	int accepts_all;
+	int accepts_weakref;
+	bool readable;
+};
 static int code_accepts_keyword(PyCodeObject * code, PyObject * varnames, char const * keyword);
 static PyObject * metaclass_chain(PyTypeObject * winner);
-static int chain_accepts_keywords(PyObject * chain, PyObject * keywords);
-static int chain_accepts_keyword(PyObject * chain, char const * keyword);
+static struct chain_verdict chain_probe(PyObject * chain, PyObject * keywords, bool weakref_column);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -167,8 +169,7 @@ PyObject * build_struct_class(
 	PyObject * forwarded_keywords = NULL;
 	PY_MOVABLE(weakref_only, NULL);
 	PY_MOVABLE(chain, NULL);
-	int accepts_all = 1;
-	int accepts_weakref = 1;
+	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
 
 	if (
 		handoff != metatype &&
@@ -182,46 +183,41 @@ PyObject * build_struct_class(
 			return NULL;
 		}
 
-		accepts_all = chain_accepts_keywords(chain, keywords);
+		verdict = chain_probe(chain, keywords, request.options.weakref);
 
-		if (accepts_all < 0) {
+		if (verdict.accepts_all < 0) {
 			return NULL;
 		}
 
-		if (accepts_all == 1) {
+		if (verdict.accepts_all == 1) {
 			forwarded_keywords = keywords;
-		} else if (request.options.weakref) {
-			accepts_weakref = chain_accepts_keyword(chain, option_keywords[OPTION_WEAKREF]);
+		} else if (request.options.weakref && verdict.accepts_weakref == 1) {
+			weakref_only = PyDict_New();
 
-			if (accepts_weakref < 0) {
+			if (
+				weakref_only == NULL ||
+				PyDict_SetItemString(weakref_only, option_keywords[OPTION_WEAKREF], Py_True) < 0
+			) {
 				return NULL;
 			}
 
-			if (accepts_weakref == 1) {
-				weakref_only = PyDict_New();
-
-				if (
-					weakref_only == NULL ||
-					PyDict_SetItemString(weakref_only, option_keywords[OPTION_WEAKREF], Py_True) <
-						0
-				) {
-					return NULL;
-				}
-
-				forwarded_keywords = weakref_only;
-			}
+			forwarded_keywords = weakref_only;
 		}
 	}
 
 	if (
 		weakref_slot_is_new(request.options, bases) &&
 		handoff->tp_new != StructMeta_new &&
-		accepts_weakref == 0
+		verdict.accepts_weakref == 0
 	) {
 		PyErr_SetString(
 			PyExc_TypeError,
-			"weakref=True cannot cross a metaclass __new__ that hands the build "
-			"off: the re-entered call cannot add the weakref slot"
+			verdict.readable ?
+				"weakref=True cannot cross a metaclass __new__ that hands the build "
+				"off: the re-entered call cannot add the weakref slot" :
+				"weakref=True cannot cross a metaclass __new__ that hands the build "
+				"off: the chain contains a __new__ whose signature cannot be read, so "
+				"the re-entered call cannot be verified to add the weakref slot"
 		);
 
 		return NULL;
@@ -388,74 +384,88 @@ static int code_accepts_keyword(
 	return 0;
 }
 
-static int callable_accepts_keyword(PyObject * const new, char const * const keyword) {
-	if (!PyFunction_Check(new)) {
-		return 0;
-	}
+static struct chain_verdict chain_probe(
+	PyObject * const chain,
+	PyObject * const keywords,
+	bool const weakref_column
+) {
+	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
 
-	PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
+	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
+		PyObject * const link = PyList_GET_ITEM(chain, i);
 
-	if ((code->co_flags & CO_VARKEYWORDS) != 0) {
-		return 1;
-	}
+		if (!PyFunction_Check(link)) {
+			verdict.readable = false;
+			verdict.accepts_all = 0;
+			verdict.accepts_weakref = 0;
+			continue;
+		}
+
+		PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) link)->func_code;
+
+		if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+			continue;
+		}
 
 #if PY_VERSION_HEX >= 0x030B0000
-	PY_OWNED(varnames, PyCode_GetVarnames(code));
+		PY_OWNED(varnames, PyCode_GetVarnames(code));
 #else
-	PyObject * const varnames = code->co_varnames;
+		PyObject * const varnames = code->co_varnames;
 #endif
 
-	if (varnames == NULL) {
-		return -1;
-	}
+		if (varnames == NULL) {
+			verdict.accepts_all = -1;
 
-	return code_accepts_keyword(code, varnames, keyword);
-}
-
-static int callable_accepts_keywords(PyObject * const new, PyObject * const keywords) {
-	if (!PyFunction_Check(new)) {
-		return 0;
-	}
-
-	PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
-
-	if ((code->co_flags & CO_VARKEYWORDS) != 0) {
-		return 1;
-	}
-
-#if PY_VERSION_HEX >= 0x030B0000
-	PY_OWNED(varnames, PyCode_GetVarnames(code));
-#else
-	PyObject * const varnames = code->co_varnames;
-#endif
-
-	if (varnames == NULL) {
-		return -1;
-	}
-
-	Py_ssize_t position = 0;
-	PyObject * key;
-	PyObject * value;
-
-	while (PyDict_Next(keywords, &position, &key, &value)) {
-		char const * const name = PyUnicode_AsUTF8(key);
-
-		if (name == NULL) {
-			return -1;
+			return verdict;
 		}
 
-		int const accepts = code_accepts_keyword(code, varnames, name);
+		Py_ssize_t position = 0;
+		PyObject * key;
+		PyObject * value;
 
-		if (accepts < 0) {
-			return -1;
+		while (PyDict_Next(keywords, &position, &key, &value)) {
+			char const * const name = PyUnicode_AsUTF8(key);
+
+			if (name == NULL) {
+				verdict.accepts_all = -1;
+
+				return verdict;
+			}
+
+			int const accepts = code_accepts_keyword(code, varnames, name);
+
+			if (accepts < 0) {
+				verdict.accepts_all = -1;
+
+				return verdict;
+			}
+
+			if (accepts == 0) {
+				verdict.accepts_all = 0;
+				break;
+			}
 		}
 
-		if (accepts == 0) {
-			return 0;
+		if (weakref_column) {
+			int const accepts_weakref = code_accepts_keyword(
+				code,
+				varnames,
+				option_keywords[OPTION_WEAKREF]
+			);
+
+			if (accepts_weakref < 0) {
+				verdict.accepts_all = -1;
+
+				return verdict;
+			}
+
+			if (accepts_weakref == 0) {
+				verdict.accepts_weakref = 0;
+			}
 		}
 	}
 
-	return 1;
+	return verdict;
 }
 
 static PyObject * metaclass_chain(PyTypeObject * const winner) {
@@ -486,34 +496,6 @@ static PyObject * metaclass_chain(PyTypeObject * const winner) {
 	}
 
 	return py_move(&chain);
-}
-
-static int chain_accepts_keywords(PyObject * const chain, PyObject * const keywords) {
-	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
-		int const accepts = callable_accepts_keywords(PyList_GET_ITEM(chain, i), keywords);
-
-		if (accepts < 0) {
-			return -1;
-		}
-
-		if (accepts == 0) {
-			return 0;
-		}
-	}
-
-	return 1;
-}
-
-static int chain_accepts_keyword(PyObject * const chain, char const * const keyword) {
-	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
-		int const accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), keyword);
-
-		if (accepts <= 0) {
-			return accepts;
-		}
-	}
-
-	return 1;
 }
 
 /* It is the third walk of `bases` in a class creation, after find_struct_base

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -384,6 +384,10 @@ static int callable_accepts_keyword(PyObject * new, PyObject * const keyword) {
 		return (PyCFunction_GET_FLAGS(new) & METH_KEYWORDS) != 0;
 	}
 
+	if ((Py_TYPE(new)->tp_flags & Py_TPFLAGS_HEAPTYPE) == 0) {
+		return 1;
+	}
+
 	return 0;
 }
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -150,20 +150,6 @@ PyObject * build_struct_class(
 		return NULL;
 	}
 
-	if (
-		metatype == &StructMeta_Type &&
-		weakref_slot_is_new(request.options, bases) &&
-		winning_metatype(metatype, bases)->tp_new != StructMeta_new
-	) {
-		PyErr_SetString(
-			PyExc_TypeError,
-			"weakref=True cannot cross a metaclass __new__ that hands the build "
-			"off: the re-entered call cannot add the weakref slot"
-		);
-
-		return NULL;
-	}
-
 	struct field_plan plan = field_plan_build(base, original_namespace);
 
 	if (field_plan_failed(&plan)) {
@@ -177,7 +163,8 @@ PyObject * build_struct_class(
 		refuse_displaced_slots(
 				original_namespace,
 				plan.all_names,
-				weakref_expected(request.options, bases)
+				weakref_expected(request.options, bases),
+				any_base_has_instance_dict(bases)
 			) !=
 			RESULT_OK
 	) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -26,8 +26,9 @@ static StructType * create_class(
 	PyObject * forwarded_keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
-static int callable_accepts_keyword(PyObject * new, PyObject * keyword);
-static PyObject * chain_forwarded_keywords(PyTypeObject * winner, PyObject * keywords);
+static int callable_accepts_keyword(PyObject * new, char const * keyword);
+static PyObject * metaclass_chain(PyTypeObject * winner);
+static int chain_accepts_keywords(PyTypeObject * winner, PyObject * keywords);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -160,17 +161,22 @@ PyObject * build_struct_class(
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;
-	PY_MOVABLE(filtered_keywords, NULL);
+	int accepts = 1;
 
-	if (handoff->tp_new != StructMeta_new && keywords != NULL && PyDict_GET_SIZE(keywords) > 0) {
-		filtered_keywords = chain_forwarded_keywords(handoff, keywords);
+	if (
+		handoff != metatype &&
+		handoff->tp_new != StructMeta_new &&
+		keywords != NULL &&
+		PyDict_GET_SIZE(keywords) > 0
+	) {
+		accepts = chain_accepts_keywords(handoff, keywords);
 
-		if (filtered_keywords == NULL) {
+		if (accepts < 0) {
 			return NULL;
 		}
 
-		if (PyDict_GET_SIZE(filtered_keywords) > 0) {
-			forwarded_keywords = filtered_keywords;
+		if (accepts == 1) {
+			forwarded_keywords = keywords;
 		}
 	}
 
@@ -178,10 +184,7 @@ PyObject * build_struct_class(
 		metatype == &StructMeta_Type &&
 		weakref_slot_is_new(request.options, bases) &&
 		handoff->tp_new != StructMeta_new &&
-		(
-			filtered_keywords == NULL ||
-			PyDict_GetItemString(filtered_keywords, option_keywords[OPTION_WEAKREF]) == NULL
-		)
+		accepts == 0
 	) {
 		PyErr_SetString(
 			PyExc_TypeError,
@@ -326,53 +329,44 @@ static StructType * create_class(
 	return (StructType *) py_move(&created);
 }
 
-static int callable_accepts_keyword(PyObject * const new, PyObject * const keyword) {
-	if (PyMethod_Check(new)) {
+static int callable_accepts_keyword(PyObject * const new, char const * const keyword) {
+	if (!PyFunction_Check(new)) {
 		return 0;
 	}
 
-	if (PyFunction_Check(new)) {
-		PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
+	PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
 
-		if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+	if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+		return 1;
+	}
+
+	PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
+
+	if (varnames == NULL) {
+		return -1;
+	}
+
+	Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
+
+	for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
+		int const compared = PyUnicode_CompareWithASCIIString(
+			PyTuple_GET_ITEM(varnames, i),
+			keyword
+		);
+
+		if (compared == 0) {
 			return 1;
 		}
 
-		PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
-
-		if (varnames == NULL) {
+		if (compared < 0 && PyErr_Occurred()) {
 			return -1;
 		}
-
-		Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
-
-		for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
-			int const compared = PyUnicode_Compare(PyTuple_GET_ITEM(varnames, i), keyword);
-
-			if (compared == 0) {
-				return 1;
-			}
-
-			if (compared < 0 && PyErr_Occurred()) {
-				return -1;
-			}
-		}
-
-		return 0;
-	}
-
-	if (PyCFunction_Check(new)) {
-		return (PyCFunction_GET_FLAGS(new) & METH_KEYWORDS) != 0;
-	}
-
-	if ((Py_TYPE(new)->tp_flags & Py_TPFLAGS_HEAPTYPE) == 0) {
-		return 1;
 	}
 
 	return 0;
 }
 
-static PyObject * chain_forwarded_keywords(PyTypeObject * const winner, PyObject * const keywords) {
+static PyObject * metaclass_chain(PyTypeObject * const winner) {
 	PY_MOVABLE(chain, PyList_New(0));
 
 	if (chain == NULL) {
@@ -395,10 +389,14 @@ static PyObject * chain_forwarded_keywords(PyTypeObject * const winner, PyObject
 		}
 	}
 
-	PY_MOVABLE(filtered, PyDict_New());
+	return py_move(&chain);
+}
 
-	if (filtered == NULL) {
-		return NULL;
+static int chain_accepts_keywords(PyTypeObject * const winner, PyObject * const keywords) {
+	PY_OWNED(chain, metaclass_chain(winner));
+
+	if (chain == NULL) {
+		return -1;
 	}
 
 	Py_ssize_t position = 0;
@@ -406,26 +404,26 @@ static PyObject * chain_forwarded_keywords(PyTypeObject * const winner, PyObject
 	PyObject * value;
 
 	while (PyDict_Next(keywords, &position, &key, &value)) {
-		int accepts = 1;
+		char const * const name = PyUnicode_AsUTF8(key);
+
+		if (name == NULL) {
+			return -1;
+		}
 
 		for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
-			accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), key);
+			int const accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), name);
 
-			if (accepts <= 0) {
-				break;
+			if (accepts < 0) {
+				return -1;
 			}
-		}
 
-		if (accepts < 0) {
-			return NULL;
-		}
-
-		if (accepts == 1 && PyDict_SetItem(filtered, key, value) < 0) {
-			return NULL;
+			if (accepts == 0) {
+				return 0;
+			}
 		}
 	}
 
-	return py_move(&filtered);
+	return 1;
 }
 
 /* It is the third walk of `bases` in a class creation, after find_struct_base

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -26,7 +26,7 @@ static StructType * create_class(
 	PyObject * keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
-static int delegate_accepts_keywords(PyTypeObject * winner);
+static int metaclass_chain_accepts_keywords(PyTypeObject * winner);
 static int new_accepts_keywords(PyObject * new);
 static enum result install_fields(
 	StructType * struct_class,
@@ -158,6 +158,26 @@ PyObject * build_struct_class(
 		return NULL;
 	}
 
+	PyTypeObject * const handoff = winning_metatype(metatype, bases);
+
+	if (weakref_slot_is_new(request.options, bases) && handoff->tp_new != StructMeta_new) {
+		int const accepts = metaclass_chain_accepts_keywords(handoff);
+
+		if (accepts < 0) {
+			return NULL;
+		}
+
+		if (accepts == 0) {
+			PyErr_SetString(
+				PyExc_TypeError,
+				"weakref=True cannot cross a metaclass __new__ that hands the build "
+				"off: the re-entered call cannot add the weakref slot"
+			);
+
+			return NULL;
+		}
+	}
+
 	struct field_plan plan = field_plan_build(base, original_namespace);
 
 	if (field_plan_failed(&plan)) {
@@ -270,7 +290,7 @@ static StructType * create_class(
 	PyObject * forwarded = NULL;
 
 	if (builder != winner && keywords != NULL && PyDict_GET_SIZE(keywords) > 0) {
-		int const accepts = delegate_accepts_keywords(winner);
+		int const accepts = metaclass_chain_accepts_keywords(winner);
 
 		if (accepts < 0) {
 			return NULL;
@@ -307,14 +327,28 @@ static StructType * create_class(
  * us for a 16-field class either way, so the walk is bounded by the width of
  * that band rather than shown to be free. It is one Py_TYPE and one
  * PyType_IsSubtype per base, and a class has one. */
-static int delegate_accepts_keywords(PyTypeObject * const winner) {
-	PY_OWNED(new, PyObject_GetAttrString((PyObject *) winner, "__new__"));
+static int metaclass_chain_accepts_keywords(PyTypeObject * const winner) {
+	PyObject * const mro = winner->tp_mro;
 
-	if (new == NULL) {
-		return -1;
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyTypeObject * const link = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
+
+		if (link == &StructMeta_Type || link == &PyType_Type) {
+			break;
+		}
+
+		PY_OWNED(new, PyObject_GetAttrString((PyObject *) link, "__new__"));
+
+		if (new == NULL) {
+			return -1;
+		}
+
+		if (new_accepts_keywords(new) != 1) {
+			return 0;
+		}
 	}
 
-	return new_accepts_keywords(new);
+	return 1;
 }
 
 static int new_accepts_keywords(PyObject * new) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -23,11 +23,12 @@ static StructType * create_class(
 	PyObject * name,
 	PyObject * bases,
 	PyObject * namespace,
-	PyObject * keywords
+	PyObject * forwarded_keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
-static int metaclass_chain_accepts_keywords(PyTypeObject * winner);
-static int new_accepts_keywords(PyObject * new);
+static int metaclass_chain_accepts_keyword(PyTypeObject * winner, PyObject * keyword);
+static int callable_accepts_keyword(PyObject * new, PyObject * keyword);
+static PyObject * chain_forwarded_keywords(PyTypeObject * winner, PyObject * keywords);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -159,27 +160,37 @@ PyObject * build_struct_class(
 	}
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
+	PyObject * forwarded_keywords = NULL;
+	PY_MOVABLE(filtered_keywords, NULL);
+
+	if (handoff->tp_new != StructMeta_new && keywords != NULL && PyDict_GET_SIZE(keywords) > 0) {
+		filtered_keywords = chain_forwarded_keywords(handoff, keywords);
+
+		if (filtered_keywords == NULL) {
+			return NULL;
+		}
+
+		if (PyDict_GET_SIZE(filtered_keywords) > 0) {
+			forwarded_keywords = filtered_keywords;
+		}
+	}
 
 	if (
 		metatype == &StructMeta_Type &&
 		weakref_slot_is_new(request.options, bases) &&
-		handoff->tp_new != StructMeta_new
+		handoff->tp_new != StructMeta_new &&
+		(
+			filtered_keywords == NULL ||
+			PyDict_GetItemString(filtered_keywords, option_keywords[OPTION_WEAKREF]) == NULL
+		)
 	) {
-		int const accepts = metaclass_chain_accepts_keywords(handoff);
+		PyErr_SetString(
+			PyExc_TypeError,
+			"weakref=True cannot cross a metaclass __new__ that hands the build "
+			"off: the re-entered call cannot add the weakref slot"
+		);
 
-		if (accepts < 0) {
-			return NULL;
-		}
-
-		if (accepts == 0) {
-			PyErr_SetString(
-				PyExc_TypeError,
-				"weakref=True cannot cross a metaclass __new__ that hands the build "
-				"off: the re-entered call cannot add the weakref slot"
-			);
-
-			return NULL;
-		}
+		return NULL;
 	}
 
 	struct field_plan plan = field_plan_build(base, original_namespace);
@@ -196,6 +207,7 @@ PyObject * build_struct_class(
 				original_namespace,
 				plan.all_names,
 				weakref_expected(request.options, bases),
+				PyDict_GetItemString(original_namespace, "__slots__") != NULL &&
 				any_base_has_instance_dict(bases)
 			) !=
 			RESULT_OK
@@ -237,7 +249,7 @@ PyObject * build_struct_class(
 		)
 	);
 	StructType * struct_class = (
-		namespace != NULL ? create_class(metatype, name, bases, namespace, keywords) :
+		namespace != NULL ? create_class(metatype, name, bases, namespace, forwarded_keywords) :
 		NULL
 	);
 
@@ -281,7 +293,7 @@ static StructType * create_class(
 	PyObject * const name,
 	PyObject * const bases,
 	PyObject * const namespace,
-	PyObject * const keywords
+	PyObject * const forwarded_keywords
 ) {
 	PY_OWNED(type_args, PyTuple_Pack(3, name, bases, namespace));
 
@@ -291,21 +303,11 @@ static StructType * create_class(
 
 	PyTypeObject * const winner = winning_metatype(metatype, bases);
 	PyTypeObject * const builder = winner->tp_new == StructMeta_new ? winner : metatype;
-	PyObject * forwarded = NULL;
 
-	if (builder != winner && keywords != NULL && PyDict_GET_SIZE(keywords) > 0) {
-		int const accepts = metaclass_chain_accepts_keywords(winner);
-
-		if (accepts < 0) {
-			return NULL;
-		}
-
-		if (accepts == 1) {
-			forwarded = keywords;
-		}
-	}
-
-	PY_MOVABLE(created, PyType_Type.tp_new(builder, type_args, forwarded));
+	PY_MOVABLE(
+		created,
+		PyType_Type.tp_new(builder, type_args, builder == winner ? NULL : forwarded_keywords)
+	);
 
 	if (created == NULL) {
 		return NULL;
@@ -325,13 +327,7 @@ static StructType * create_class(
 	return (StructType *) py_move(&created);
 }
 
-/* It is the third walk of `bases` in a class creation, after find_struct_base
- * and _PyType_CalculateMetaclass. Measured, and smaller than the measurement:
- * replacing the body with `return requested` leaves class creation at 9.77-9.87
- * us for a 16-field class either way, so the walk is bounded by the width of
- * that band rather than shown to be free. It is one Py_TYPE and one
- * PyType_IsSubtype per base, and a class has one. */
-static int metaclass_chain_accepts_keywords(PyTypeObject * const winner) {
+static int metaclass_chain_accepts_keyword(PyTypeObject * const winner, PyObject * const keyword) {
 	PyObject * const mro = winner->tp_mro;
 
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
@@ -347,7 +343,7 @@ static int metaclass_chain_accepts_keywords(PyTypeObject * const winner) {
 			return -1;
 		}
 
-		if (new_accepts_keywords(new) != 1) {
+		if (callable_accepts_keyword(new, keyword) != 1) {
 			return 0;
 		}
 	}
@@ -355,19 +351,33 @@ static int metaclass_chain_accepts_keywords(PyTypeObject * const winner) {
 	return 1;
 }
 
-static int new_accepts_keywords(PyObject * new) {
+static int callable_accepts_keyword(PyObject * new, PyObject * const keyword) {
 	while (PyMethod_Check(new)) {
 		new = PyMethod_GET_FUNCTION(new);
 	}
 
 	if (PyFunction_Check(new)) {
-		return (
-			(
-				((PyCodeObject *) ((PyFunctionObject *) new)->func_code)->co_flags &
-				CO_VARKEYWORDS
-			) !=
-			0
-		);
+		PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) new)->func_code;
+
+		if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+			return 1;
+		}
+
+		PY_OWNED(varnames, PyObject_GetAttrString((PyObject *) code, "co_varnames"));
+
+		if (varnames == NULL) {
+			return -1;
+		}
+
+		Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
+
+		for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
+			if (PyUnicode_Compare(PyTuple_GET_ITEM(varnames, i), keyword) == 0) {
+				return 1;
+			}
+		}
+
+		return 0;
 	}
 
 	if (PyCFunction_Check(new)) {
@@ -377,6 +387,38 @@ static int new_accepts_keywords(PyObject * new) {
 	return 0;
 }
 
+static PyObject * chain_forwarded_keywords(PyTypeObject * const winner, PyObject * const keywords) {
+	PY_MOVABLE(filtered, PyDict_New());
+
+	if (filtered == NULL) {
+		return NULL;
+	}
+
+	Py_ssize_t position = 0;
+	PyObject * key;
+	PyObject * value;
+
+	while (PyDict_Next(keywords, &position, &key, &value)) {
+		int const accepts = metaclass_chain_accepts_keyword(winner, key);
+
+		if (accepts < 0) {
+			return NULL;
+		}
+
+		if (accepts == 1 && PyDict_SetItem(filtered, key, value) < 0) {
+			return NULL;
+		}
+	}
+
+	return py_move(&filtered);
+}
+
+/* It is the third walk of `bases` in a class creation, after find_struct_base
+ * and _PyType_CalculateMetaclass. Measured, and smaller than the measurement:
+ * replacing the body with `return requested` leaves class creation at 9.77-9.87
+ * us for a 16-field class either way, so the walk is bounded by the width of
+ * that band rather than shown to be free. It is one Py_TYPE and one
+ * PyType_IsSubtype per base, and a class has one. */
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -26,7 +26,6 @@ static StructType * create_class(
 	PyObject * forwarded_keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
-static int metaclass_chain_accepts_keyword(PyTypeObject * winner, PyObject * keyword);
 static int callable_accepts_keyword(PyObject * new, PyObject * keyword);
 static PyObject * chain_forwarded_keywords(PyTypeObject * winner, PyObject * keywords);
 static enum result install_fields(
@@ -327,30 +326,6 @@ static StructType * create_class(
 	return (StructType *) py_move(&created);
 }
 
-static int metaclass_chain_accepts_keyword(PyTypeObject * const winner, PyObject * const keyword) {
-	PyObject * const mro = winner->tp_mro;
-
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
-		PyTypeObject * const link = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
-
-		if (link == &StructMeta_Type || link == &PyType_Type) {
-			break;
-		}
-
-		PY_OWNED(new, PyObject_GetAttrString((PyObject *) link, "__new__"));
-
-		if (new == NULL) {
-			return -1;
-		}
-
-		if (callable_accepts_keyword(new, keyword) != 1) {
-			return 0;
-		}
-	}
-
-	return 1;
-}
-
 static int callable_accepts_keyword(PyObject * new, PyObject * const keyword) {
 	while (PyMethod_Check(new)) {
 		new = PyMethod_GET_FUNCTION(new);
@@ -392,6 +367,28 @@ static int callable_accepts_keyword(PyObject * new, PyObject * const keyword) {
 }
 
 static PyObject * chain_forwarded_keywords(PyTypeObject * const winner, PyObject * const keywords) {
+	PY_MOVABLE(chain, PyList_New(0));
+
+	if (chain == NULL) {
+		return NULL;
+	}
+
+	PyObject * const mro = winner->tp_mro;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyTypeObject * const link = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
+
+		if (link == &StructMeta_Type || link == &PyType_Type) {
+			break;
+		}
+
+		PY_OWNED(new, PyObject_GetAttrString((PyObject *) link, "__new__"));
+
+		if (new == NULL || PyList_Append(chain, new) < 0) {
+			return NULL;
+		}
+	}
+
 	PY_MOVABLE(filtered, PyDict_New());
 
 	if (filtered == NULL) {
@@ -403,7 +400,15 @@ static PyObject * chain_forwarded_keywords(PyTypeObject * const winner, PyObject
 	PyObject * value;
 
 	while (PyDict_Next(keywords, &position, &key, &value)) {
-		int const accepts = metaclass_chain_accepts_keyword(winner, key);
+		int accepts = 1;
+
+		for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
+			accepts = callable_accepts_keyword(PyList_GET_ITEM(chain, i), key);
+
+			if (accepts <= 0) {
+				break;
+			}
+		}
 
 		if (accepts < 0) {
 			return NULL;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -27,6 +27,7 @@ static StructType * create_class(
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
 static int delegate_accepts_keywords(PyTypeObject * winner);
+static int new_accepts_keywords(PyObject * new);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -268,7 +269,7 @@ static StructType * create_class(
 	PyTypeObject * const builder = winner->tp_new == StructMeta_new ? winner : metatype;
 	PyObject * forwarded = NULL;
 
-	if (builder != winner) {
+	if (builder != winner && keywords != NULL && PyDict_GET_SIZE(keywords) > 0) {
 		int const accepts = delegate_accepts_keywords(winner);
 
 		if (accepts < 0) {
@@ -313,10 +314,29 @@ static int delegate_accepts_keywords(PyTypeObject * const winner) {
 		return -1;
 	}
 
-	return (
-		PyFunction_Check(new) &&
-		(((PyCodeObject *) ((PyFunctionObject *) new)->func_code)->co_flags & CO_VARKEYWORDS) != 0
-	);
+	return new_accepts_keywords(new);
+}
+
+static int new_accepts_keywords(PyObject * new) {
+	while (PyMethod_Check(new)) {
+		new = PyMethod_GET_FUNCTION(new);
+	}
+
+	if (PyFunction_Check(new)) {
+		return (
+			(
+				((PyCodeObject *) ((PyFunctionObject *) new)->func_code)->co_flags &
+				CO_VARKEYWORDS
+			) !=
+			0
+		);
+	}
+
+	if (PyCFunction_Check(new)) {
+		return PyCFunction_GET_FLAGS(new) & METH_KEYWORDS;
+	}
+
+	return 0;
 }
 
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -326,9 +326,9 @@ static StructType * create_class(
 	return (StructType *) py_move(&created);
 }
 
-static int callable_accepts_keyword(PyObject * new, PyObject * const keyword) {
-	while (PyMethod_Check(new)) {
-		new = PyMethod_GET_FUNCTION(new);
+static int callable_accepts_keyword(PyObject * const new, PyObject * const keyword) {
+	if (PyMethod_Check(new)) {
+		return 0;
 	}
 
 	if (PyFunction_Check(new)) {
@@ -347,8 +347,14 @@ static int callable_accepts_keyword(PyObject * new, PyObject * const keyword) {
 		Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
 
 		for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
-			if (PyUnicode_Compare(PyTuple_GET_ITEM(varnames, i), keyword) == 0) {
+			int const compared = PyUnicode_Compare(PyTuple_GET_ITEM(varnames, i), keyword);
+
+			if (compared == 0) {
 				return 1;
+			}
+
+			if (compared < 0 && PyErr_Occurred()) {
+				return -1;
 			}
 		}
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -333,7 +333,7 @@ static int new_accepts_keywords(PyObject * new) {
 	}
 
 	if (PyCFunction_Check(new)) {
-		return PyCFunction_GET_FLAGS(new) & METH_KEYWORDS;
+		return (PyCFunction_GET_FLAGS(new) & METH_KEYWORDS) != 0;
 	}
 
 	return 0;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -20,6 +20,7 @@
 
 static StructType * create_class(
 	PyTypeObject * metatype,
+	PyTypeObject * handoff,
 	PyObject * name,
 	PyObject * bases,
 	PyObject * namespace,
@@ -277,7 +278,14 @@ PyObject * build_struct_class(
 		)
 	);
 	StructType * struct_class = (
-		namespace != NULL ? create_class(metatype, name, bases, namespace, forwarded_keywords) :
+		namespace != NULL ? create_class(
+			metatype,
+			handoff,
+			name,
+			bases,
+			namespace,
+			forwarded_keywords
+		) :
 		NULL
 	);
 
@@ -318,6 +326,7 @@ PyObject * build_struct_class(
 
 static StructType * create_class(
 	PyTypeObject * const metatype,
+	PyTypeObject * const handoff,
 	PyObject * const name,
 	PyObject * const bases,
 	PyObject * const namespace,
@@ -329,12 +338,11 @@ static StructType * create_class(
 		return NULL;
 	}
 
-	PyTypeObject * const winner = winning_metatype(metatype, bases);
-	PyTypeObject * const builder = winner->tp_new == StructMeta_new ? winner : metatype;
+	PyTypeObject * const builder = handoff->tp_new == StructMeta_new ? handoff : metatype;
 
 	PY_MOVABLE(
 		created,
-		PyType_Type.tp_new(builder, type_args, builder == winner ? NULL : forwarded_keywords)
+		PyType_Type.tp_new(builder, type_args, builder == handoff ? NULL : forwarded_keywords)
 	);
 
 	if (created == NULL) {
@@ -345,7 +353,7 @@ static StructType * create_class(
 		PyErr_Format(
 			PyExc_TypeError,
 			"%.200s.__new__ returned %.200s, which is not a struct class",
-			winner->tp_name,
+			handoff->tp_name,
 			Py_TYPE(created)->tp_name
 		);
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -3,6 +3,12 @@
 #include <stddef.h>
 #include <string.h>
 
+#if PY_VERSION_HEX < 0x030B0000
+#	include <code.h>
+#else
+#	include <cpython/code.h>
+#endif
+
 #include "../construct.h"
 #include "../fields.h"
 #include "meta.h"
@@ -20,6 +26,7 @@ static StructType * create_class(
 	PyObject * keywords
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
+static int delegate_accepts_keywords(PyTypeObject * winner);
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -259,10 +266,21 @@ static StructType * create_class(
 
 	PyTypeObject * const winner = winning_metatype(metatype, bases);
 	PyTypeObject * const builder = winner->tp_new == StructMeta_new ? winner : metatype;
-	PY_MOVABLE(
-		created,
-		PyType_Type.tp_new(builder, type_args, builder == winner ? NULL : keywords)
-	);
+	PyObject * forwarded = NULL;
+
+	if (builder != winner) {
+		int const accepts = delegate_accepts_keywords(winner);
+
+		if (accepts < 0) {
+			return NULL;
+		}
+
+		if (accepts == 1) {
+			forwarded = keywords;
+		}
+	}
+
+	PY_MOVABLE(created, PyType_Type.tp_new(builder, type_args, forwarded));
 
 	if (created == NULL) {
 		return NULL;
@@ -288,6 +306,19 @@ static StructType * create_class(
  * us for a 16-field class either way, so the walk is bounded by the width of
  * that band rather than shown to be free. It is one Py_TYPE and one
  * PyType_IsSubtype per base, and a class has one. */
+static int delegate_accepts_keywords(PyTypeObject * const winner) {
+	PY_OWNED(new, PyObject_GetAttrString((PyObject *) winner, "__new__"));
+
+	if (new == NULL) {
+		return -1;
+	}
+
+	return (
+		PyFunction_Check(new) &&
+		(((PyCodeObject *) ((PyFunctionObject *) new)->func_code)->co_flags & CO_VARKEYWORDS) != 0
+	);
+}
+
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;
 

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -58,7 +58,7 @@ struct options inherited_options(PyObject * bases, StructType const * behaviour)
 bool any_struct_base_is_mutable(PyObject * bases);
 bool has_weakref_slot(StructType const * base);
 bool weakref_expected(struct options options, PyObject * bases);
-bool weakref_slot_is_new(struct options options, PyObject * bases);
+bool any_base_has_instance_dict(PyObject * bases);
 
 struct binding_plan binding_plan(
 	struct options options,
@@ -91,7 +91,8 @@ PyObject * build_class_namespace(
 enum result refuse_displaced_slots(
 	PyObject * original_namespace,
 	PyObject * all_names,
-	bool carries_a_weakref_slot
+	bool carries_a_weakref_slot,
+	bool carries_an_instance_dict
 );
 enum result refuse_colliding_methods(
 	PyObject * original_namespace,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -56,7 +56,7 @@ StructType * find_behaviour_base(PyObject * bases);
 struct equality_source resolves_body_equality(PyObject * bases);
 struct options inherited_options(PyObject * bases, StructType const * behaviour);
 bool any_struct_base_is_mutable(PyObject * bases);
-bool has_weakref_slot(StructType const * base);
+bool any_base_has_weakref_slot(PyObject * bases);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
 bool weakref_slot_is_new(struct options options, PyObject * bases);
@@ -83,6 +83,7 @@ PyObject * build_class_namespace(
 	PyObject * new_names,
 	struct options options,
 	StructType const * base,
+	PyObject * bases,
 	struct options inherited,
 	bool frozen_across_bases,
 	bool body_defines_eq,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -57,6 +57,7 @@ struct equality_source resolves_body_equality(PyObject * bases);
 struct options inherited_options(PyObject * bases, StructType const * behaviour);
 bool any_struct_base_is_mutable(PyObject * bases);
 bool any_base_has_weakref_slot(PyObject * bases);
+bool carries_weakref_slot(PyTypeObject const * type);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
 bool weakref_slot_is_new(struct options options, PyObject * bases);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -59,6 +59,7 @@ bool any_struct_base_is_mutable(PyObject * bases);
 bool has_weakref_slot(StructType const * base);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
+bool weakref_slot_is_new(struct options options, PyObject * bases);
 
 struct binding_plan binding_plan(
 	struct options options,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -92,8 +92,8 @@ PyObject * build_class_namespace(
 enum result refuse_displaced_slots(
 	PyObject * original_namespace,
 	PyObject * all_names,
-	bool carries_a_weakref_slot,
-	bool carries_an_instance_dict
+	PyObject * bases,
+	struct options options
 );
 enum result refuse_colliding_methods(
 	PyObject * original_namespace,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -99,6 +99,7 @@ enum result refuse_colliding_methods(
 	PyObject * class_name
 );
 enum result refuse_mixin_method_fields(PyObject * all_names);
+enum result refuse_slot_name_fields(PyObject * all_names);
 
 PyObject * build_struct_class(
 	PyTypeObject * metatype,

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -9,6 +9,14 @@
 #include "../result.h"
 #include "../types.h"
 
+static char const * weakref_slot_name(void) {
+	return "__weakref__";
+}
+
+static char const * instance_dict_slot_name(void) {
+	return "__dict__";
+}
+
 static PyObject * build_slots(PyObject * new_names, bool weakref);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
@@ -78,7 +86,8 @@ PyObject * build_class_namespace(
 enum result refuse_displaced_slots(
 	PyObject * const original_namespace,
 	PyObject * const all_names,
-	bool const carries_a_weakref_slot
+	bool const carries_a_weakref_slot,
+	bool const carries_an_instance_dict
 ) {
 	PyObject * const declared = PyDict_GetItemString(original_namespace, "__slots__");
 
@@ -108,7 +117,7 @@ enum result refuse_displaced_slots(
 			return RESULT_ERROR;
 		}
 
-		if (PyUnicode_CompareWithASCIIString(entry, "__weakref__") == 0) {
+		if (PyUnicode_CompareWithASCIIString(entry, weakref_slot_name()) == 0) {
 			if (carries_a_weakref_slot) {
 				continue;
 			}
@@ -123,7 +132,11 @@ enum result refuse_displaced_slots(
 			return RESULT_ERROR;
 		}
 
-		if (PyUnicode_CompareWithASCIIString(entry, "__dict__") == 0) {
+		if (PyUnicode_CompareWithASCIIString(entry, instance_dict_slot_name()) == 0) {
+			if (carries_an_instance_dict) {
+				continue;
+			}
+
 			PyErr_SetString(
 				PyExc_TypeError,
 				"__slots__ names __dict__ and a struct carries no instance dict; "
@@ -163,9 +176,12 @@ enum result refuse_slot_name_fields(PyObject * const all_names) {
 		char const * const owner = (
 			PyUnicode_CompareWithASCIIString(
 				field_name,
-				"__weakref__"
+				weakref_slot_name()
 			) == 0 ? "the weakref slot's" :
-			PyUnicode_CompareWithASCIIString(field_name, "__dict__") == 0 ? "the instance dict's" :
+			PyUnicode_CompareWithASCIIString(
+				field_name,
+				instance_dict_slot_name()
+			) == 0 ? "the instance dict's" :
 			NULL
 		);
 
@@ -192,7 +208,7 @@ static PyObject * build_slots(PyObject * const new_names, bool const weakref) {
 	}
 
 	if (weakref) {
-		PY_OWNED(weakref_name, PyUnicode_FromString("__weakref__"));
+		PY_OWNED(weakref_name, PyUnicode_FromString(weakref_slot_name()));
 
 		if (weakref_name == NULL || PyList_Append(names, weakref_name) < 0) {
 			return NULL;

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -100,14 +100,17 @@ PyObject * build_class_namespace(
 enum result refuse_displaced_slots(
 	PyObject * const original_namespace,
 	PyObject * const all_names,
-	bool const carries_a_weakref_slot,
-	bool const carries_an_instance_dict
+	PyObject * const bases,
+	struct options const options
 ) {
 	PyObject * const declared = PyDict_GetItemString(original_namespace, "__slots__");
 
 	if (declared == NULL) {
 		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
 	}
+
+	bool const carries_a_weakref_slot = weakref_expected(options, bases);
+	bool const carries_an_instance_dict = any_base_has_instance_dict(bases);
 
 	PY_OWNED(
 		entries,

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -31,7 +31,7 @@ static enum slot_name_owner slot_name_owner_of(PyObject * const name) {
 	return SLOT_NAME_NONE;
 }
 
-static PyObject * build_slots(PyObject * new_names, bool weakref);
+static PyObject * build_slots(PyObject * new_names, bool weakref, PyObject * bases);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
 	PyObject * namespace,
@@ -65,13 +65,14 @@ PyObject * build_class_namespace(
 	PyObject * const new_names,
 	struct options const options,
 	StructType const * const base,
+	PyObject * const bases,
 	struct options const inherited,
 	bool const frozen_across_bases,
 	bool const body_defines_eq,
 	bool const inherits_body_eq,
 	bool const derive_not_equal
 ) {
-	PY_OWNED(slots, build_slots(new_names, options.weakref && !has_weakref_slot(base)));
+	PY_OWNED(slots, build_slots(new_names, options.weakref, bases));
 	PY_MOVABLE(namespace, PyDict_Copy(original_namespace));
 
 	if (
@@ -214,14 +215,18 @@ enum result refuse_slot_name_fields(PyObject * const all_names) {
 	return RESULT_OK;
 }
 
-static PyObject * build_slots(PyObject * const new_names, bool const weakref) {
+static PyObject * build_slots(
+	PyObject * const new_names,
+	bool const weakref,
+	PyObject * const bases
+) {
 	PY_OWNED(names, PySequence_List(new_names));
 
 	if (names == NULL) {
 		return NULL;
 	}
 
-	if (weakref) {
+	if (weakref && !any_base_has_weakref_slot(bases)) {
 		PY_OWNED(weakref_name, PyUnicode_FromString(weakref_slot_name()));
 
 		if (weakref_name == NULL || PyList_Append(names, weakref_name) < 0) {

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -17,6 +17,20 @@ static char const * instance_dict_slot_name(void) {
 	return "__dict__";
 }
 
+enum slot_name_owner { SLOT_NAME_NONE, SLOT_NAME_WEAKREF, SLOT_NAME_INSTANCE_DICT };
+
+static enum slot_name_owner slot_name_owner_of(PyObject * const name) {
+	if (PyUnicode_CompareWithASCIIString(name, weakref_slot_name()) == 0) {
+		return SLOT_NAME_WEAKREF;
+	}
+
+	if (PyUnicode_CompareWithASCIIString(name, instance_dict_slot_name()) == 0) {
+		return SLOT_NAME_INSTANCE_DICT;
+	}
+
+	return SLOT_NAME_NONE;
+}
+
 static PyObject * build_slots(PyObject * new_names, bool weakref);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
@@ -117,7 +131,9 @@ enum result refuse_displaced_slots(
 			return RESULT_ERROR;
 		}
 
-		if (PyUnicode_CompareWithASCIIString(entry, weakref_slot_name()) == 0) {
+		enum slot_name_owner const owner = slot_name_owner_of(entry);
+
+		if (owner == SLOT_NAME_WEAKREF) {
 			if (carries_a_weakref_slot) {
 				continue;
 			}
@@ -132,7 +148,7 @@ enum result refuse_displaced_slots(
 			return RESULT_ERROR;
 		}
 
-		if (PyUnicode_CompareWithASCIIString(entry, instance_dict_slot_name()) == 0) {
+		if (owner == SLOT_NAME_INSTANCE_DICT) {
 			if (carries_an_instance_dict) {
 				continue;
 			}
@@ -173,24 +189,19 @@ enum result refuse_displaced_slots(
 enum result refuse_slot_name_fields(PyObject * const all_names) {
 	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(all_names); ++i) {
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
-		char const * const owner = (
-			PyUnicode_CompareWithASCIIString(
-				field_name,
-				weakref_slot_name()
-			) == 0 ? "the weakref slot's" :
-			PyUnicode_CompareWithASCIIString(
-				field_name,
-				instance_dict_slot_name()
-			) == 0 ? "the instance dict's" :
+		enum slot_name_owner const owner = slot_name_owner_of(field_name);
+		char const * const owner_name = (
+			owner == SLOT_NAME_WEAKREF ? "the weakref slot's" :
+			owner == SLOT_NAME_INSTANCE_DICT ? "the instance dict's" :
 			NULL
 		);
 
-		if (owner != NULL) {
+		if (owner_name != NULL) {
 			PyErr_Format(
 				PyExc_TypeError,
 				"'%U' is %s name and cannot be a field",
 				field_name,
-				owner
+				owner_name
 			);
 
 			return RESULT_ERROR;

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -123,6 +123,16 @@ enum result refuse_displaced_slots(
 			return RESULT_ERROR;
 		}
 
+		if (PyUnicode_CompareWithASCIIString(entry, "__dict__") == 0) {
+			PyErr_SetString(
+				PyExc_TypeError,
+				"__slots__ names __dict__ and a struct carries no instance dict; "
+				"a non-struct base that carries one gives the struct one"
+			);
+
+			return RESULT_ERROR;
+		}
+
 		int const named_by_a_field = PySequence_Contains(all_names, entry);
 
 		if (named_by_a_field < 0) {
@@ -142,6 +152,33 @@ enum result refuse_displaced_slots(
 		);
 
 		return RESULT_ERROR;
+	}
+
+	return RESULT_OK;
+}
+
+enum result refuse_slot_name_fields(PyObject * const all_names) {
+	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(all_names); ++i) {
+		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
+		char const * const owner = (
+			PyUnicode_CompareWithASCIIString(
+				field_name,
+				"__weakref__"
+			) == 0 ? "the weakref slot's" :
+			PyUnicode_CompareWithASCIIString(field_name, "__dict__") == 0 ? "the instance dict's" :
+			NULL
+		);
+
+		if (owner != NULL) {
+			PyErr_Format(
+				PyExc_TypeError,
+				"'%U' is %s name and cannot be a field",
+				field_name,
+				owner
+			);
+
+			return RESULT_ERROR;
+		}
 	}
 
 	return RESULT_OK;

--- a/src/options.c
+++ b/src/options.c
@@ -4,15 +4,6 @@
 #include "options.h"
 #include "owned.h"
 
-enum option {
-	OPTION_FROZEN,
-	OPTION_EQ,
-	OPTION_ORDER,
-	OPTION_REPR,
-	OPTION_MATCH_ARGS,
-	OPTION_WEAKREF,
-};
-
 enum : Py_ssize_t {
 	OPTION_COUNT = OPTION_WEAKREF + 1,
 };
@@ -22,7 +13,7 @@ struct option_lookup {
 	enum option option;
 };
 
-static char const * const option_keywords[OPTION_COUNT] = {
+char const * const option_keywords[OPTION_COUNT] = {
 	[OPTION_FROZEN] = "frozen",
 	[OPTION_EQ] = "eq",
 	[OPTION_ORDER] = "order",

--- a/src/options.h
+++ b/src/options.h
@@ -17,6 +17,17 @@ struct options_request {
 	struct options options;
 };
 
+enum option {
+	OPTION_FROZEN,
+	OPTION_EQ,
+	OPTION_ORDER,
+	OPTION_REPR,
+	OPTION_MATCH_ARGS,
+	OPTION_WEAKREF,
+};
+
+extern char const * const option_keywords[];
+
 static inline struct options options_initial(void) {
 	return (struct options){
 		.frozen = true,

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -547,6 +547,23 @@ class TestBindingsSalixOwns:
             class Dicted(Struct):
                 __slots__ = ("__dict__",)
 
+    def test_a_slot_naming_an_inherited_dict_is_accepted(self):
+        """Naming the inherited dict loses nothing, so the entry is accepted
+        and the dict still works.
+        """
+
+        class Dicted:
+            pass
+
+        class WithDict(Struct, Dicted, frozen=False):
+            x: int
+            __slots__ = ("__dict__",)
+
+        instance = WithDict(1)
+        instance.extra = 2
+
+        assert instance.__dict__ == {"extra": 2}
+
     def test_a_field_named_weakref_is_refused(self):
         with pytest.raises(TypeError, match="weakref slot's name"):
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -564,6 +564,20 @@ class TestBindingsSalixOwns:
 
         assert instance.__dict__ == {"extra": 2}
 
+    @pytest.mark.skipif(sys.version_info < (3, 12), reason="managed dicts are 3.12+")
+    def test_a_slot_naming_an_inherited_managed_dict_is_accepted(self):
+        class DictedSlots:
+            __slots__ = ("__dict__",)
+
+        class WithManaged(Struct, DictedSlots, frozen=False):
+            x: int
+            __slots__ = ("__dict__",)
+
+        instance = WithManaged(1)
+        instance.extra = 2
+
+        assert instance.__dict__ == {"extra": 2}
+
     def test_a_field_named_weakref_is_refused(self):
         with pytest.raises(TypeError, match="weakref slot's name"):
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -541,6 +541,24 @@ class TestBindingsSalixOwns:
                 x: int
                 __slots__ = ("__weakref__", "x")
 
+    def test_a_slot_naming_dict_gets_the_dict_advice(self):
+        with pytest.raises(TypeError, match="carries no instance dict"):
+
+            class Dicted(Struct):
+                __slots__ = ("__dict__",)
+
+    def test_a_field_named_weakref_is_refused(self):
+        with pytest.raises(TypeError, match="weakref slot's name"):
+
+            class Named(Struct):
+                __weakref__: int
+
+    def test_a_field_named_dict_is_refused(self):
+        with pytest.raises(TypeError, match="instance dict's name"):
+
+            class Named(Struct):
+                __dict__: int
+
     def test_an_inherited_weakref_slot_exempts_it_too(self):
         """The other half of the exemption: the class need not ask for the slot
         if a base already has one, because then salix drops nothing.

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -330,26 +330,6 @@ class TestAMetaclassSubclass:
 
         assert built(1, 2) < built(1, 3)
 
-    def test_a_strict_init_subclass_survives_the_handoff_with_an_option_keyword(self):
-        """The hand-off's keywords never reach __init_subclass__, so a strict
-        signature stays valid.
-        """
-
-        class Strict(Struct):
-            def __init_subclass__(cls):
-                pass
-
-        class Delegating(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
-
-        class Base(Strict, metaclass=Delegating):
-            x: int
-
-        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
-
-        assert built(1, 2) < built(1, 3)
-
     def test_two_unrelated_metatypes_still_raise_the_conflict(self):
         """Picking the winner ourselves must not swallow the case that has no
         winner: type_new is handed the requested metatype and says so.

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -14,6 +14,11 @@ class Forwarding(META):
     def __new__(metacls, name, bases, namespace, **keywords):
         return super().__new__(metacls, name, bases, namespace, **keywords)
 
+
+class Plain(META):
+    def __new__(metacls, name, bases, namespace):
+        return super().__new__(metacls, name, bases, namespace)
+
 # Both spellings of both, in one place: two literals drifted apart is a test
 # that silently stops covering a name.
 METADATA_NAMES = (
@@ -328,10 +333,6 @@ class TestAMetaclassSubclass:
         the settle restores what the keyword meant.
         """
 
-        class Plain(META):
-            def __new__(metacls, name, bases, namespace):
-                return super().__new__(metacls, name, bases, namespace)
-
         class Base(Struct, metaclass=Plain):
             x: int
 
@@ -343,10 +344,6 @@ class TestAMetaclassSubclass:
         """The keywords cannot ride a __new__ that does not take them, so the
         refusal says so instead of blaming the entry salix itself wrote.
         """
-
-        class Plain(META):
-            def __new__(metacls, name, bases, namespace):
-                return super().__new__(metacls, name, bases, namespace)
 
         class Base(Struct, metaclass=Plain):
             x: int

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -343,7 +343,7 @@ class TestAMetaclassSubclass:
         held = built(1, 2)
 
         assert weakref.ref(held)() is held
-        assert built(1, 2) != built(1, 3)
+        assert built(1, 2) != built(1, 2)
 
     def test_a_delegate_without_keywords_still_gets_none_handed_over(self):
         """A delegate whose __new__ takes no **keywords would be handed the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -369,6 +369,17 @@ class TestAMetaclassSubclass:
         with pytest.raises(TypeError, match="cannot cross"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
 
+    def test_a_cobase_weakref_slot_needs_no_duplicate_entry(self):
+        class Slotted:
+            __slots__ = ("__weakref__",)
+
+        class WithSlot(Struct, Slotted, weakref=True):
+            x: int
+
+        held = WithSlot(1)
+
+        assert weakref.ref(held)() is held
+
     def test_a_keyword_only_delegate_still_gets_the_class_statement_keywords(self):
         """The class statement hands its keywords to the metaclass's own
         __new__, so a delegate that names them as keyword-only parameters

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -327,7 +327,11 @@ class TestAMetaclassSubclass:
 
         assert weakref.ref(held)() is held
 
-    def test_a_keyword_only_delegate_that_names_only_weakref_cannot_take_the_rest(self):
+    def test_a_keyword_only_delegate_that_names_only_weakref_gets_weakref_alone(self):
+        """The one option the settle cannot repair rides by itself; the rest
+        takes the keyword-less path and the settle restores it.
+        """
+
         class KwOnly(META):
             def __new__(metacls, name, bases, namespace, *, weakref=False):
                 return super().__new__(metacls, name, bases, namespace, weakref=weakref)
@@ -335,8 +339,11 @@ class TestAMetaclassSubclass:
         class Base(Struct, metaclass=KwOnly):
             x: int
 
-        with pytest.raises(TypeError, match="cannot cross"):
-            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True, eq=False)
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True, eq=False)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
+        assert built(1, 2) != built(1, 3)
 
     def test_a_delegate_without_keywords_still_gets_none_handed_over(self):
         """A delegate whose __new__ takes no **keywords would be handed the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -345,6 +345,40 @@ class TestAMetaclassSubclass:
         with pytest.raises(TypeError, match="cannot cross"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
 
+    def test_a_keyword_only_delegate_still_gets_the_class_statement_keywords(self):
+        """The class statement hands its keywords to the metaclass's own
+        __new__, so a delegate that names them as keyword-only parameters
+        builds without any hand-off from salix.
+        """
+
+        class KwOnly(META):
+            def __new__(metacls, name, bases, namespace, *, weakref=False):
+                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
+
+        class Base(Struct, metaclass=KwOnly):
+            x: int
+
+        class Built(Base, weakref=True):
+            y: int = 0
+
+        held = Built(1)
+
+        assert weakref.ref(held)() is held
+
+    def test_a_staticmethod_delegate_accepts_the_handoff_keywords(self):
+        class Staticmethoded(META):
+            @staticmethod
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return META.__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Staticmethoded):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
+
     def test_a_keyword_rides_only_a_chain_that_takes_it_end_to_end(self):
         """A chain whose intermediate __new__ takes no **keywords would raise
         on the options, so the hand-off stays keyword-less and the settle

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -301,11 +301,20 @@ class TestAMetaclassSubclass:
         assert type(built) is Delegating
 
     def test_weakref_survives_the_handoff_to_a_derived_metatype(self):
-        class Delegating(META):
-            def __new__(metacls, name, bases, namespace, **keywords):
-                return super().__new__(metacls, name, bases, namespace, **keywords)
+        class Base(Struct, metaclass=Forwarding):
+            x: int
 
-        class Base(Struct, metaclass=Delegating):
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
+
+    def test_a_keyword_only_delegate_that_names_weakref_can_add_the_slot(self):
+        class KwOnly(META):
+            def __new__(metacls, name, bases, namespace, *, weakref=False):
+                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
+
+        class Base(Struct, metaclass=KwOnly):
             x: int
 
         built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -327,6 +327,17 @@ class TestAMetaclassSubclass:
 
         assert weakref.ref(held)() is held
 
+    def test_a_keyword_only_delegate_that_names_only_weakref_cannot_take_the_rest(self):
+        class KwOnly(META):
+            def __new__(metacls, name, bases, namespace, *, weakref=False):
+                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
+
+        class Base(Struct, metaclass=KwOnly):
+            x: int
+
+        with pytest.raises(TypeError, match="cannot cross"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True, eq=False)
+
     def test_a_delegate_without_keywords_still_gets_none_handed_over(self):
         """A delegate whose __new__ takes no **keywords would be handed the
         options and raise; it gets the keyword-less hand-off it declared, and

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -298,6 +298,7 @@ class TestAMetaclassSubclass:
         built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
 
         assert built(1, 2) < built(1, 3)
+        assert type(built) is Delegating
 
     def test_weakref_survives_the_handoff_to_a_derived_metatype(self):
         class Delegating(META):
@@ -311,7 +312,23 @@ class TestAMetaclassSubclass:
         held = built(1, 2)
 
         assert weakref.ref(held)() is held
-        assert type(built) is Delegating
+
+    def test_a_delegate_without_keywords_still_gets_none_handed_over(self):
+        """A delegate whose __new__ takes no **keywords would be handed the
+        options and raise; it gets the keyword-less hand-off it declared, and
+        the settle restores what the keyword meant.
+        """
+
+        class Plain(META):
+            def __new__(metacls, name, bases, namespace):
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Base(Struct, metaclass=Plain):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert built(1, 2) < built(1, 3)
 
     def test_two_unrelated_metatypes_still_raise_the_conflict(self):
         """Picking the winner ourselves must not swallow the case that has no

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -301,7 +301,8 @@ class TestAMetaclassSubclass:
 
     def test_weakref_survives_the_handoff_to_a_derived_metatype(self):
         class Delegating(META):
-            pass
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
 
         class Base(Struct, metaclass=Delegating):
             x: int
@@ -496,16 +497,18 @@ class TestAMetaclassSubclass:
 
         assert weakref.ref(instance)() is instance
 
-    def test_a_delegate_cannot_add_a_weakref_slot_the_call_planned(self):
-        """The re-entered build cannot add the weakref slot, so the refusal
-        says so instead of dying in the inner call's displaced-slot check.
+    def test_a_delegate_can_add_the_weakref_slot_the_call_planned(self):
+        """The keywords ride the hand-off, so the re-entered build plans the
+        same slot and the direct spelling builds like the subclass spelling.
         """
 
         class Base(Struct, metaclass=Forwarding):
             x: int
 
-        with pytest.raises(TypeError, match="cannot cross"):
-            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
 
     def test_a_delegate_that_strips_the_dunders_is_settled(self):
         """A delegate that removes the dunders from the namespace leaves the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -330,6 +330,26 @@ class TestAMetaclassSubclass:
 
         assert built(1, 2) < built(1, 3)
 
+    def test_a_strict_init_subclass_survives_the_handoff_with_an_option_keyword(self):
+        """The hand-off's keywords never reach __init_subclass__, so a strict
+        signature stays valid.
+        """
+
+        class Strict(Struct):
+            def __init_subclass__(cls):
+                pass
+
+        class Delegating(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Strict, metaclass=Delegating):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert built(1, 2) < built(1, 3)
+
     def test_two_unrelated_metatypes_still_raise_the_conflict(self):
         """Picking the winner ourselves must not swallow the case that has no
         winner: type_new is handed the requested metatype and says so.

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -298,6 +298,18 @@ class TestAMetaclassSubclass:
         built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
 
         assert built(1, 2) < built(1, 3)
+
+    def test_weakref_survives_the_handoff_to_a_derived_metatype(self):
+        class Delegating(META):
+            pass
+
+        class Base(Struct, metaclass=Delegating):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
         assert type(built) is Delegating
 
     def test_two_unrelated_metatypes_still_raise_the_conflict(self):

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -330,6 +330,42 @@ class TestAMetaclassSubclass:
 
         assert built(1, 2) < built(1, 3)
 
+    def test_a_delegate_that_cannot_take_the_options_cannot_add_the_weakref_slot(self):
+        """The keywords cannot ride a __new__ that does not take them, so the
+        refusal says so instead of blaming the entry salix itself wrote.
+        """
+
+        class Plain(META):
+            def __new__(metacls, name, bases, namespace):
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Base(Struct, metaclass=Plain):
+            x: int
+
+        with pytest.raises(TypeError, match="cannot cross"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+
+    def test_a_keyword_rides_only_a_chain_that_takes_it_end_to_end(self):
+        """A chain whose intermediate __new__ takes no **keywords would raise
+        on the options, so the hand-off stays keyword-less and the settle
+        restores what the keyword meant.
+        """
+
+        class Mid(META):
+            def __new__(metacls, name, bases, namespace):
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Low(Mid):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        class Base(Struct, metaclass=Low):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert built(1, 2) < built(1, 3)
+
     def test_two_unrelated_metatypes_still_raise_the_conflict(self):
         """Picking the winner ourselves must not swallow the case that has no
         winner: type_new is handed the requested metatype and says so.

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -369,6 +369,21 @@ class TestAMetaclassSubclass:
         with pytest.raises(TypeError, match="cannot cross"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
 
+    def test_a_delegate_that_swallows_the_options_gets_the_displaced_slot_advice(self):
+        """The boundary: a delegate that accepts the options and drops them
+        re-enters keyword-less, and the advice blames the entry salix wrote.
+        """
+
+        class Swallowing(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Base(Struct, metaclass=Swallowing):
+            x: int
+
+        with pytest.raises(TypeError, match="carries no weakref slot"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+
     def test_a_cobase_weakref_slot_needs_no_duplicate_entry(self):
         class Slotted:
             __slots__ = ("__weakref__",)


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was to resolve issue #90, the three residues recorded from PR #88's review, each directioned in the issue, gated on the full matrix.

Closes #90.

**What:** the three `__slots__` refusal residues from #88's review, each reproduced on `main` first.

<details>

**1. The re-entrant path no longer blames the body for salix's own entry** — `create_class` handed `type.__new__` `NULL` keywords, so a delegating metatype re-entered without them, saw the `weakref=True` outer call's own `__weakref__` entry, and refused it with advice the caller had already followed ("a struct gets one from weakref=True", to a caller who passed exactly that). `create_class` now forwards the keywords on the hand-off path (`builder != winner`), so the re-entered call plans the same weakref the outer call did — and `weakref=True` with a delegating metaclass now **builds with a working weakref**. The direct build still passes `NULL`, so the normal path is untouched. Pinned beside the existing `order=True` hand-off test.

**2. `__dict__` gets its own sentence** — the generic "declare it as a field" advice was nonsense for `__dict__`; it now names how a struct gets an instance dict (a non-struct base that carries one), the way `__weakref__` already did.

**3. Slot-name fields refuse cleanly** — a field literally named `__weakref__` or `__dict__` was accepted by the field plan and died later in `resolve_slot_offsets` with an internal-looking `RuntimeError`. Both are refused at class creation, naming which slot owns the name.

**Boundary, stated precisely:** a delegate that cannot accept the options (`__new__` without `**keywords` or a named `weakref`) gets the accurate "cannot cross" refusal from the direct spelling. A delegate that accepts the options and then drops them re-enters keyword-less by its own code; its diagnosis is the displaced-slot advice rather than the pre-PR cross message. The same advice covers every spelling the gate does not watch — a subclass-metaclass caller with a chain-rejecting delegate included — and every such shape except one was diagnosed by that same advice before this PR too; only the direct spelling's diagnosis is what this PR moves. The exception, named honestly: the class-statement spelling (`class Built(Base, weakref=True)`) over a keyword-swallowing metaclass silently loses weakref=True with no diagnosis — the gate's `handoff != metatype` guard is false for that spelling and the install path never sees the requested weakref. That loss is pre-existing, measured on 3.14.6 in the round-19 review, and is the same #55 keyword-loss boundary — the pre-PR gate could not tell forwarding from swallowing, and the whole point of this PR is to let forwarding delegates build. That distinction is the #55 keyword loss.

**Two further boundaries, stated the same way:**

- *The managed-weakref flag is trusted* — `carries_weakref_slot` treats `MANAGED_WEAKREF` on a heap type as proof the base carries the slot. The alternative (offset-only) was measured wrong on every gate version: a plain `class D: pass` has the flag set with a zero offset and *is* weakref-able on 3.12, 3.13, 3.14, and 3.15, so offset-only misses real bases. The only shape where the flag lies is a static-builtin subclass (`class J(list): __slots__ = ()` — bit set, offset zero, `weakref.ref(J())` raises `TypeError`), which is uniform on all four versions and unconstructible as a struct co-base (CPython's own layout check fires first, measured on 3.14). The flag is the layout truth on every type a struct build can reach; this is the assumption, version-checked rather than asserted.
- *Unreadable chain links get the "cannot be verified" refusal* — a C `tp_new` or `@classmethod` `__new__` in the delegate chain is not introspectable (measured: a C `METH_KEYWORDS` wrapper over-claims; a classmethod double-binds five args into four), so the gate now says the re-entered call *cannot be verified* to add the slot rather than claiming it cannot. The probe architecture itself — signature introspection vs. CPython's own binding — is carried by #108, not this PR.

**Verification** — all three reproduced before the fix; four new pins (hand-off weakref, dict advice, both field refusals); the camas gate is green on the full matrix (3.10–3.15, free-threaded, analyzers, in-file C tests) with 1146 passing on 3.14.

</details>
