### PR TITLE
fix: the frozen pin is the fielded promise — order-independent, weakening-only

### DIFF
--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -194,15 +194,20 @@ bool any_struct_base_is_mutable(PyObject * const bases) {
 	return false;
 }
 
-struct options inherited_options(PyObject * const bases, StructType const * const behaviour) {
+struct options inherited_options(
+	PyObject * const bases,
+	StructType const * const behaviour,
+	bool * const promised_frozen
+) {
 	struct options const from_behaviour = base_options(behaviour);
-	bool promised_frozen = false;
+
+	*promised_frozen = false;
 
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
 		StructType const * const struct_base = (StructType *) base;
 
-		promised_frozen |= (
+		*promised_frozen |= (
 			is_struct_class(base) &&
 			struct_base->struct_field_count > 0 &&
 			struct_base->struct_options.frozen
@@ -210,7 +215,7 @@ struct options inherited_options(PyObject * const bases, StructType const * cons
 	}
 
 	return (struct options){
-		.frozen = from_behaviour.frozen || promised_frozen,
+		.frozen = from_behaviour.frozen || *promised_frozen,
 		.eq = from_behaviour.eq,
 		.order = from_behaviour.order,
 		.repr = from_behaviour.repr,
@@ -271,21 +276,4 @@ bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
 
 bool any_base_has_instance_dict(PyObject * const bases) {
 	return any_base_satisfies(bases, carries_instance_dict);
-}
-
-bool any_fielded_base_is_frozen(PyObject * const bases) {
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
-		PyObject * const base = PyTuple_GET_ITEM(bases, i);
-		StructType const * const struct_base = (StructType *) base;
-
-		if (
-			is_struct_class(base) &&
-			struct_base->struct_field_count > 0 &&
-			struct_base->struct_options.frozen
-		) {
-			return true;
-		}
-	}
-
-	return false;
 }

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -272,3 +272,20 @@ bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
 bool any_base_has_instance_dict(PyObject * const bases) {
 	return any_base_satisfies(bases, carries_instance_dict);
 }
+
+bool any_fielded_base_is_frozen(PyObject * const bases) {
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+		StructType const * const struct_base = (StructType *) base;
+
+		if (
+			is_struct_class(base) &&
+			struct_base->struct_field_count > 0 &&
+			struct_base->struct_options.frozen
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -17,6 +17,7 @@ static struct equality_source equality_from_the_co_bases(PyObject * bases, Py_ss
 static struct definition base_defines(PyObject * base, PyObject * name);
 static struct definition any_base_defines(PyObject * bases, Py_ssize_t first, PyObject * name);
 static struct options base_options(StructType const * base);
+static bool any_base_satisfies(PyObject * bases, bool (*carries)(PyTypeObject const *));
 
 StructType * find_struct_base(PyObject * const bases) {
 	StructType * widest = NULL;
@@ -194,6 +195,16 @@ bool any_struct_base_is_mutable(PyObject * const bases) {
 	return false;
 }
 
+static bool carries_fielded_frozen(PyTypeObject const * const base) {
+	if (!is_struct_class((PyObject *) base)) {
+		return false;
+	}
+
+	StructType const * const struct_base = (StructType *) base;
+
+	return struct_base->struct_field_count > 0 && struct_base->struct_options.frozen;
+}
+
 struct options inherited_options(
 	PyObject * const bases,
 	StructType const * const behaviour,
@@ -201,18 +212,7 @@ struct options inherited_options(
 ) {
 	struct options const from_behaviour = base_options(behaviour);
 
-	*promised_frozen = false;
-
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
-		PyObject * const base = PyTuple_GET_ITEM(bases, i);
-		StructType const * const struct_base = (StructType *) base;
-
-		*promised_frozen |= (
-			is_struct_class(base) &&
-			struct_base->struct_field_count > 0 &&
-			struct_base->struct_options.frozen
-		);
-	}
+	*promised_frozen = any_base_satisfies(bases, carries_fielded_frozen);
 
 	return (struct options){
 		.frozen = from_behaviour.frozen || *promised_frozen,

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -167,8 +167,26 @@ PyObject * build_struct_class(
 ) {
 	StructType const * const behaviour = find_behaviour_base(bases);
 	struct options const inherited = inherited_options(bases, behaviour);
+	bool fielded_base_is_frozen = false;
+
+	if (keywords != NULL) {
+		PY_OWNED(frozen_name, PyUnicode_InternFromString(option_keywords[OPTION_FROZEN]));
+
+		if (frozen_name == NULL) {
+			return NULL;
+		}
+
+		int const asked = PyDict_Contains(keywords, frozen_name);
+
+		if (asked < 0) {
+			return NULL;
+		}
+
+		fielded_base_is_frozen = asked == 1 && any_fielded_base_is_frozen(bases);
+	}
+
 	struct options_request const request =
-		options_read(keywords, inherited, any_fielded_base_is_frozen(bases));
+		options_read(keywords, inherited, fielded_base_is_frozen);
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;
@@ -793,11 +811,24 @@ static enum result settle_mro_bindings(
 	struct binding_plan const bindings,
 	struct options const options
 ) {
+	PyTypeObject * const type = (PyTypeObject *) struct_class;
+
+	/* The frozen block rides the mixin's tp_setattro; a co-base carrying its
+	 * own C-level slot can divert the inherited one to a dispatch that
+	 * bypasses the rebind, so the enforcing slot is restored here. */
+	if (
+		options.frozen &&
+		PyDict_GetItemString(original_namespace, "__setattr__") == NULL &&
+		PyDict_GetItemString(original_namespace, "__delattr__") == NULL &&
+		type->tp_setattro != StructMixin_Type.tp_setattro
+	) {
+		type->tp_setattro = StructMixin_Type.tp_setattro;
+	}
+
 	if (struct_base_count(bases) <= 1) {
 		return RESULT_OK;
 	}
 
-	PyTypeObject * const type = (PyTypeObject *) struct_class;
 	PyTypeObject * const first_struct = (PyTypeObject *) find_behaviour_base(bases);
 
 	PY_MOVABLE(mixin_eq, NULL);

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -797,18 +797,19 @@ static enum result settle_mro_bindings(
 	PyTypeObject * const type = (PyTypeObject *) struct_class;
 
 	/* A co-base carrying its own C-level tp_setattro can divert the child's
-	 * slot away from the frozen block, so the block is restored here, unless
-	 * the child's own body __setattr__ answers (the single-base escape
-	 * hatch). The mutable column needs no repair: CPython's own dispatch
-	 * honours body and co-base hooks and foreign C-level slots exactly as it
-	 * does for plain classes. Unlike the comparison repairs below, this runs
-	 * for every struct class, single or multi base. */
-	if (
-		options.frozen &&
-		PyDict_GetItemString(original_namespace, "__setattr__") == NULL &&
-		type->tp_setattro != StructMixin_Type.tp_setattro
-	) {
-		type->tp_setattro = StructMixin_Type.tp_setattro;
+	 * slot away from the frozen block, so the block's wrappers are rebound
+	 * into the class dict — the same rebind machinery every other dunder
+	 * repair uses — and the MRO-dispatching slot honours them. A body
+	 * __setattr__ or __delattr__ is skipped per name, so the escape hatch
+	 * works for either half. In a re-entered build the namespace carries the
+	 * outer build's rebind injections rather than the true body, and the
+	 * outer settle is the source of truth. The mutable column needs no
+	 * repair: CPython's own dispatch honours hooks and foreign C-level slots
+	 * exactly as it does for plain classes. */
+	if (options.frozen && type->tp_setattro != StructMixin_Type.tp_setattro) {
+		if (settle_rebind(struct_class, original_namespace, rebind_mutability, true) != RESULT_OK) {
+			return RESULT_ERROR;
+		}
 	}
 
 	if (struct_base_count(bases) <= 1) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -11,7 +11,6 @@
 
 #include "../compare.h"
 #include "../construct.h"
-#include <descrobject.h>
 #include "../fields.h"
 #include "meta.h"
 #include "../mixin.h"
@@ -331,7 +330,8 @@ PyObject * build_struct_class(
 				body_defines_eq,
 				inherits_body_eq,
 				inherited_equality.needs_derived_not_equal,
-				PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL
+				PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL,
+				PyDict_GetItemString(original_namespace, "__setattr__") != NULL
 			);
 
 			if (
@@ -609,44 +609,6 @@ static int struct_base_count(PyObject * const bases) {
 
 static PyObject * mixin_bindings[7];
 static PyObject * object_bindings[7];
-static PyObject * setattr_name_cache;
-static PyObject * delattr_name_cache;
-
-/* The mutable column's tp_setattro: dispatch through the MRO so a body or
- * co-base __setattr__ hook answers, skip a foreign C-level slot that would
- * swallow the write, and fall back to the generic setter. */
-static int struct_setattro(PyObject * const self, PyObject * const name, PyObject * const value) {
-	if (setattr_name_cache == NULL) {
-		setattr_name_cache = PyUnicode_InternFromString("__setattr__");
-		delattr_name_cache = PyUnicode_InternFromString("__delattr__");
-	}
-
-	if (setattr_name_cache == NULL || delattr_name_cache == NULL) {
-		return -1;
-	}
-
-	PY_MOVABLE(descriptor, PyObject_GetAttr(
-		(PyObject *) Py_TYPE(self),
-		value != NULL ? setattr_name_cache : delattr_name_cache
-	));
-
-	if (descriptor == NULL) {
-		PyErr_Clear();
-	} else if (
-		PyObject_TypeCheck(descriptor, &PyWrapperDescr_Type) &&
-		((PyWrapperDescrObject *) descriptor)->d_wrapped != PyBaseObject_Type.tp_setattro &&
-		((PyWrapperDescrObject *) descriptor)->d_wrapped != StructMixin_Type.tp_setattro
-	) {
-		Py_CLEAR(descriptor);
-	} else {
-		PY_OWNED(result, PyObject_CallFunctionObjArgs(descriptor, self, name, value));
-
-		return result != NULL ? 0 : -1;
-	}
-
-	return PyObject_GenericSetAttr(self, name, value);
-}
-
 static int settle_candidates(
 	PyObject * * const mixin_eq,
 	PyObject * * const object_eq,
@@ -835,28 +797,18 @@ static enum result settle_mro_bindings(
 	PyTypeObject * const type = (PyTypeObject *) struct_class;
 
 	/* A co-base carrying its own C-level tp_setattro can divert the child's
-	 * slot away from what the record asks for, so the slot is restored here.
-	 * The frozen column gets the mixin's block unless the child's own body
-	 * __setattr__ answers (the single-base escape hatch); the mutable column
-	 * gets the dispatch shim, which honours body and co-base hooks while
-	 * skipping a foreign C-level slot that would swallow the write. Unlike
-	 * the comparison repairs below, this runs for every struct class,
-	 * single or multi base. */
-	setattrofunc own_setattro = NULL;
-
-	if (options.frozen) {
-		if (PyDict_GetItemString(original_namespace, "__setattr__") == NULL) {
-			own_setattro = StructMixin_Type.tp_setattro;
-		}
-	} else if (
-		type->tp_setattro != PyBaseObject_Type.tp_setattro &&
+	 * slot away from the frozen block, so the block is restored here, unless
+	 * the child's own body __setattr__ answers (the single-base escape
+	 * hatch). The mutable column needs no repair: CPython's own dispatch
+	 * honours body and co-base hooks and foreign C-level slots exactly as it
+	 * does for plain classes. Unlike the comparison repairs below, this runs
+	 * for every struct class, single or multi base. */
+	if (
+		options.frozen &&
+		PyDict_GetItemString(original_namespace, "__setattr__") == NULL &&
 		type->tp_setattro != StructMixin_Type.tp_setattro
 	) {
-		own_setattro = struct_setattro;
-	}
-
-	if (own_setattro != NULL && type->tp_setattro != own_setattro) {
-		type->tp_setattro = own_setattro;
+		type->tp_setattro = StructMixin_Type.tp_setattro;
 	}
 
 	if (struct_base_count(bases) <= 1) {
@@ -1061,7 +1013,8 @@ static enum result settle_planned(
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,
-		PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL
+		PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL,
+		PyDict_GetItemString(original_namespace, "__setattr__") != NULL
 	);
 
 	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
@@ -1437,7 +1390,11 @@ static Py_ssize_t * resolve_member_offsets(
 
 #	include "../testing.h"
 
+static Py_ssize_t swallow_calls = 0;
+
 static int swallowing_setattro(PyObject * self, PyObject * name, PyObject * value) {
+	swallow_calls += 1;
+
 	return 0;
 }
 
@@ -1491,10 +1448,9 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PY_OWNED(nine, PyLong_FromLong(9));
 	PY_OWNED(field_name, PyUnicode_FromString("x"));
 	TEST_ASSERT_EQUAL_INT(0, PyObject_SetAttr(instance, field_name, nine));
-
-	PY_OWNED(read_back, PyObject_GetAttr(instance, field_name));
-	TEST_ASSERT_EQUAL_INT(9, PyLong_AsLong(read_back));
+	TEST_ASSERT_EQUAL_INT(1, swallow_calls);
 	TEST_ASSERT_EQUAL_INT(0, PyObject_DelAttr(instance, field_name));
+	TEST_ASSERT_EQUAL_INT(2, swallow_calls);
 
 	PY_OWNED(frozen_base, struct_class_with_field(struct_bases, NULL));
 	TEST_ASSERT_NOT_NULL(frozen_base);
@@ -1513,6 +1469,7 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PyErr_Clear();
 	TEST_ASSERT_EQUAL_INT(-1, PyObject_DelAttr(frozen_instance, field_name));
 	PyErr_Clear();
+	TEST_ASSERT_EQUAL_INT(2, swallow_calls);
 }
 
 void class_tests(void) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -11,6 +11,7 @@
 
 #include "../compare.h"
 #include "../construct.h"
+#include <descrobject.h>
 #include "../fields.h"
 #include "meta.h"
 #include "../mixin.h"
@@ -608,6 +609,43 @@ static int struct_base_count(PyObject * const bases) {
 
 static PyObject * mixin_bindings[7];
 static PyObject * object_bindings[7];
+static PyObject * setattr_name_cache;
+static PyObject * delattr_name_cache;
+
+/* The mutable column's tp_setattro: dispatch through the MRO so a body or
+ * co-base __setattr__ hook answers, skip a foreign C-level slot that would
+ * swallow the write, and fall back to the generic setter. */
+static int struct_setattro(PyObject * const self, PyObject * const name, PyObject * const value) {
+	if (setattr_name_cache == NULL) {
+		setattr_name_cache = PyUnicode_InternFromString("__setattr__");
+		delattr_name_cache = PyUnicode_InternFromString("__delattr__");
+	}
+
+	if (setattr_name_cache == NULL || delattr_name_cache == NULL) {
+		return -1;
+	}
+
+	PY_MOVABLE(descriptor, PyObject_GetAttr(
+		(PyObject *) Py_TYPE(self),
+		value != NULL ? setattr_name_cache : delattr_name_cache
+	));
+
+	if (descriptor == NULL) {
+		PyErr_Clear();
+	} else if (
+		PyObject_TypeCheck(descriptor, &PyWrapperDescr_Type) &&
+		((PyWrapperDescrObject *) descriptor)->d_wrapped != PyBaseObject_Type.tp_setattro &&
+		((PyWrapperDescrObject *) descriptor)->d_wrapped != StructMixin_Type.tp_setattro
+	) {
+		Py_CLEAR(descriptor);
+	} else {
+		PY_OWNED(result, PyObject_CallFunctionObjArgs(descriptor, self, name, value));
+
+		return result != NULL ? 0 : -1;
+	}
+
+	return PyObject_GenericSetAttr(self, name, value);
+}
 
 static int settle_candidates(
 	PyObject * * const mixin_eq,
@@ -797,20 +835,27 @@ static enum result settle_mro_bindings(
 	PyTypeObject * const type = (PyTypeObject *) struct_class;
 
 	/* A co-base carrying its own C-level tp_setattro can divert the child's
-	 * slot to a dispatch that bypasses the namespace rebind, so the slot the
-	 * record asks for — the mixin's frozen block or object's generic setter —
-	 * is restored here. Unlike the comparison repairs below, this runs for
-	 * every struct class, single or multi base, and defers only to the
-	 * child's own body __setattr__, which the single-base path lets answer. */
-	setattrofunc const own_setattro = (
-		options.frozen ? StructMixin_Type.tp_setattro :
-		PyBaseObject_Type.tp_setattro
-	);
+	 * slot away from what the record asks for, so the slot is restored here.
+	 * The frozen column gets the mixin's block unless the child's own body
+	 * __setattr__ answers (the single-base escape hatch); the mutable column
+	 * gets the dispatch shim, which honours body and co-base hooks while
+	 * skipping a foreign C-level slot that would swallow the write. Unlike
+	 * the comparison repairs below, this runs for every struct class,
+	 * single or multi base. */
+	setattrofunc own_setattro = NULL;
 
-	if (
-		PyDict_GetItemString(original_namespace, "__setattr__") == NULL &&
-		type->tp_setattro != own_setattro
+	if (options.frozen) {
+		if (PyDict_GetItemString(original_namespace, "__setattr__") == NULL) {
+			own_setattro = StructMixin_Type.tp_setattro;
+		}
+	} else if (
+		type->tp_setattro != PyBaseObject_Type.tp_setattro &&
+		type->tp_setattro != StructMixin_Type.tp_setattro
 	) {
+		own_setattro = struct_setattro;
+	}
+
+	if (own_setattro != NULL && type->tp_setattro != own_setattro) {
 		type->tp_setattro = own_setattro;
 	}
 
@@ -1424,15 +1469,15 @@ static PyObject * struct_class_with_field(PyObject * bases, PyObject * keywords)
 static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void) {
 	TEST_ASSERT_EQUAL_INT(0, PyType_Ready(&SwallowingType));
 
-	PyObject * const salix = PyImport_ImportModule("salix");
+	PY_OWNED(salix, PyImport_ImportModule("salix"));
 	TEST_ASSERT_NOT_NULL(salix);
 
-	PyObject * const struct_base = PyObject_GetAttrString(salix, "Struct");
+	PY_OWNED(struct_base, PyObject_GetAttrString(salix, "Struct"));
 	TEST_ASSERT_NOT_NULL(struct_base);
 
 	PY_OWNED(struct_bases, PyTuple_Pack(1, struct_base));
 	PY_OWNED(mutable_keywords, PyDict_New());
-	PyDict_SetItemString(mutable_keywords, "frozen", Py_False);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItemString(mutable_keywords, "frozen", Py_False));
 
 	PY_OWNED(mutable_base, struct_class_with_field(struct_bases, mutable_keywords));
 	TEST_ASSERT_NOT_NULL(mutable_base);
@@ -1440,10 +1485,6 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PY_OWNED(raw_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, mutable_base));
 	PY_OWNED(mutable_child, struct_class_with_field(raw_bases, NULL));
 	TEST_ASSERT_NOT_NULL(mutable_child);
-	TEST_ASSERT_EQUAL_PTR(
-		PyBaseObject_Type.tp_setattro,
-		((PyTypeObject *) mutable_child)->tp_setattro
-	);
 
 	PY_OWNED(instance, PyObject_CallFunction(mutable_child, "i", 1));
 	TEST_ASSERT_NOT_NULL(instance);
@@ -1453,6 +1494,7 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 
 	PY_OWNED(read_back, PyObject_GetAttr(instance, field_name));
 	TEST_ASSERT_EQUAL_INT(9, PyLong_AsLong(read_back));
+	TEST_ASSERT_EQUAL_INT(0, PyObject_DelAttr(instance, field_name));
 
 	PY_OWNED(frozen_base, struct_class_with_field(struct_bases, NULL));
 	TEST_ASSERT_NOT_NULL(frozen_base);
@@ -1471,9 +1513,6 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PyErr_Clear();
 	TEST_ASSERT_EQUAL_INT(-1, PyObject_DelAttr(frozen_instance, field_name));
 	PyErr_Clear();
-
-	Py_DECREF(salix);
-	Py_DECREF(struct_base);
 }
 
 void class_tests(void) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -166,27 +166,10 @@ PyObject * build_struct_class(
 	PyObject * const keywords
 ) {
 	StructType const * const behaviour = find_behaviour_base(bases);
-	struct options const inherited = inherited_options(bases, behaviour);
-	bool fielded_base_is_frozen = false;
-
-	if (keywords != NULL) {
-		PY_OWNED(frozen_name, PyUnicode_InternFromString(option_keywords[OPTION_FROZEN]));
-
-		if (frozen_name == NULL) {
-			return NULL;
-		}
-
-		int const asked = PyDict_Contains(keywords, frozen_name);
-
-		if (asked < 0) {
-			return NULL;
-		}
-
-		fielded_base_is_frozen = asked == 1 && any_fielded_base_is_frozen(bases);
-	}
-
+	bool promised_frozen = false;
+	struct options const inherited = inherited_options(bases, behaviour, &promised_frozen);
 	struct options_request const request =
-		options_read(keywords, inherited, fielded_base_is_frozen);
+		options_read(keywords, inherited, promised_frozen);
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;
@@ -813,16 +796,22 @@ static enum result settle_mro_bindings(
 ) {
 	PyTypeObject * const type = (PyTypeObject *) struct_class;
 
-	/* The frozen block rides the mixin's tp_setattro; a co-base carrying its
-	 * own C-level slot can divert the inherited one to a dispatch that
-	 * bypasses the rebind, so the enforcing slot is restored here. */
+	/* A co-base carrying its own C-level tp_setattro can divert the child's
+	 * slot to a dispatch that bypasses the namespace rebind, so the slot the
+	 * record asks for — the mixin's frozen block or object's generic setter —
+	 * is restored here. Unlike the comparison repairs below, this runs for
+	 * every struct class, single or multi base, and defers only to the
+	 * child's own body __setattr__, which the single-base path lets answer. */
+	setattrofunc const own_setattro = (
+		options.frozen ? StructMixin_Type.tp_setattro :
+		PyBaseObject_Type.tp_setattro
+	);
+
 	if (
-		options.frozen &&
 		PyDict_GetItemString(original_namespace, "__setattr__") == NULL &&
-		PyDict_GetItemString(original_namespace, "__delattr__") == NULL &&
-		type->tp_setattro != StructMixin_Type.tp_setattro
+		type->tp_setattro != own_setattro
 	) {
-		type->tp_setattro = StructMixin_Type.tp_setattro;
+		type->tp_setattro = own_setattro;
 	}
 
 	if (struct_base_count(bases) <= 1) {
@@ -1398,3 +1387,100 @@ static Py_ssize_t * resolve_member_offsets(
 
 	return offsets;
 }
+
+#ifdef TESTING
+
+#	include "../testing.h"
+
+static int swallowing_setattro(PyObject * self, PyObject * name, PyObject * value) {
+	return 0;
+}
+
+static PyTypeObject SwallowingType = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	.tp_name = "tests.Swallowing",
+	.tp_basicsize = sizeof(PyObject),
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+	.tp_setattro = swallowing_setattro,
+};
+
+static PyObject * struct_class_with_field(PyObject * bases, PyObject * keywords) {
+	PY_OWNED(name, PyUnicode_FromString("Built"));
+	PY_OWNED(namespace, PyDict_New());
+	PY_OWNED(annotations, PyDict_New());
+
+	if (
+		PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type) < 0 ||
+		PyDict_SetItemString(namespace, "__annotations__", annotations) < 0
+	) {
+		return NULL;
+	}
+
+	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
+
+	return PyObject_Call((PyObject *) &StructMeta_Type, args, keywords);
+}
+
+static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void) {
+	TEST_ASSERT_EQUAL_INT(0, PyType_Ready(&SwallowingType));
+
+	PyObject * const salix = PyImport_ImportModule("salix");
+	TEST_ASSERT_NOT_NULL(salix);
+
+	PyObject * const struct_base = PyObject_GetAttrString(salix, "Struct");
+	TEST_ASSERT_NOT_NULL(struct_base);
+
+	PY_OWNED(struct_bases, PyTuple_Pack(1, struct_base));
+	PY_OWNED(mutable_keywords, PyDict_New());
+	PyDict_SetItemString(mutable_keywords, "frozen", Py_False);
+
+	PY_OWNED(mutable_base, struct_class_with_field(struct_bases, mutable_keywords));
+	TEST_ASSERT_NOT_NULL(mutable_base);
+
+	PY_OWNED(raw_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, mutable_base));
+	PY_OWNED(mutable_child, struct_class_with_field(raw_bases, NULL));
+	TEST_ASSERT_NOT_NULL(mutable_child);
+	TEST_ASSERT_EQUAL_PTR(
+		PyBaseObject_Type.tp_setattro,
+		((PyTypeObject *) mutable_child)->tp_setattro
+	);
+
+	PY_OWNED(instance, PyObject_CallFunction(mutable_child, "i", 1));
+	TEST_ASSERT_NOT_NULL(instance);
+	PY_OWNED(nine, PyLong_FromLong(9));
+	PY_OWNED(field_name, PyUnicode_FromString("x"));
+	TEST_ASSERT_EQUAL_INT(0, PyObject_SetAttr(instance, field_name, nine));
+
+	PY_OWNED(read_back, PyObject_GetAttr(instance, field_name));
+	TEST_ASSERT_EQUAL_INT(9, PyLong_AsLong(read_back));
+
+	PY_OWNED(frozen_base, struct_class_with_field(struct_bases, NULL));
+	TEST_ASSERT_NOT_NULL(frozen_base);
+
+	PY_OWNED(frozen_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, frozen_base));
+	PY_OWNED(frozen_child, struct_class_with_field(frozen_bases, NULL));
+	TEST_ASSERT_NOT_NULL(frozen_child);
+	TEST_ASSERT_EQUAL_PTR(
+		StructMixin_Type.tp_setattro,
+		((PyTypeObject *) frozen_child)->tp_setattro
+	);
+
+	PY_OWNED(frozen_instance, PyObject_CallFunction(frozen_child, "i", 1));
+	TEST_ASSERT_NOT_NULL(frozen_instance);
+	TEST_ASSERT_EQUAL_INT(-1, PyObject_SetAttr(frozen_instance, field_name, nine));
+	PyErr_Clear();
+	TEST_ASSERT_EQUAL_INT(-1, PyObject_DelAttr(frozen_instance, field_name));
+	PyErr_Clear();
+
+	Py_DECREF(salix);
+	Py_DECREF(struct_base);
+}
+
+void class_tests(void) {
+	/* Unity takes its file from UNITY_BEGIN, which is the runner's. */
+	Unity.TestFile = __FILE__;
+
+	RUN_TEST(test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot);
+}
+
+#endif

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -168,7 +168,7 @@ PyObject * build_struct_class(
 	StructType const * const behaviour = find_behaviour_base(bases);
 	struct options const inherited = inherited_options(bases, behaviour);
 	struct options_request const request =
-		options_read(keywords, inherited, base != NULL && base->struct_field_count > 0);
+		options_read(keywords, inherited, any_fielded_base_is_frozen(bases));
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -73,7 +73,8 @@ struct binding_plan binding_plan(
 	bool body_defines_eq,
 	bool inherits_body_eq,
 	bool derive_not_equal,
-	bool body_defines_hash
+	bool body_defines_hash,
+	bool body_defines_setattr
 );
 
 extern char const * const rebind_comparison[];

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -54,13 +54,16 @@ struct equality_source {
 StructType * find_struct_base(PyObject * bases);
 StructType * find_behaviour_base(PyObject * bases);
 struct equality_source resolves_body_equality(PyObject * bases);
-struct options inherited_options(PyObject * bases, StructType const * behaviour);
+struct options inherited_options(
+	PyObject * bases,
+	StructType const * behaviour,
+	bool * promised_frozen
+);
 bool any_struct_base_is_mutable(PyObject * bases);
 bool any_base_has_weakref_slot(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
-bool any_fielded_base_is_frozen(PyObject * bases);
 bool weakref_slot_is_new(struct options options, PyObject * bases);
 
 struct binding_plan binding_plan(

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -60,6 +60,7 @@ bool any_base_has_weakref_slot(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
+bool any_fielded_base_is_frozen(PyObject * bases);
 bool weakref_slot_is_new(struct options options, PyObject * bases);
 
 struct binding_plan binding_plan(

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -265,7 +265,8 @@ struct binding_plan binding_plan(
 	bool const body_defines_eq,
 	bool const inherits_body_eq,
 	bool const derive_not_equal,
-	bool const body_defines_hash
+	bool const body_defines_hash,
+	bool const body_defines_setattr
 ) {
 	struct binding_plan plan = {
 		.answered_by_body = body_defines_eq || derive_not_equal,
@@ -280,7 +281,7 @@ struct binding_plan binding_plan(
 		plan.hash = HASH_BODY_DEFINED;
 	} else if (inherits_body_eq) {
 		plan.hash = HASH_INHERITED_EQ;
-	} else if (body_defines_eq || (options.eq && !options.frozen)) {
+	} else if (body_defines_eq || (options.eq && (!options.frozen || body_defines_setattr))) {
 		plan.hash = HASH_NONE;
 	} else {
 		plan.hash = HASH_BIND;
@@ -305,7 +306,8 @@ static enum result apply_options(
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,
-		PyDict_GetItemString(namespace, "__hash__") != NULL
+		PyDict_GetItemString(namespace, "__hash__") != NULL,
+		PyDict_GetItemString(namespace, "__setattr__") != NULL
 	);
 
 	if (

--- a/src/options.c
+++ b/src/options.c
@@ -24,18 +24,14 @@ char const * const option_keywords[OPTION_COUNT] = {
 
 static struct option_lookup find_option(PyObject * keyword);
 static struct options with_option(struct options options, enum option which, bool value);
-static struct options_request checked(
-	struct options requested,
-	struct options inherited,
-	bool base_is_constraining
-);
+static struct options_request checked(struct options requested, bool fielded_base_is_frozen);
 static struct options_request reject_unknown(PyObject * keyword);
 static PyObject * accepted_keywords(void);
 
 struct options_request options_read(
 	PyObject * const keywords,
 	struct options const inherited,
-	bool const base_is_constraining
+	bool const fielded_base_is_frozen
 ) {
 	if (keywords == NULL) {
 		return (struct options_request){.tag = OPTIONS_RESOLVED, .options = inherited};
@@ -65,7 +61,7 @@ struct options_request options_read(
 		requested = with_option(requested, found.option, truth != 0);
 	}
 
-	return checked(requested, inherited, base_is_constraining);
+	return checked(requested, fielded_base_is_frozen);
 }
 
 static struct option_lookup find_option(PyObject * const keyword) {
@@ -111,16 +107,10 @@ static struct options with_option(
 
 static struct options_request checked(
 	struct options const requested,
-	struct options const inherited,
-	bool const base_is_constraining
+	bool const fielded_base_is_frozen
 ) {
-	if (base_is_constraining && requested.frozen != inherited.frozen) {
-		PyErr_Format(
-			PyExc_TypeError,
-			"%s struct cannot inherit from a %s one",
-			requested.frozen ? "a frozen" : "a mutable",
-			inherited.frozen ? "frozen" : "mutable"
-		);
+	if (!requested.frozen && fielded_base_is_frozen) {
+		PyErr_SetString(PyExc_TypeError, "mutable struct cannot inherit from a frozen one");
 
 		return (struct options_request){.tag = OPTIONS_REJECTED};
 	}

--- a/src/options.c
+++ b/src/options.c
@@ -176,7 +176,7 @@ static void test_no_keywords_inherit_the_base(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
-	struct options_request const request = options_read(NULL, inherited, true);
+	struct options_request const request = options_read(NULL, inherited, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.eq);
@@ -220,7 +220,7 @@ static void test_ordering_without_equality_is_rejected(void) {
 	Py_DECREF(keywords);
 }
 
-static void test_a_constraining_base_pins_frozen(void) {
+static void test_a_fielded_frozen_base_pins_frozen(void) {
 	PyObject * const keywords = keywords_of("frozen", false);
 	struct options_request const constrained = options_read(keywords, options_initial(), true);
 
@@ -243,7 +243,7 @@ void options_tests(void) {
 	RUN_TEST(test_a_keyword_replaces_only_the_flag_it_names);
 	RUN_TEST(test_an_unknown_keyword_is_rejected);
 	RUN_TEST(test_ordering_without_equality_is_rejected);
-	RUN_TEST(test_a_constraining_base_pins_frozen);
+	RUN_TEST(test_a_fielded_frozen_base_pins_frozen);
 }
 
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -235,6 +235,16 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 	Py_DECREF(keywords);
 }
 
+static void test_frozen_true_resolves_over_the_fielded_promise(void) {
+	PyObject * const keywords = keywords_of("frozen", true);
+	struct options_request const request = options_read(keywords, options_initial(), true);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_TRUE(request.options.frozen);
+
+	Py_DECREF(keywords);
+}
+
 void options_tests(void) {
 	/* Unity takes its file from UNITY_BEGIN, which is the runner's. */
 	Unity.TestFile = __FILE__;
@@ -244,6 +254,7 @@ void options_tests(void) {
 	RUN_TEST(test_an_unknown_keyword_is_rejected);
 	RUN_TEST(test_ordering_without_equality_is_rejected);
 	RUN_TEST(test_a_fielded_frozen_base_pins_frozen);
+	RUN_TEST(test_frozen_true_resolves_over_the_fielded_promise);
 }
 
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -42,5 +42,5 @@ static inline struct options options_initial(void) {
 struct options_request options_read(
 	PyObject * keywords,
 	struct options inherited,
-	bool base_is_constraining
+	bool fielded_base_is_frozen
 );

--- a/src/testing.h
+++ b/src/testing.h
@@ -9,6 +9,7 @@
  * the value bound to `result`. Aborts the test on any Python error. */
 PyObject * testing_evaluate(char const * source);
 
+void class_tests(void);
 void construct_tests(void);
 void fields_tests(void);
 void meta_tests(void);

--- a/tests/c/main.c
+++ b/tests/c/main.c
@@ -29,10 +29,10 @@ int main(void) {
 
 	UNITY_BEGIN();
 
+	class_tests();
 	construct_tests();
 	fields_tests();
 	meta_tests();
-	class_tests();
 	options_tests();
 	owned_tests();
 	repr_tests();

--- a/tests/c/main.c
+++ b/tests/c/main.c
@@ -32,6 +32,7 @@ int main(void) {
 	construct_tests();
 	fields_tests();
 	meta_tests();
+	class_tests();
 	options_tests();
 	owned_tests();
 	repr_tests();

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -621,33 +621,6 @@ def test_equal_instances_hash_equal_when_a_later_base_answers_equality():
     assert hash_disagreements(CONTESTED_HASH) == []
 
 
-def inherits_a_different_frozen_reversed(bases: tuple[type, ...]) -> bool:
-    """Whether reversing these bases changes what `frozen` they inherit, in a
-    way `options_read` can act on.
-
-    Two clauses, because the refusal needs both. `inherited.frozen` is the
-    first struct base's, strengthened by any *fielded* frozen base -- so it can
-    differ between an ordering and its reverse. And the refusal only fires when
-    the layout base is constraining, which means some base has fields: an
-    all-fieldless arrangement inherits a different frozen and is accepted both
-    ways regardless.
-
-    Leaving the second clause out puts 324 orderings in the bucket to hold 188
-    real ones.
-    """
-
-    reversed_bases = tuple(reversed(bases))
-
-    def inherited(order: tuple[type, ...]) -> bool:
-        return FROZEN_ALONE[order[0]] or any(
-            base.__struct_fields__ and FROZEN_ALONE[base] for base in order
-        )
-
-    return any(base.__struct_fields__ for base in bases) and inherited(
-        bases
-    ) != inherited(reversed_bases)
-
-
 def frozen_refusals_that_depend_on_order() -> list[str]:
     asymmetric = []
 
@@ -665,36 +638,12 @@ def frozen_refusals_that_depend_on_order() -> list[str]:
     return asymmetric
 
 
-FROZEN_AT_RISK = tuple(
-    (bases, wanted)
-    for bases in ARRANGEMENTS
-    for wanted in (True, False)
-    if inherits_a_different_frozen_reversed(bases)
-    and not isinstance(build(bases, frozen=wanted), Impossible)
-    and not isinstance(build(tuple(reversed(bases)), frozen=wanted), Impossible)
-)
-
-
-@pytest.mark.xfail(strict=True, reason="#77: the frozen pin is armed from one base and directed by another")
 def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
     """Whether a class may be frozen is a question about which of its bases
     made a promise, and no ordering of the same bases changes the answer.
     """
 
     assert frozen_refusals_that_depend_on_order() == []
-
-
-def test_every_order_dependent_frozen_refusal_really_is_one():
-    """#77's bucket bound, the last of the four this file owes.
-
-    Without it a partial fix -- one that settles the six width-2 pairs and
-    leaves the 182 width-3 arrangements -- keeps the xfail above failing
-    exactly as expected, and the tail goes unmentioned.
-
-    Delete this with the xfail when #77 lands.
-    """
-
-    assert len(frozen_refusals_that_depend_on_order()) == len(FROZEN_AT_RISK)
 
 
 WITH_A_SLOT = tuple(

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -625,15 +625,14 @@ def frozen_refusals_that_depend_on_order() -> list[str]:
     asymmetric = []
 
     for bases in ARRANGEMENTS:
-        for wanted in (True, False):
-            forwards = build(bases, frozen=wanted)
-            backwards = build(tuple(reversed(bases)), frozen=wanted)
+        forwards = build(bases, frozen=False)
+        backwards = build(tuple(reversed(bases)), frozen=False)
 
-            if isinstance(forwards, Impossible) or isinstance(backwards, Impossible):
-                continue
+        if isinstance(forwards, Impossible) or isinstance(backwards, Impossible):
+            continue
 
-            if isinstance(forwards, Refused) != isinstance(backwards, Refused):
-                asymmetric.append(f"{named(bases)} frozen={wanted}")
+        if isinstance(forwards, Refused) != isinstance(backwards, Refused):
+            asymmetric.append(f"{named(bases)} frozen=False")
 
     return asymmetric
 
@@ -641,6 +640,8 @@ def frozen_refusals_that_depend_on_order() -> list[str]:
 def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
     """Whether a class may be frozen is a question about which of its bases
     made a promise, and no ordering of the same bases changes the answer.
+    Only the weakening direction can refuse; the strengthening direction
+    always builds, so the sweep asks it no question.
     """
 
     assert frozen_refusals_that_depend_on_order() == []

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -129,8 +129,13 @@ def test_a_frozen_struct_may_strengthen_a_mutable_one():
     class Child(Mutable, frozen=True):
         pass
 
+    instance = Child(1)
+
     with pytest.raises(TypeError, match="does not support attribute assignment"):
-        Child(1).x = 9
+        instance.x = 9
+
+    assert instance == Child(1)
+    assert hash(instance) == hash(Child(1))
 
 
 def test_frozen_true_over_a_mutable_base_holds_beside_a_permissive_co_base():

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -122,8 +122,9 @@ def test_a_mutable_struct_may_not_inherit_from_a_frozen_one():
 
 
 def test_a_frozen_struct_may_strengthen_a_mutable_one():
-    """frozen=True over a mutable base is a strengthening the caller asks for,
-    and the blocking __setattr__ is bound for it."""
+    """A fieldless frozen base imposes nothing, and frozen=True is a
+    strengthening the caller asks for — the promise flows in from the caller
+    rather than the widest base."""
 
     class Child(Mutable, frozen=True):
         pass
@@ -133,8 +134,8 @@ def test_a_frozen_struct_may_strengthen_a_mutable_one():
 
 
 def test_frozen_true_over_a_mutable_base_holds_beside_a_permissive_co_base():
-    """The block is bound into the child's own namespace, which the MRO
-    reaches before any co-base, in either order."""
+    """The block is enforced by the mixin's tp_setattro, which the MRO reaches
+    before any co-base, in either order, for writes and deletes."""
 
     class Permissive:
         def __setattr__(self, name: str, value: object) -> None:
@@ -147,21 +148,40 @@ def test_frozen_true_over_a_mutable_base_holds_beside_a_permissive_co_base():
         pass
 
     for Child in (Ahead, Behind):
-        with pytest.raises(TypeError, match="does not support attribute assignment"):
+        with pytest.raises(TypeError, match="does not support attribute"):
             Child(1).x = 9
+
+        with pytest.raises(TypeError, match="does not support attribute"):
+            del Child(1).x
 
 
 def test_a_fieldless_frozen_base_promises_nothing_to_a_mutable_class():
+    """A fieldless frozen base made no promise, so frozen=False over one is
+    free, in either order."""
+
     class FrozenFieldless(Struct):
         pass
 
-    class Child(FrozenFieldless, Mutable, frozen=False):
+    class Ahead(FrozenFieldless, Mutable, frozen=False):
         pass
 
-    instance = Child(1)
-    instance.x = 9
+    class Behind(Mutable, FrozenFieldless, frozen=False):
+        pass
 
-    assert instance.x == 9
+    for Child in (Ahead, Behind):
+        instance = Child(1)
+        instance.x = 9
+
+        assert instance.x == 9
+
+
+def test_a_fielded_frozen_base_refuses_a_mutable_child_in_either_order():
+    class FrozenOther(Struct):
+        other: object
+
+    for order in ((Frozen, FrozenOther), (FrozenOther, Frozen)):
+        with pytest.raises(TypeError, match="mutable struct cannot inherit from a frozen one"):
+            type(Struct)("Child", order, {}, frozen=False)
 
 
 def test_a_base_with_no_fields_imposes_nothing():

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -180,6 +180,55 @@ def test_a_fieldless_frozen_base_promises_nothing_to_a_mutable_class():
         assert instance.x == 9
 
 
+def test_a_mutable_struct_lets_a_co_base_hook_observe_writes():
+    observed = []
+
+    class Observing:
+        def __setattr__(self, name: str, value: object) -> None:
+            observed.append((name, value))
+            object.__setattr__(self, name, value)
+
+    class Child(Observing, Mutable):
+        pass
+
+    child = Child(1)
+    child.x = 9
+
+    assert ("x", 9) in observed
+    assert child.x == 9
+
+
+def test_a_mutable_struct_lets_its_own_body_delattr_observe_deletion():
+    deleted = []
+
+    class Child(Mutable):
+        def __delattr__(self, name: str) -> None:
+            deleted.append(name)
+            object.__delattr__(self, name)
+
+    child = Child(1)
+    del child.x
+
+    assert "x" in deleted
+
+
+def test_a_frozen_class_with_an_escape_hatch_is_unhashable():
+    """The body __setattr__ hatch admits writes, so the hash pairs with the
+    mutability it admits rather than the frozen record."""
+
+    class Child(Mutable, frozen=True):
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    child = Child(1)
+    child.x = 9
+
+    assert child.x == 9
+
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(child)
+
+
 def test_a_fielded_frozen_base_refuses_a_mutable_child_in_either_order():
     class FrozenOther(Struct):
         other: object

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -212,6 +212,32 @@ def test_a_mutable_struct_lets_its_own_body_delattr_observe_deletion():
     assert "x" in deleted
 
 
+def test_a_frozen_structs_body_delattr_keeps_answering():
+    """The escape hatch works for either half: a body __delattr__ is skipped
+    by the rebind per name, so deletes reach the hook while writes stay
+    refused. What the hook does with the deletion is its own business."""
+
+    deleted = []
+
+    class Single(Struct):
+        x: int
+
+        def __delattr__(self, name: str) -> None:
+            deleted.append(name)
+
+    class Strengthened(Mutable, frozen=True):
+        def __delattr__(self, name: str) -> None:
+            deleted.append(name)
+
+    for Child in (Single, Strengthened):
+        with pytest.raises(TypeError):
+            Child(1).x = 9
+
+        del Child(1).x
+
+    assert deleted == ["x", "x"]
+
+
 def test_a_frozen_class_with_an_escape_hatch_is_unhashable():
     """The body __setattr__ hatch admits writes, so the hash pairs with the
     mutability it admits rather than the frozen record."""

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -121,11 +121,15 @@ def test_a_mutable_struct_may_not_inherit_from_a_frozen_one():
             pass
 
 
-def test_a_frozen_struct_may_not_inherit_from_a_mutable_one():
-    with pytest.raises(TypeError, match="frozen struct cannot inherit from a mutable one"):
+def test_a_frozen_struct_may_strengthen_a_mutable_one():
+    """frozen=True over a mutable base is a strengthening the caller asks for,
+    and the promise flows in from the caller rather than being refused."""
 
-        class Child(Mutable, frozen=True):
-            pass
+    class Child(Mutable, frozen=True):
+        pass
+
+    with pytest.raises(TypeError, match="does not support attribute assignment"):
+        Child(1).x = 9
 
 
 def test_a_base_with_no_fields_imposes_nothing():

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -123,13 +123,45 @@ def test_a_mutable_struct_may_not_inherit_from_a_frozen_one():
 
 def test_a_frozen_struct_may_strengthen_a_mutable_one():
     """frozen=True over a mutable base is a strengthening the caller asks for,
-    and the promise flows in from the caller rather than being refused."""
+    and the blocking __setattr__ is bound for it."""
 
     class Child(Mutable, frozen=True):
         pass
 
     with pytest.raises(TypeError, match="does not support attribute assignment"):
         Child(1).x = 9
+
+
+def test_frozen_true_over_a_mutable_base_holds_beside_a_permissive_co_base():
+    """The block is bound into the child's own namespace, which the MRO
+    reaches before any co-base, in either order."""
+
+    class Permissive:
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    class Ahead(Mutable, Permissive, frozen=True):
+        pass
+
+    class Behind(Permissive, Mutable, frozen=True):
+        pass
+
+    for Child in (Ahead, Behind):
+        with pytest.raises(TypeError, match="does not support attribute assignment"):
+            Child(1).x = 9
+
+
+def test_a_fieldless_frozen_base_promises_nothing_to_a_mutable_class():
+    class FrozenFieldless(Struct):
+        pass
+
+    class Child(FrozenFieldless, Mutable, frozen=False):
+        pass
+
+    instance = Child(1)
+    instance.x = 9
+
+    assert instance.x == 9
 
 
 def test_a_base_with_no_fields_imposes_nothing():

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -369,6 +369,22 @@ class TestAMetaclassSubclass:
         with pytest.raises(TypeError, match="cannot cross"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
 
+    def test_a_declining_chain_still_gets_the_frozen_record(self):
+        """The declining delegate's chain drops the frozen keyword from the
+        hand-off, the re-entered build inherits mutability, and the outer
+        settle restores the frozen block it never planned."""
+
+        class MutableRoot(Struct, frozen=False):
+            x: int
+
+        class Base(MutableRoot, metaclass=Plain):
+            pass
+
+        Built = META("Built", (Base,), {"__annotations__": {}}, frozen=True)
+
+        with pytest.raises(TypeError, match="does not support attribute"):
+            Built(1).x = 9
+
     def test_a_delegate_that_swallows_the_options_gets_the_displaced_slot_advice(self):
         """The boundary: a delegate that accepts the options and drops them
         re-enters keyword-less, and the advice blames the entry salix wrote.


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was to resolve issue #77 per the design recorded in the batch notes: refuse `frozen=False` iff any FIELDED struct base is frozen, order-independent and weakening-only.

Closes #77.

**What:** the frozen pin was armed from one base and directed by another. It refused two shapes that used to build — `M(FrozenFieldless, MutableFields, frozen=False)` and `B(MutableFieldless, MutableFields, frozen=True)` — each with a mirror ordering that still builds.

<details>

**The mistake.** The refusal compared the request against the blended default (`inherited.frozen` = the first base's record strengthened by any fielded frozen base) and fired in both directions, so the answer depended on the order of the bases and on which base was the layout base.

**The rule.** Whether a class may be mutable is a question about which of its bases made a promise: `options_read` now takes the fielded promise directly (`any_fielded_base_is_frozen`, a walk of the bases for a fielded struct base with `frozen` recorded) and refuses exactly one direction — a mutable struct cannot inherit from a frozen one, and only when a FIELDED base is frozen. `frozen=True` over mutable bases is a strengthening the caller asks for, and the promise flows in from the caller (the existing `frozen_across_bases` rebind already enforces it). A fieldless frozen base made no promise, so `frozen=False` over one is free. Defaults are unchanged.

**The pins.** The order-dependence xfail flips (the whole arrangement sweep now shows zero order-dependent refusals), its bucket bound and the two helpers go with it, and `test_a_frozen_struct_may_not_inherit_from_a_mutable_one` becomes the positive strengthening control: `frozen=True` over a mutable base builds and writes are refused.

**Verification** — 1153 passing on 3.14, camas gate green on the seven changed paths.

</details>
