### PR TITLE
fix: the weakref option follows the slot truth — the explicit drop refuses, the record is forced

### DIFF
--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -270,10 +270,6 @@ bool weakref_expected(struct options const options, PyObject * const bases) {
 	return options.weakref || any_base_satisfies(bases, carries_weakref_slot);
 }
 
-bool weakref_slot_is_new(struct options const options, PyObject * const bases) {
-	return options.weakref && !any_base_satisfies(bases, carries_weakref_slot);
-}
-
 bool any_base_has_instance_dict(PyObject * const bases) {
 	return any_base_satisfies(bases, carries_instance_dict);
 }

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -1521,6 +1521,7 @@ static void test_a_later_bases_slot_forces_the_record(void) {
 	TEST_ASSERT_NOT_NULL(mixed_child);
 
 	TEST_ASSERT_TRUE(((StructType *) mixed_child)->struct_options.weakref);
+	TEST_ASSERT_TRUE(carries_weakref_slot((PyTypeObject *) mixed_child));
 }
 
 void class_tests(void) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -176,6 +176,7 @@ PyObject * build_struct_class(
 		return NULL;
 	}
 
+	bool const weakref_requested = request.options.weakref;
 	request.options.weakref |= weakref_carried;
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
@@ -196,7 +197,7 @@ PyObject * build_struct_class(
 			return NULL;
 		}
 
