### PR TITLE
feat: refuse functools-wrapped methods under a field name (closes #89)

### DIFF
--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -533,6 +533,38 @@ enum result refuse_colliding_methods(
 	return RESULT_OK;
 }
 
+static PyObject * qualname_of(PyObject * const value) {
+	if (PyFunction_Check(value)) {
+		return Py_XNewRef(((PyFunctionObject *) value)->func_qualname);
+	}
+
+	PY_MOVABLE(qualname, PyObject_GetAttrString(value, "__qualname__"));
+
+	if (qualname != NULL) {
+		return py_move(&qualname);
+	}
+
+	if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+		return NULL;
+	}
+
+	PyErr_Clear();
+
+	PY_MOVABLE(func, PyObject_GetAttrString(value, "func"));
+
+	if (func == NULL) {
+		if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+			return NULL;
+		}
+
+		PyErr_Clear();
+
+		return NULL;
+	}
+
+	return PyFunction_Check(func) ? Py_XNewRef(((PyFunctionObject *) func)->func_qualname) : NULL;
+}
+
 static int defines_a_method(
 	PyObject * const bound,
 	PyObject * const field_name,
@@ -547,16 +579,13 @@ static int defines_a_method(
 		return 1;
 	}
 
-	if (!PyFunction_Check(bound)) {
-		return 0;
+	PY_OWNED(qualname, qualname_of(bound));
+
+	if (qualname == NULL) {
+		return PyErr_Occurred() ? -1 : 0;
 	}
 
-	return defined_in_this_body(
-		((PyFunctionObject *) bound)->func_qualname,
-		field_name,
-		class_name,
-		spelling
-	);
+	return defined_in_this_body(qualname, field_name, class_name, spelling);
 }
 
 static int defined_in_this_body(

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -533,9 +533,13 @@ enum result refuse_colliding_methods(
 	return RESULT_OK;
 }
 
-static PyObject * qualname_of(PyObject * const value) {
+static PyObject * qualname_direct(PyObject * const value) {
 	if (PyFunction_Check(value)) {
 		return Py_XNewRef(((PyFunctionObject *) value)->func_qualname);
+	}
+
+	if (PyMethod_Check(value) || PyType_Check(value)) {
+		return NULL;
 	}
 
 	PY_MOVABLE(qualname, PyObject_GetAttrString(value, "__qualname__"));
@@ -550,6 +554,20 @@ static PyObject * qualname_of(PyObject * const value) {
 
 	PyErr_Clear();
 
+	return NULL;
+}
+
+static PyObject * qualname_of(PyObject * const value) {
+	PY_MOVABLE(direct, qualname_direct(value));
+
+	if (direct != NULL || PyErr_Occurred()) {
+		return py_move(&direct);
+	}
+
+	if (PyCallable_Check(value)) {
+		return NULL;
+	}
+
 	PY_MOVABLE(func, PyObject_GetAttrString(value, "func"));
 
 	if (func == NULL) {
@@ -562,7 +580,7 @@ static PyObject * qualname_of(PyObject * const value) {
 		return NULL;
 	}
 
-	return PyFunction_Check(func) ? Py_XNewRef(((PyFunctionObject *) func)->func_qualname) : NULL;
+	return qualname_direct(func);
 }
 
 static int defines_a_method(

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -943,6 +943,45 @@ class TestDefaultsThatAreCallable:
 
         assert WithBound().handler is bound
 
+    def test_a_bound_method_of_a_same_named_foreign_class_still_defaults_a_field(self):
+        class Colliding:
+            def handler(self):
+                return 1
+
+        bound = Colliding().handler
+
+        built = type(Struct)(
+            "Colliding", (Struct,), {"__annotations__": {"handler": object}, "handler": bound}
+        )
+
+        assert built().handler() == 1
+
+    def test_a_partial_of_a_same_named_foreign_function_still_defaults_a_field(self):
+        class Colliding:
+            def handler(self, first):
+                return first
+
+        partialled = functools.partial(Colliding().handler, 1)
+
+        built = type(Struct)(
+            "Colliding", (Struct,), {"__annotations__": {"handler": object}, "handler": partialled}
+        )
+
+        assert built().handler() == 1
+
+    def test_a_nested_class_of_a_same_named_foreign_class_still_defaults_a_field(self):
+        class Colliding:
+            class x:
+                pass
+
+        foreign = Colliding
+
+        built = type(Struct)(
+            "Colliding", (Struct,), {"__annotations__": {"x": object}, "x": foreign.x}
+        )
+
+        assert built().x is foreign.x
+
     def test_a_type_defaults_a_field(self):
         class WithType(Struct):
             kind: object = int
@@ -1005,8 +1044,9 @@ class TestTheFunctoolsSpellingsAreRefused:
     wrapper becomes the field's default. The body-binding carve-out fetches
     the wrapped function's `__qualname__` -- `functools.wraps` copies it, and
     `cached_property` carries it on `func` -- so the same tail-match rule
-    refuses these spellings too, along with a nested class, whose qualname is
-    the same shape.
+    refuses these spellings too. Bound methods, types, and callables escape
+    the fetch; the same-named controls live in
+    `TestDefaultsThatAreCallable`.
     """
 
     def test_a_cached_property_named_after_a_field_is_refused(self):
@@ -1026,14 +1066,6 @@ class TestTheFunctoolsSpellingsAreRefused:
                 @functools.cache  # noqa: B019 -- the wrapper is the subject, not the caching
                 def y(self) -> int:
                     return 99
-
-    def test_a_nested_class_named_after_a_field_is_refused(self):
-        with pytest.raises(TypeError, match="is a field, and the class body binds"):
-            class Nested(Struct):
-                x: int
-
-                class x:
-                    pass
 
     def test_a_cache_wrapped_foreign_function_still_defaults_a_field(self):
         class WithForeign(Struct):

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -999,41 +999,44 @@ class TestRefusalsWiderThanTheDefect:
                 handler: object = Colliding.handler
 
 
-class TestCollisionsStillNotRefused:
-    """The wrapped spellings the four-spelling rule does not reach, pinned so
-    the silent defaulting cannot regress unnoticed. #54's refusal covers a
-    `def` and the three decorators; a `functools` wrapper is neither a
-    `property` subclass nor a function, so it is dropped and becomes the
-    field's default exactly as before -- a required field silently turning
-    optional, which is the corruption #54 describes.
-
-    Not widened here because no version-stable test separates these from a
-    default someone means: `functools.partial` is a descriptor from 3.13 and
-    not before, and a bound method is one on every version. Tracked as its
-    own issue.
+class TestTheFunctoolsSpellingsAreRefused:
+    """A functools wrapper under a field's name is neither a `property`
+    subclass nor a function, so the four-spelling rule misses it and the
+    wrapper becomes the field's default. The body-binding carve-out fetches
+    the wrapped function's `__qualname__` -- `functools.wraps` copies it, and
+    `cached_property` carries it on `func` -- so the same tail-match rule
+    refuses these spellings too, along with a nested class, whose qualname is
+    the same shape.
     """
 
-    def test_a_cached_property_named_after_a_field_still_becomes_its_default(self):
-        class Cached(Struct):
-            x: int
+    def test_a_cached_property_named_after_a_field_is_refused(self):
+        with pytest.raises(TypeError, match="is a field, and the class body binds"):
+            class Cached(Struct):
+                x: int
 
-            @functools.cached_property
-            def x(self) -> int:
-                return 99
+                @functools.cached_property
+                def x(self) -> int:
+                    return 99
 
-        (default,) = Cached._struct_defaults_
+    def test_a_cache_wrapped_method_named_after_a_field_is_refused(self):
+        with pytest.raises(TypeError, match="is a field, and the class body binds"):
+            class Wrapped(Struct):
+                y: int
 
-        assert isinstance(default, functools.cached_property)
-        assert Cached().x is default
+                @functools.cache  # noqa: B019 -- the wrapper is the subject, not the caching
+                def y(self) -> int:
+                    return 99
 
-    def test_a_cache_wrapped_method_named_after_a_field_does_the_same(self):
-        class Wrapped(Struct):
-            y: int
+    def test_a_nested_class_named_after_a_field_is_refused(self):
+        with pytest.raises(TypeError, match="is a field, and the class body binds"):
+            class Nested(Struct):
+                x: int
 
-            @functools.cache  # noqa: B019 -- the wrapper is the subject, not the caching
-            def y(self) -> int:
-                return 99
+                class x:
+                    pass
 
-        (default,) = Wrapped._struct_defaults_
+    def test_a_cache_wrapped_foreign_function_still_defaults_a_field(self):
+        class WithForeign(Struct):
+            handler: object = functools.cache(module_level_handler)
 
-        assert Wrapped().y is default
+        assert WithForeign().handler(1) == 1

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1037,6 +1037,20 @@ class TestRefusalsWiderThanTheDefect:
             class Colliding(Struct):
                 handler: object = Colliding.handler
 
+    def test_a_cache_wrapped_method_of_a_same_named_foreign_class_is_refused(self):
+        """The wrapper carries the wrapped function's qualname, so the known
+        same-name limitation reaches the wrapped spelling too.
+        """
+
+        class Colliding:
+            def handler(self) -> int:
+                return 1
+
+        with pytest.raises(TypeError, match=r"'handler' is a field"):
+
+            class Colliding(Struct):
+                handler: object = functools.cache(Colliding.handler)
+
 
 class TestTheFunctoolsSpellingsAreRefused:
     """A functools wrapper under a field's name is neither a `property`
@@ -1072,3 +1086,50 @@ class TestTheFunctoolsSpellingsAreRefused:
             handler: object = functools.cache(module_level_handler)
 
         assert WithForeign().handler(1) == 1
+
+    def test_a_partial_over_a_body_method_still_defaults_the_field(self):
+        """The ruling's escape: a partial is callable and carries no qualname,
+        so it stays a default even when it wraps this body's own method.
+        """
+
+        class Partialled(Struct):
+            x: int
+
+            def x(self):
+                return 99
+
+            x = functools.partial(x)
+
+        assert isinstance(Partialled().x, functools.partial)
+
+    def test_a_wrapper_of_a_callable_wrapper_still_defaults_the_field(self):
+        """The hop resolves one wrapper level, so a composition whose inner
+        wrapper is callable (a partial) stays the ruling's escape.
+        """
+
+        class Composed(Struct):
+            x: int
+
+            def x(self):
+                return 99
+
+            x = functools.cached_property(functools.partial(x))
+
+        assert isinstance(Composed().x, functools.cached_property)
+
+    def test_a_raising_qualname_propagates(self):
+        """The fetch runs the author's own attribute code; a raising one is
+        their error and propagates.
+        """
+
+        class Hostile:
+            def __getattr__(self, name):
+                if name == "__qualname__":
+                    raise ValueError("nope")
+
+                raise AttributeError(name)
+
+        with pytest.raises(ValueError, match="nope"):
+            type(Struct)(
+                "H", (Struct,), {"__annotations__": {"handler": object}, "handler": Hostile()}
+            )


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was to resolve issue #89 per the fetch-policy ruling: the body-binding carve-out.

Closes #89.

**What:** the four-spelling rule covers a `def` and the `property` / `classmethod` / `staticmethod` decorators. A `functools` wrapper under a field's name is none of those, so it fell through to the pre-#54 treatment: dropped from the namespace and installed as the field's default — a required field silently turning optional, with `_struct_defaults_` reporting the wrapper.

<details>

**The rule.** The refusal only ever consults bindings of this class's own body, never base-resolved attributes, so reading `__qualname__` off such a value is the same boundary the existing no-fetch discipline protects (the ruling). `qualname_of` reads `func_qualname` off a plain function, fetches `__qualname__` otherwise, and hops one level to `func` for wrappers like `cached_property` that carry none; a missing qualname means no method, and a raising one propagates. `functools.wraps` copies `__qualname__`, so `cache` / `lru_cache` match the existing tail-match rule, and a nested class under a field's name does too — its qualname is the same shape.

**The pins.** The two collision pins flip to refusal pins, and a foreign-wrapper control (`functools.cache` of a module-level function still defaults a field) joins them. Three same-named controls — a bound method, a partial, and a nested class of a foreign class that shares the struct's name — pin the boundary the ruling keeps: bound methods, types, and callables escape the fetch and stay defaults, so the carve-out refuses nothing a body meant. The nested-class half of the issue is deliberately left: a class default is a default someone means, and the qualname tail-match cannot separate a body-defined nested class from a foreign same-named one. The wrapped variants of the known same-name limitation are pinned both ways: a same-named foreign cache wrapper is refused (the limitation), a partial over this body's own method and a wrapper-of-a-callable-wrapper composition stay defaults (the ruling's escape — the hop resolves qualname-carrying wrappers, not callable ones). The reviewer's metaclass claim was probed and does not reproduce: a same-named foreign class with a custom metaclass builds, since the type escape is subtype-inclusive. A raising `__qualname__` propagates, pinned.The fetch runs the author's own attribute code — the ruled cost of the carve-out, which only ever consults this class's own body bindings. The reviewer's consolidation observation (the body-binding classification is answered a different way at each refusal site) is filed as #119.

**Verification** — 1204 passing on 3.14, the 3.12 matrix green, c_test green, gate green on the two changed paths.

</details>