-		verdict = chain_probe(chain, keywords, request.options.weakref);
+		verdict = chain_probe(chain, keywords, weakref_requested);
 
 		if (verdict.accepts_all < 0) {
 			return NULL;
@@ -204,7 +205,7 @@ PyObject * build_struct_class(
 
 		if (verdict.accepts_all == 1) {
 			forwarded_keywords = keywords;
-		} else if (request.options.weakref && verdict.accepts_weakref == 1) {
+		} else if (weakref_requested && verdict.accepts_weakref == 1) {
 			weakref_only = PyDict_New();
 
 			if (
@@ -1480,7 +1481,16 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 static PyObject * struct_class_empty(PyObject * bases, PyObject * keywords) {
 	PY_OWNED(name, PyUnicode_FromString("Built"));
 	PY_OWNED(namespace, PyDict_New());
+
+	if (name == NULL || namespace == NULL) {
+		return NULL;
+	}
+
 	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
+
+	if (args == NULL) {
+		return NULL;
+	}
 
 	return PyObject_Call((PyObject *) &StructMeta_Type, args, keywords);
 }
@@ -1493,6 +1503,8 @@ static void test_a_later_bases_slot_forces_the_record(void) {
 	TEST_ASSERT_NOT_NULL(struct_base);
 
 	PY_OWNED(struct_bases, PyTuple_Pack(1, struct_base));
+	TEST_ASSERT_NOT_NULL(struct_bases);
+
 	PY_OWNED(weak_keywords, PyDict_New());
 	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItemString(weak_keywords, "weakref", Py_True));
 
@@ -1503,6 +1515,8 @@ static void test_a_later_bases_slot_forces_the_record(void) {
 	TEST_ASSERT_NOT_NULL(plain_base);
 
 	PY_OWNED(mixed_bases, PyTuple_Pack(2, plain_base, weak_base));
+	TEST_ASSERT_NOT_NULL(mixed_bases);
+
 	PY_OWNED(mixed_child, struct_class_empty(mixed_bases, NULL));
 	TEST_ASSERT_NOT_NULL(mixed_child);
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -168,12 +168,14 @@ PyObject * build_struct_class(
 	StructType const * const behaviour = find_behaviour_base(bases);
 	bool promised_frozen = false;
 	struct options const inherited = inherited_options(bases, behaviour, &promised_frozen);
-	struct options_request const request =
-		options_read(keywords, inherited, promised_frozen);
+	struct options_request request =
+		options_read(keywords, inherited, promised_frozen, any_base_has_weakref_slot(bases));
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;
 	}
+
+	request.options.weakref |= any_base_has_weakref_slot(bases);
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -167,15 +167,16 @@ PyObject * build_struct_class(
 ) {
 	StructType const * const behaviour = find_behaviour_base(bases);
 	bool promised_frozen = false;
+	bool const weakref_carried = any_base_has_weakref_slot(bases);
 	struct options const inherited = inherited_options(bases, behaviour, &promised_frozen);
 	struct options_request request =
-		options_read(keywords, inherited, promised_frozen, any_base_has_weakref_slot(bases));
+		options_read(keywords, inherited, promised_frozen, weakref_carried);
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;
 	}
 
-	request.options.weakref |= any_base_has_weakref_slot(bases);
+	request.options.weakref |= weakref_carried;
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;
@@ -218,7 +219,8 @@ PyObject * build_struct_class(
 	}
 
 	if (
-		weakref_slot_is_new(request.options, bases) &&
+		request.options.weakref &&
+		!weakref_carried &&
 		handoff->tp_new != StructMeta_new &&
 		verdict.accepts_weakref == 0
 	) {
@@ -1475,11 +1477,44 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	TEST_ASSERT_EQUAL_INT(2, swallow_calls);
 }
 
+static PyObject * struct_class_empty(PyObject * bases, PyObject * keywords) {
+	PY_OWNED(name, PyUnicode_FromString("Built"));
+	PY_OWNED(namespace, PyDict_New());
+	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
+
+	return PyObject_Call((PyObject *) &StructMeta_Type, args, keywords);
+}
+
+static void test_a_later_bases_slot_forces_the_record(void) {
+	PY_OWNED(salix, PyImport_ImportModule("salix"));
+	TEST_ASSERT_NOT_NULL(salix);
+
+	PY_OWNED(struct_base, PyObject_GetAttrString(salix, "Struct"));
+	TEST_ASSERT_NOT_NULL(struct_base);
+
+	PY_OWNED(struct_bases, PyTuple_Pack(1, struct_base));
+	PY_OWNED(weak_keywords, PyDict_New());
+	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItemString(weak_keywords, "weakref", Py_True));
+
+	PY_OWNED(weak_base, struct_class_empty(struct_bases, weak_keywords));
+	TEST_ASSERT_NOT_NULL(weak_base);
+
+	PY_OWNED(plain_base, struct_class_with_field(struct_bases, NULL));
+	TEST_ASSERT_NOT_NULL(plain_base);
+
+	PY_OWNED(mixed_bases, PyTuple_Pack(2, plain_base, weak_base));
+	PY_OWNED(mixed_child, struct_class_empty(mixed_bases, NULL));
+	TEST_ASSERT_NOT_NULL(mixed_child);
+
+	TEST_ASSERT_TRUE(((StructType *) mixed_child)->struct_options.weakref);
+}
+
 void class_tests(void) {
 	/* Unity takes its file from UNITY_BEGIN, which is the runner's. */
 	Unity.TestFile = __FILE__;
 
 	RUN_TEST(test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot);
+	RUN_TEST(test_a_later_bases_slot_forces_the_record);
 }
 
 #endif

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -64,7 +64,6 @@ bool any_base_has_weakref_slot(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
-bool weakref_slot_is_new(struct options options, PyObject * bases);
 
 struct binding_plan binding_plan(
 	struct options options,

--- a/src/options.c
+++ b/src/options.c
@@ -31,13 +31,15 @@ static PyObject * accepted_keywords(void);
 struct options_request options_read(
 	PyObject * const keywords,
 	struct options const inherited,
-	bool const fielded_base_is_frozen
+	bool const fielded_base_is_frozen,
+	bool const weakref_slot_carried
 ) {
 	if (keywords == NULL) {
 		return (struct options_request){.tag = OPTIONS_RESOLVED, .options = inherited};
 	}
 
 	struct options requested = inherited;
+	bool weakref_written = false;
 	PyObject * keyword;
 	PyObject * value;
 	Py_ssize_t position = 0;
@@ -58,7 +60,14 @@ struct options_request options_read(
 			return (struct options_request){.tag = OPTIONS_REJECTED};
 		}
 
+		weakref_written |= found.option == OPTION_WEAKREF;
 		requested = with_option(requested, found.option, truth != 0);
+	}
+
+	if (weakref_written && !requested.weakref && weakref_slot_carried) {
+		PyErr_SetString(PyExc_TypeError, "weakref=False cannot drop a weakref slot a base carries");
+
+		return (struct options_request){.tag = OPTIONS_REJECTED};
 	}
 
 	return checked(requested, fielded_base_is_frozen);
@@ -176,7 +185,7 @@ static void test_no_keywords_inherit_the_base(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
-	struct options_request const request = options_read(NULL, inherited, false);
+	struct options_request const request = options_read(NULL, inherited, false, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.eq);
@@ -185,7 +194,7 @@ static void test_no_keywords_inherit_the_base(void) {
 
 static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 	PyObject * const keywords = keywords_of("order", true);
-	struct options_request const request = options_read(keywords, options_initial(), false);
+	struct options_request const request = options_read(keywords, options_initial(), false, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.order);
@@ -197,7 +206,7 @@ static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 
 static void test_an_unknown_keyword_is_rejected(void) {
 	PyObject * const keywords = keywords_of("frozn", true);
-	struct options_request const request = options_read(keywords, options_initial(), false);
+	struct options_request const request = options_read(keywords, options_initial(), false, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
 	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
@@ -211,7 +220,7 @@ static void test_ordering_without_equality_is_rejected(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
-	struct options_request const request = options_read(keywords, inherited, false);
+	struct options_request const request = options_read(keywords, inherited, false, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
 	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
@@ -222,12 +231,17 @@ static void test_ordering_without_equality_is_rejected(void) {
 
 static void test_a_fielded_frozen_base_pins_frozen(void) {
 	PyObject * const keywords = keywords_of("frozen", false);
-	struct options_request const constrained = options_read(keywords, options_initial(), true);
+	struct options_request const constrained = options_read(
+		keywords,
+		options_initial(),
+		true,
+		false
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, constrained.tag);
 	PyErr_Clear();
 
-	struct options_request const free = options_read(keywords, options_initial(), false);
+	struct options_request const free = options_read(keywords, options_initial(), false, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, free.tag);
 	TEST_ASSERT_FALSE(free.options.frozen);
@@ -235,9 +249,19 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 	Py_DECREF(keywords);
 }
 
+static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
+	PyObject * const keywords = keywords_of("weakref", false);
+	struct options_request const refused = options_read(keywords, options_initial(), false, true);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, refused.tag);
+	PyErr_Clear();
+
+	Py_DECREF(keywords);
+}
+
 static void test_frozen_true_resolves_over_the_fielded_promise(void) {
 	PyObject * const keywords = keywords_of("frozen", true);
-	struct options_request const request = options_read(keywords, options_initial(), true);
+	struct options_request const request = options_read(keywords, options_initial(), true, false);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.frozen);
@@ -254,6 +278,7 @@ void options_tests(void) {
 	RUN_TEST(test_an_unknown_keyword_is_rejected);
 	RUN_TEST(test_ordering_without_equality_is_rejected);
 	RUN_TEST(test_a_fielded_frozen_base_pins_frozen);
+	RUN_TEST(test_a_carried_weakref_slot_refuses_the_explicit_drop);
 	RUN_TEST(test_frozen_true_resolves_over_the_fielded_promise);
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -260,6 +260,7 @@ static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 	struct options_request const refused = options_read(keywords, options_initial(), false, true);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, refused.tag);
+	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
 	PyErr_Clear();
 
 	Py_DECREF(keywords);

--- a/src/options.c
+++ b/src/options.c
@@ -64,13 +64,19 @@ struct options_request options_read(
 		requested = with_option(requested, found.option, truth != 0);
 	}
 
+	struct options_request const checked_request = checked(requested, fielded_base_is_frozen);
+
+	if (checked_request.tag == OPTIONS_REJECTED) {
+		return checked_request;
+	}
+
 	if (weakref_written && !requested.weakref && weakref_slot_carried) {
 		PyErr_SetString(PyExc_TypeError, "weakref=False cannot drop a weakref slot a base carries");
 
 		return (struct options_request){.tag = OPTIONS_REJECTED};
 	}
 
-	return checked(requested, fielded_base_is_frozen);
+	return checked_request;
 }
 
 static struct option_lookup find_option(PyObject * const keyword) {

--- a/src/options.c
+++ b/src/options.c
@@ -266,6 +266,16 @@ static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 	Py_DECREF(keywords);
 }
 
+static void test_weakref_false_without_a_carried_slot_still_resolves(void) {
+	PyObject * const keywords = keywords_of("weakref", false);
+	struct options_request const request = options_read(keywords, options_initial(), false, false);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_FALSE(request.options.weakref);
+
+	Py_DECREF(keywords);
+}
+
 static void test_frozen_true_resolves_over_the_fielded_promise(void) {
 	PyObject * const keywords = keywords_of("frozen", true);
 	struct options_request const request = options_read(keywords, options_initial(), true, false);
@@ -286,6 +296,7 @@ void options_tests(void) {
 	RUN_TEST(test_ordering_without_equality_is_rejected);
 	RUN_TEST(test_a_fielded_frozen_base_pins_frozen);
 	RUN_TEST(test_a_carried_weakref_slot_refuses_the_explicit_drop);
+	RUN_TEST(test_weakref_false_without_a_carried_slot_still_resolves);
 	RUN_TEST(test_frozen_true_resolves_over_the_fielded_promise);
 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -42,5 +42,6 @@ static inline struct options options_initial(void) {
 struct options_request options_read(
 	PyObject * keywords,
 	struct options inherited,
-	bool fielded_base_is_frozen
+	bool fielded_base_is_frozen,
+	bool weakref_slot_carried
 );

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -668,7 +668,6 @@ def weakref_requests_ignored(combinations: tuple[Combination, ...]) -> list[str]
     return ignored
 
 
-@pytest.mark.xfail(strict=True, reason="#78: weakref is recorded from one base and slotted from another")
 def test_the_weakref_option_and_the_slot_agree():
     """CPython cannot take an inherited `__weakref__` away, so `weakref=False`
     over a base that has one is a request salix cannot honour -- and accepting
@@ -683,22 +682,6 @@ def test_the_weakref_option_and_the_slot_agree():
     assert weakref_requests_ignored(WITH_A_SLOT) == []
 
 
-def test_every_class_carrying_an_inherited_slot_really_does_ignore_the_request():
-    """The bound that gives the xfail above a size, for the same reason the
-    #76 buckets have one: an aggregate `== []` over a bucket where everything
-    already fails flips only on a *complete* fix.
-
-    Without this, a partial fix for #78 -- one that refuses `weakref=False` for
-    some arrangements and not others -- shrinks the violation list while the
-    xfail stays failed-as-expected, and so stays green. A refusal makes
-    `is_a_class` false and drops the combination silently; here that shows up
-    as the count no longer matching the bucket.
-    """
-
-    assert len(weakref_requests_ignored(WITH_A_SLOT)) == len(WITH_A_SLOT)
-
-
-@pytest.mark.xfail(strict=True, reason="#78: weakref is recorded from one base and slotted from another")
 def test_a_single_base_asking_to_drop_an_inherited_weakref_slot_is_the_same_bug():
     """#78's smallest form, stated on its own so that it is covered whether or
     not the sweep above still reaches it. The slot is inherited and cannot be
@@ -708,9 +691,5 @@ def test_a_single_base_asking_to_drop_an_inherited_weakref_slot_is_the_same_bug(
 
     without = build((Weak,), field="fresh", weakref=False)
 
-    assert not isinstance(without, Impossible)
-
-    if isinstance(without, Refused):
-        assert "weakref" in without.message
-    else:
-        assert observe(without).weakref is False
+    assert isinstance(without, Refused)
+    assert "weakref" in without.message

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -679,13 +679,11 @@ def weakref_requests_ignored(combinations: tuple[Combination, ...]) -> list[str]
 
 def test_the_weakref_option_and_the_slot_agree():
     """CPython cannot take an inherited `__weakref__` away, so `weakref=False`
-    over a base that has one is a request salix cannot honour -- and accepting
-    it silently leaves the class recording one answer and giving another.
+    over a base that has one is a request salix cannot honour: every member of
+    this bucket must refuse rather than accept and drop the request.
 
-    `Weak` alone is in here beside the arrangements because the single base is
-    the smallest form of it: `class C(Weak, weakref=False)` builds today and
-    the reference still works. A fix aimed only at the multi-base reading would
-    turn every other case here red and leave that one passing unexercised.
+    `Weak` alone sits beside the arrangements as the refusal's smallest form,
+    pinned on its own by the test below.
     """
 
     assert weakref_requests_ignored(WITH_A_SLOT) == []

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -345,10 +345,11 @@ def test_a_class_is_weak_referenceable_only_where_its_bases_make_it_so():
 
     The "no less" half is CPython's and not worth claiming: an inherited
     `__weakref__` cannot be dropped, and a class that tried would be refused at
-    build time and caught by the size pin. What is salix's, and what this
-    catches, is the *other* direction -- a class becoming weak-referenceable
-    when nothing gave it a slot, whether by `build_slots` appending one over a
-    base that already has it or by a struct class growing a `__dict__`.
+    build time -- pinned by the single-base test below. What is salix's, and
+    what this catches, is the *other* direction -- a class becoming
+    weak-referenceable when nothing gave it a slot, whether by `build_slots`
+    appending one over a base that already has it or by a struct class growing
+    a `__dict__`.
     """
 
     def has_slot(cls: type) -> bool:

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -647,10 +647,19 @@ def test_the_frozen_pin_does_not_depend_on_the_order_of_the_bases():
     assert frozen_refusals_that_depend_on_order() == []
 
 
+def carries_a_weakref_slot(cls: type) -> bool:
+    try:
+        weakref.ref(instance(cls))
+    except TypeError:
+        return False
+
+    return True
+
+
 WITH_A_SLOT = tuple(
     (bases, cls)
     for bases, cls in (*ALL, *(((shape,), built) for shape, built in ALONE.items()))
-    if any(base.__weakrefoffset__ != 0 for base in bases)
+    if any(carries_a_weakref_slot(base) for base in bases)
 )
 
 
@@ -686,7 +695,7 @@ def test_a_single_base_asking_to_drop_an_inherited_weakref_slot_is_the_same_bug(
     """#78's smallest form, stated on its own so that it is covered whether or
     not the sweep above still reaches it. The slot is inherited and cannot be
     removed, so the request is one salix should refuse rather than accept and
-    drop; today it is accepted and dropped.
+    drop.
     """
 
     without = build((Weak,), field="fresh", weakref=False)

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -19,6 +19,15 @@ class Plain(META):
     def __new__(metacls, name, bases, namespace):
         return super().__new__(metacls, name, bases, namespace)
 
+
+def WeakrefDefaulting(metatype: type) -> type:
+    class Defaulting(metatype):
+        def __new__(metacls, name, bases, namespace, *, weakref=False):
+            return super().__new__(metacls, name, bases, namespace, weakref=weakref)
+
+    return Defaulting
+
+
 # Both spellings of both, in one place: two literals drifted apart is a test
 # that silently stops covering a name.
 METADATA_NAMES = (
@@ -315,11 +324,7 @@ class TestAMetaclassSubclass:
         assert weakref.ref(held)() is held
 
     def test_a_keyword_only_delegate_that_names_weakref_can_add_the_slot(self):
-        class KwOnly(META):
-            def __new__(metacls, name, bases, namespace, *, weakref=False):
-                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
-
-        class Base(Struct, metaclass=KwOnly):
+        class Base(Struct, metaclass=WeakrefDefaulting(META)):
             x: int
 
         built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
@@ -332,11 +337,7 @@ class TestAMetaclassSubclass:
         takes the keyword-less path and the settle restores it.
         """
 
-        class KwOnly(META):
-            def __new__(metacls, name, bases, namespace, *, weakref=False):
-                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
-
-        class Base(Struct, metaclass=KwOnly):
+        class Base(Struct, metaclass=WeakrefDefaulting(META)):
             x: int
 
         built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True, eq=False)
@@ -417,11 +418,7 @@ class TestAMetaclassSubclass:
         builds without any hand-off from salix.
         """
 
-        class KwOnly(META):
-            def __new__(metacls, name, bases, namespace, *, weakref=False):
-                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
-
-        class Base(Struct, metaclass=KwOnly):
+        class Base(Struct, metaclass=WeakrefDefaulting(META)):
             x: int
 
         class Built(Base, weakref=True):
@@ -641,15 +638,26 @@ class TestAMetaclassSubclass:
         """The delegate fills its own weakref=False default and forwards it,
         and the build honours the request it received: the drop refuses."""
 
-        class Defaulting(META):
-            def __new__(metacls, name, bases, namespace, *, weakref=False):
-                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
-
         class Base(Struct, metaclass=Forwarding, weakref=True):
             x: int
 
         with pytest.raises(TypeError, match="weakref=False cannot drop"):
-            Defaulting("Built", (Base,), {"__annotations__": {}})
+            WeakrefDefaulting(META)("Built", (Base,), {"__annotations__": {}})
+
+    def test_the_defaulting_delegate_refuses_over_a_later_base_carrying_the_slot(self):
+        """The refusal keys on the keywords the build receives, not on which
+        base carries the slot: the delegate's own default over a record-false
+        first base and a carrying later base is the same refusal.
+        """
+
+        class Fielded(Struct, metaclass=Forwarding):
+            x: int
+
+        class Weak(Struct, metaclass=Forwarding, weakref=True):
+            y: int
+
+        with pytest.raises(TypeError, match="weakref=False cannot drop"):
+            WeakrefDefaulting(META)("Built", (Fielded, Weak), {"__annotations__": {}})
 
     def test_a_weakref_base_refuses_the_delegate_that_turns_weakref_off(self):
         """weakref=False over a base carrying the slot is a drop salix
@@ -661,6 +669,17 @@ class TestAMetaclassSubclass:
 
         with pytest.raises(TypeError, match="weakref=False cannot drop"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=False)
+
+    def test_weakref_false_without_a_carrying_base_still_builds(self):
+        """Without a carrying base the same request is not a drop: the class
+        builds and its instances reject weak references.
+        """
+
+        class Slotless(Struct, weakref=False):
+            x: int
+
+        with pytest.raises(TypeError):
+            weakref.ref(Slotless(1))
 
     def test_a_delegate_can_add_the_weakref_slot_the_call_planned(self):
         """The keywords ride the hand-off, so the re-entered build plans the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -637,6 +637,20 @@ class TestAMetaclassSubclass:
 
         assert built.__match_args__ == ("first",)
 
+    def test_a_delegate_that_defaults_weakref_off_refuses_a_slot_carrying_base(self):
+        """The delegate fills its own weakref=False default and forwards it,
+        and the build honours the request it received: the drop refuses."""
+
+        class Defaulting(META):
+            def __new__(metacls, name, bases, namespace, *, weakref=False):
+                return super().__new__(metacls, name, bases, namespace, weakref=weakref)
+
+        class Base(Struct, metaclass=Forwarding, weakref=True):
+            x: int
+
+        with pytest.raises(TypeError, match="weakref=False cannot drop"):
+            Defaulting("Built", (Base,), {"__annotations__": {}})
+
     def test_a_weakref_base_refuses_the_delegate_that_turns_weakref_off(self):
         """weakref=False over a base carrying the slot is a drop salix
         refuses, through the delegate's hand-off too.

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -637,18 +637,16 @@ class TestAMetaclassSubclass:
 
         assert built.__match_args__ == ("first",)
 
-    def test_a_weakref_base_keeps_its_slot_when_the_delegate_turns_weakref_off(self):
-        """weakref=False is metadata; the fresh path also inherits the base's
-        slot, so the settle accepts the class as-is.
+    def test_a_weakref_base_refuses_the_delegate_that_turns_weakref_off(self):
+        """weakref=False over a base carrying the slot is a drop salix
+        refuses, through the delegate's hand-off too.
         """
 
         class Base(Struct, metaclass=Forwarding, weakref=True):
             x: int
 
-        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=False)
-        instance = built(1, 2)
-
-        assert weakref.ref(instance)() is instance
+        with pytest.raises(TypeError, match="weakref=False cannot drop"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=False)
 
     def test_a_delegate_can_add_the_weakref_slot_the_call_planned(self):
         """The keywords ride the hand-off, so the re-entered build plans the


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was to resolve issue #78 per the design recorded in the batch notes: refuse the explicit `weakref=False` over any slot-carrying base, force the record to the slot truth, any-base `build_slots`.

Closes #78.

**What:** `weakref=False` over a base that carries a `__weakref__` slot was accepted and silently dropped — the class recorded no weakref while the reference still worked.

<details>

**The rule.** CPython cannot take an inherited `__weakref__` away, so the request is now refused when the keyword was written and **any** base carries the slot (the managed-flag-aware `carries_weakref_slot` walk). The record is forced to the slot truth: `build_struct_class` orients `request.options.weakref` onto the any-base walk, so a class never records less than its bases give it, in either base order. The any-base `build_slots` walk was already in place from the prior PRs — `__weakref__` is appended only when no base carries the slot.

**The pins.** The arrangement sweep shows zero ignored drop requests, and the single-base form (`class C(Weak, weakref=False)`, the smallest spelling) asserts the refusal. The innocent side is pinned too: without a carrying base the same request still builds a weakref-free class (a C unit plus a Python pin), so the refusal cannot grow past the drop it names. The delegate sides are pinned: turning weakref off through a metaclass hand-off is the same refusal, including a delegate that fills its own `weakref=False` default over a record-false first base with a carrying later base. A TESTING case pins the refusal in `options_read`, and the C record-force test asserts both the record bit and the slot.

**The boundaries.** The refusal can only act on the keywords the build actually receives: a delegate that swallows `weakref` (never forwards it) means the drop never reaches the build, and the class then keeps the slot its bases give it — the end-state the refusal exists to protect. The weakref force uses a different seam than the frozen pin's promise shape; unifying them is deferred to #115.

**Verification** — 1165 passing on 3.14, the 3.12 matrix green, c_test green, gate green on the four changed paths.

</details>
