### PR TITLE
fix: class-build dict probes report failed lookups (closes #117)

### DIFF
--- a/src/annotations.c
+++ b/src/annotations.c
@@ -3,6 +3,7 @@
 
 #include "annotations.h"
 #include "owned.h"
+#include "types.h"
 
 /* annotationlib.Format. The numbering is the API. */
 enum annotation_format {
@@ -29,10 +30,14 @@ static bool context_slot_is_free(PyObject * error);
 #endif
 
 PyObject * struct_annotations(PyObject * const namespace) {
-	PyObject * const declared = PyDict_GetItemString(namespace, "__annotations__");
+	PyObject * const declared = dict_get_string(namespace, "__annotations__");
 
 	if (declared != NULL) {
 		return Py_NewRef(declared);
+	}
+
+	if (PyErr_Occurred()) {
+		return NULL;
 	}
 
 	/* Owned rather than borrowed: on 3.14+ evaluate imports a module, which runs
@@ -41,16 +46,20 @@ PyObject * struct_annotations(PyObject * const namespace) {
 	PY_OWNED(annotate, Py_XNewRef(borrow_annotate(namespace)));
 
 	if (annotate == NULL) {
-		return PyDict_New();
+		return PyErr_Occurred() ? NULL : PyDict_New();
 	}
 
 	return evaluate(annotate);
 }
 
 static PyObject * borrow_annotate(PyObject * const namespace) {
-	PyObject * const annotate = PyDict_GetItemString(namespace, "__annotate__");
+	PyObject * const annotate = dict_get_string(namespace, "__annotate__");
 
-	return annotate != NULL ? annotate : PyDict_GetItemString(namespace, "__annotate_func__");
+	if (annotate != NULL || PyErr_Occurred()) {
+		return annotate;
+	}
+
+	return dict_get_string(namespace, "__annotate_func__");
 }
 
 static PyObject * evaluate(PyObject * const annotate) {

--- a/src/fields.c
+++ b/src/fields.c
@@ -633,12 +633,6 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 		PY_OWNED(value, dict_value_ref(default_by_name, field_name));
 
 		if (value == NULL) {
-			if (PyErr_Occurred()) {
-				Py_DECREF(defaults);
-
-				return NULL;
-			}
-
 			Py_DECREF(defaults);
 
 			return NULL;

--- a/src/fields.c
+++ b/src/fields.c
@@ -248,15 +248,16 @@ static enum result append_declared(
 			return RESULT_ERROR;
 		}
 
-		PyObject * const declared_default = PyDict_GetItem(namespace, field_name);
+		PY_OWNED(declared_default, dict_value_ref(namespace, field_name));
 
-		if (
-			declared_default != NULL &&
-			(
-				refuse_reserved_name(field_name) != RESULT_OK ||
-				PyDict_SetItem(default_by_name, field_name, declared_default) < 0 ||
-				refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
-			)
+		if (declared_default == NULL) {
+			if (PyErr_Occurred()) {
+				return RESULT_ERROR;
+			}
+		} else if (
+			refuse_reserved_name(field_name) != RESULT_OK ||
+			PyDict_SetItem(default_by_name, field_name, declared_default) < 0 ||
+			refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
 		) {
 			return RESULT_ERROR;
 		}
@@ -629,7 +630,19 @@ static PyObject * build_defaults(PyObject * const all_names, PyObject * const de
 
 	for (Py_ssize_t i = first_default; i < field_count; ++i) {
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
-		PyObject * const value = PyDict_GetItem(default_by_name, field_name);
+		PY_OWNED(value, dict_value_ref(default_by_name, field_name));
+
+		if (value == NULL) {
+			if (PyErr_Occurred()) {
+				Py_DECREF(defaults);
+
+				return NULL;
+			}
+
+			Py_DECREF(defaults);
+
+			return NULL;
+		}
 
 		/* Twice, on purpose. The first read is what raises in the ordinary case,
 		 * but its verdict is not final: it reads an object the module still

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -257,7 +257,13 @@ PyObject * build_struct_class(
 		return NULL;
 	}
 
-	bool const body_defines_eq = PyDict_GetItemString(original_namespace, "__eq__") != NULL;
+	int const defines_eq = dict_has_string(original_namespace, "__eq__");
+
+	if (defines_eq < 0) {
+		return NULL;
+	}
+
+	bool const body_defines_eq = defines_eq == 1;
 
 	struct equality_source const inherited_equality = (
 		request.options.eq == inherited.eq && !body_defines_eq ? resolves_body_equality(bases) :
@@ -329,28 +335,35 @@ PyObject * build_struct_class(
 		if (settled != RESULT_OK) {
 			Py_CLEAR(struct_class);
 		} else {
-			struct binding_plan const bindings = binding_plan(
-				request.options,
-				inherited,
-				frozen_across_bases,
-				body_defines_eq,
-				inherits_body_eq,
-				inherited_equality.needs_derived_not_equal,
-				PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL,
-				PyDict_GetItemString(original_namespace, "__setattr__") != NULL
-			);
+			int const defines_hash = dict_has_string(original_namespace, rebind_hash[0]);
+			int const defines_setattr = dict_has_string(original_namespace, "__setattr__");
 
-			if (
-				settle_mro_bindings(
-					struct_class,
-					bases,
-					original_namespace,
-					bindings,
-					request.options
-				) !=
-				RESULT_OK
-			) {
+			if (defines_hash < 0 || defines_setattr < 0) {
 				Py_CLEAR(struct_class);
+			} else {
+				struct binding_plan const bindings = binding_plan(
+					request.options,
+					inherited,
+					frozen_across_bases,
+					body_defines_eq,
+					inherits_body_eq,
+					inherited_equality.needs_derived_not_equal,
+					defines_hash == 1,
+					defines_setattr == 1
+				);
+
+				if (
+					settle_mro_bindings(
+						struct_class,
+						bases,
+						original_namespace,
+						bindings,
+						request.options
+					) !=
+					RESULT_OK
+				) {
+					Py_CLEAR(struct_class);
+				}
 			}
 		}
 	}

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -260,6 +260,8 @@ PyObject * build_struct_class(
 	int const defines_eq = dict_has_string(original_namespace, "__eq__");
 
 	if (defines_eq < 0) {
+		field_plan_clear(&plan);
+
 		return NULL;
 	}
 
@@ -681,6 +683,29 @@ static int settle_candidates(
 /* What the class's MRO hands out below the class's own dict for the three
  * names, asked after the class exists so the answer is the real resolution,
  * in one walk, with the defining entry tracked for each. */
+static enum result resolve_dunder(
+	PyObject * const dict,
+	PyObject * const name,
+	PyObject * * const resolved,
+	PyTypeObject * const entry,
+	PyTypeObject * * const owner
+) {
+	if (*resolved != NULL) {
+		return RESULT_OK;
+	}
+
+	PY_MOVABLE(found, dict_value_ref(dict, name));
+
+	if (found == NULL) {
+		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
+	}
+
+	*resolved = py_move(&found);
+	*owner = entry;
+
+	return RESULT_OK;
+}
+
 static enum result mro_dunders_of(
 	PyTypeObject * const type,
 	PyObject * * const resolved_eq,
@@ -715,31 +740,12 @@ static enum result mro_dunders_of(
 			return RESULT_ERROR;
 		}
 
-		if (*resolved_eq == NULL) {
-			PyObject * const found = PyDict_GetItem(dict, eq_name);
-
-			if (found != NULL) {
-				*resolved_eq = Py_NewRef(found);
-				*eq_owner = entry;
-			}
-		}
-
-		if (*resolved_ne == NULL) {
-			PyObject * const found = PyDict_GetItem(dict, ne_name);
-
-			if (found != NULL) {
-				*resolved_ne = Py_NewRef(found);
-				*ne_owner = entry;
-			}
-		}
-
-		if (*resolved_repr == NULL) {
-			PyObject * const found = PyDict_GetItem(dict, repr_name);
-
-			if (found != NULL) {
-				*resolved_repr = Py_NewRef(found);
-				*repr_owner = entry;
-			}
+		if (
+			resolve_dunder(dict, eq_name, resolved_eq, entry, eq_owner) != RESULT_OK ||
+			resolve_dunder(dict, ne_name, resolved_ne, entry, ne_owner) != RESULT_OK ||
+			resolve_dunder(dict, repr_name, resolved_repr, entry, repr_owner) != RESULT_OK
+		) {
+			return RESULT_ERROR;
 		}
 
 		if (*resolved_eq != NULL && *resolved_ne != NULL && *resolved_repr != NULL) {
@@ -1061,13 +1067,22 @@ static enum result settle_planned(
 	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
 		for (char const * const * name = *tables; *name != NULL; name += 1) {
 			int const in_class = dict_has_string(class_dict, *name);
-			int const in_body = dict_has_string(original_namespace, *name);
 
-			if (in_class < 0 || in_body < 0) {
+			if (in_class < 0) {
 				return RESULT_ERROR;
 			}
 
-			if (in_class == 1 && in_body == 0 && !settled_by_the_plan(*name, bindings)) {
+			if (in_class == 0) {
+				continue;
+			}
+
+			int const in_body = dict_has_string(original_namespace, *name);
+
+			if (in_body < 0) {
+				return RESULT_ERROR;
+			}
+
+			if (in_body == 0 && !settled_by_the_plan(*name, bindings)) {
 				return refuse_unplanned(struct_class);
 			}
 		}

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -119,6 +119,36 @@ static char const * const * const settle_tables[] = {
 	NULL,
 };
 
+/* An exact-str key answers a probe by identity or in C, so a namespace of
+ * them cannot fail the sweep; anything else might. The sweep is what turns
+ * a poisoned lookup into a propagated error before type.__new__ misreads it
+ * as absence and silently builds a half-settled class. */
+static enum result verify_settle_names_readable(PyObject * const original_namespace) {
+	Py_ssize_t position = 0;
+	PyObject * key;
+	PyObject * value;
+
+	while (PyDict_Next(original_namespace, &position, &key, &value)) {
+		if (!PyUnicode_CheckExact(key)) {
+			for (
+				char const * const * const * tables = settle_tables;
+				*tables != NULL;
+				tables += 1
+			) {
+				for (char const * const * name = *tables; *name != NULL; name += 1) {
+					if (dict_has_string(original_namespace, *name) < 0) {
+						return RESULT_ERROR;
+					}
+				}
+			}
+
+			return RESULT_OK;
+		}
+	}
+
+	return RESULT_OK;
+}
+
 static bool table_names(char const * const * const names, char const * const name) {
 	for (char const * const * entry = names; *entry != NULL; entry += 1) {
 		if (strcmp(*entry, name) == 0) {
@@ -245,6 +275,7 @@ PyObject * build_struct_class(
 	}
 
 	if (
+		verify_settle_names_readable(original_namespace) != RESULT_OK ||
 		refuse_reserved_metadata_names(original_namespace, plan.new_names) != RESULT_OK ||
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
 		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -583,7 +583,13 @@ static enum result settle_rebind(
 	);
 
 	for (char const * const * name = names; *name != NULL; name += 1) {
-		if (PyDict_GetItemString(original_namespace, *name) != NULL) {
+		int const present = dict_has_string(original_namespace, *name);
+
+		if (present < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (present == 1) {
 			continue;
 		}
 
@@ -787,11 +793,19 @@ static int honours_a_body_comparison(
 		}
 
 		for (Py_ssize_t name = 0; name < 6; ++name) {
-			PyObject * const bound = PyDict_GetItemString(dict, (char const * const[6]){
+			PyObject * const bound = dict_get_string(dict, (char const * const[6]){
 				"__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__",
 			}[name]);
 
-			if (bound != NULL && bound != mixin_bindings[name] && bound != object_bindings[name]) {
+			if (bound == NULL) {
+				if (PyErr_Occurred()) {
+					return -1;
+				}
+
+				continue;
+			}
+
+			if (bound != mixin_bindings[name] && bound != object_bindings[name]) {
 				return 1;
 			}
 		}
@@ -1026,6 +1040,13 @@ static enum result settle_planned(
 		return refuse_unplanned(struct_class);
 	}
 
+	int const defines_hash = dict_has_string(original_namespace, rebind_hash[0]);
+	int const defines_setattr = dict_has_string(original_namespace, "__setattr__");
+
+	if (defines_hash < 0 || defines_setattr < 0) {
+		return RESULT_ERROR;
+	}
+
 	struct binding_plan const bindings = binding_plan(
 		options,
 		inherited,
@@ -1033,17 +1054,20 @@ static enum result settle_planned(
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,
-		PyDict_GetItemString(original_namespace, rebind_hash[0]) != NULL,
-		PyDict_GetItemString(original_namespace, "__setattr__") != NULL
+		defines_hash == 1,
+		defines_setattr == 1
 	);
 
 	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
 		for (char const * const * name = *tables; *name != NULL; name += 1) {
-			if (
-				PyDict_GetItemString(class_dict, *name) != NULL &&
-				PyDict_GetItemString(original_namespace, *name) == NULL &&
-				!settled_by_the_plan(*name, bindings)
-			) {
+			int const in_class = dict_has_string(class_dict, *name);
+			int const in_body = dict_has_string(original_namespace, *name);
+
+			if (in_class < 0 || in_body < 0) {
+				return RESULT_ERROR;
+			}
+
+			if (in_class == 1 && in_body == 0 && !settled_by_the_plan(*name, bindings)) {
 				return refuse_unplanned(struct_class);
 			}
 		}
@@ -1073,12 +1097,19 @@ static enum result settle_planned(
 
 	/* bind_not_equal's answered case on a live class: the fresh build binds
 	 * object's __ne__ when the body answered equality itself. */
-	if (
-		bindings.answered_by_body &&
-		PyDict_GetItemString(original_namespace, rebind_not_equal[0]) == NULL &&
-		settle_rebind(struct_class, original_namespace, rebind_not_equal, false) != RESULT_OK
-	) {
-		return RESULT_ERROR;
+	if (bindings.answered_by_body) {
+		int const defines_ne = dict_has_string(original_namespace, rebind_not_equal[0]);
+
+		if (defines_ne < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (
+			defines_ne == 0 &&
+			settle_rebind(struct_class, original_namespace, rebind_not_equal, false) != RESULT_OK
+		) {
+			return RESULT_ERROR;
+		}
 	}
 
 	if (
@@ -1129,15 +1160,14 @@ static enum result settle_planned(
 			return RESULT_ERROR;
 		}
 	} else {
-		PyObject * const body_match_args = PyDict_GetItemString(
-			original_namespace,
-			"__match_args__"
-		);
+		PyObject * const body_match_args = dict_get_string(original_namespace, "__match_args__");
 
 		if (body_match_args != NULL) {
 			if (PyDict_SetItemString(class_dict, "__match_args__", body_match_args) < 0) {
 				return RESULT_ERROR;
 			}
+		} else if (PyErr_Occurred()) {
+			return RESULT_ERROR;
 		} else if (PyDict_DelItemString(class_dict, "__match_args__") < 0) {
 			if (PyErr_ExceptionMatches(PyExc_KeyError)) {
 				PyErr_Clear();
@@ -1170,9 +1200,23 @@ static enum result restore_stripped(
 ) {
 	for (char const * const * const * table = tables; *table != NULL; table += 1) {
 		for (char const * const * name = *table; *name != NULL; name += 1) {
-			PyObject * const body_value = PyDict_GetItemString(original_namespace, *name);
+			PyObject * const body_value = dict_get_string(original_namespace, *name);
 
-			if (body_value == NULL || PyDict_GetItemString(class_dict, *name) == body_value) {
+			if (body_value == NULL) {
+				if (PyErr_Occurred()) {
+					return RESULT_ERROR;
+				}
+
+				continue;
+			}
+
+			PyObject * const class_value = dict_get_string(class_dict, *name);
+
+			if (class_value == NULL && PyErr_Occurred()) {
+				return RESULT_ERROR;
+			}
+
+			if (class_value == body_value) {
 				continue;
 			}
 

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -105,7 +105,7 @@ enum result refuse_displaced_slots(
 	PyObject * const bases,
 	struct options const options
 ) {
-	PyObject * const declared = PyDict_GetItemString(original_namespace, "__slots__");
+	PyObject * const declared = dict_get_string(original_namespace, "__slots__");
 
 	if (declared == NULL) {
 		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
@@ -250,13 +250,13 @@ enum result refuse_reserved_metadata_names(
 	}
 
 	for (char const * const * reserved = reserved_metadata_names; *reserved != NULL; ++reserved) {
-		PyObject * const bound = PyDict_GetItemString(original_namespace, *reserved);
+		int const bound = dict_has_string(original_namespace, *reserved);
 
-		if (PyErr_Occurred()) {
+		if (bound < 0) {
 			return RESULT_ERROR;
 		}
 
-		if (bound != NULL) {
+		if (bound == 1) {
 			PyErr_Format(
 				PyExc_TypeError,
 				"'%s' is reserved for salix's metadata and cannot be a field "
@@ -357,9 +357,8 @@ static enum result apply_options(
 ) {
 	int const defines_hash = dict_has_string(namespace, "__hash__");
 	int const defines_setattr = dict_has_string(namespace, "__setattr__");
-	int const defines_ne = dict_has_string(namespace, "__ne__");
 
-	if (defines_hash < 0 || defines_setattr < 0 || defines_ne < 0) {
+	if (defines_hash < 0 || defines_setattr < 0) {
 		return RESULT_ERROR;
 	}
 
@@ -374,12 +373,16 @@ static enum result apply_options(
 		defines_setattr == 1
 	);
 
-	if (
-		plan.answered_by_body &&
-		defines_ne == 0 &&
-		rebind(namespace, rebind_not_equal, false) != RESULT_OK
-	) {
-		return RESULT_ERROR;
+	if (plan.answered_by_body) {
+		int const defines_ne = dict_has_string(namespace, "__ne__");
+
+		if (defines_ne < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (defines_ne == 0 && rebind(namespace, rebind_not_equal, false) != RESULT_OK) {
+			return RESULT_ERROR;
+		}
 	}
 
 	if (plan.rebind_comparison && rebind(namespace, rebind_comparison, options.eq) != RESULT_OK) {

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -355,6 +355,14 @@ static enum result apply_options(
 	bool const inherits_body_eq,
 	bool const derive_not_equal
 ) {
+	int const defines_hash = dict_has_string(namespace, "__hash__");
+	int const defines_setattr = dict_has_string(namespace, "__setattr__");
+	int const defines_ne = dict_has_string(namespace, "__ne__");
+
+	if (defines_hash < 0 || defines_setattr < 0 || defines_ne < 0) {
+		return RESULT_ERROR;
+	}
+
 	struct binding_plan const plan = binding_plan(
 		options,
 		inherited,
@@ -362,13 +370,13 @@ static enum result apply_options(
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,
-		PyDict_GetItemString(namespace, "__hash__") != NULL,
-		PyDict_GetItemString(namespace, "__setattr__") != NULL
+		defines_hash == 1,
+		defines_setattr == 1
 	);
 
 	if (
 		plan.answered_by_body &&
-		PyDict_GetItemString(namespace, "__ne__") == NULL &&
+		defines_ne == 0 &&
 		rebind(namespace, rebind_not_equal, false) != RESULT_OK
 	) {
 		return RESULT_ERROR;
@@ -428,7 +436,13 @@ static enum result rebind(
 	);
 
 	for (char const * const * name = names; *name != NULL; ++name) {
-		if (PyDict_GetItemString(namespace, *name) != NULL) {
+		int const present = dict_has_string(namespace, *name);
+
+		if (present < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (present == 1) {
 			continue;
 		}
 

--- a/src/types.h
+++ b/src/types.h
@@ -110,6 +110,35 @@ static inline PyObject * dict_value_ref(PyObject * const mapping, PyObject * con
 #endif
 }
 
+/* Presence without the doctrine's cost: -1 is a lookup error, which a bare
+ * PyDict_GetItemString would silently read as "absent" -- and on 3.14 it
+ * clears the error outright, so the StringRef spelling is required there. */
+static inline int dict_has_string(PyObject * const mapping, char const * const name) {
+#if PY_VERSION_HEX >= 0x030E0000
+	PyObject * value = NULL;
+
+	if (PyDict_GetItemStringRef(mapping, name, &value) < 0) {
+		return -1;
+	}
+
+	if (value != NULL) {
+		Py_DECREF(value);
+
+		return 1;
+	}
+
+	return 0;
+#else
+	PyObject * const value = PyDict_GetItemString(mapping, name);
+
+	if (value != NULL) {
+		return 1;
+	}
+
+	return PyErr_Occurred() ? -1 : 0;
+#endif
+}
+
 #if PY_VERSION_HEX < 0x030D0000
 #	define STRUCT_BEGIN_CRITICAL_SECTION(object) {
 #	define STRUCT_END_CRITICAL_SECTION() }

--- a/src/types.h
+++ b/src/types.h
@@ -110,33 +110,31 @@ static inline PyObject * dict_value_ref(PyObject * const mapping, PyObject * con
 #endif
 }
 
-/* Presence without the doctrine's cost: -1 is a lookup error, which a bare
- * PyDict_GetItemString would silently read as "absent" -- and on 3.14 it
- * clears the error outright, so the StringRef spelling is required there. */
+/* The class-build dict probes share this pair: PyDict_GetItemString
+ * suppresses a lookup error on every version, so presence and value probes
+ * go through WithError, whose NULL reports a failure the caller must not
+ * read as absence. The value is borrowed -- the mapping outlives its use. */
+static inline PyObject * dict_get_string(PyObject * const mapping, char const * const name) {
+	PyObject * const key = PyUnicode_FromString(name);
+
+	if (key == NULL) {
+		return NULL;
+	}
+
+	PyObject * const value = PyDict_GetItemWithError(mapping, key);
+	Py_DECREF(key);
+
+	return value;
+}
+
 static inline int dict_has_string(PyObject * const mapping, char const * const name) {
-#if PY_VERSION_HEX >= 0x030E0000
-	PyObject * value = NULL;
-
-	if (PyDict_GetItemStringRef(mapping, name, &value) < 0) {
-		return -1;
-	}
-
-	if (value != NULL) {
-		Py_DECREF(value);
-
-		return 1;
-	}
-
-	return 0;
-#else
-	PyObject * const value = PyDict_GetItemString(mapping, name);
+	PyObject * const value = dict_get_string(mapping, name);
 
 	if (value != NULL) {
 		return 1;
 	}
 
 	return PyErr_Occurred() ? -1 : 0;
-#endif
 }
 
 #if PY_VERSION_HEX < 0x030D0000

--- a/src/types.h
+++ b/src/types.h
@@ -106,7 +106,9 @@ static inline PyObject * dict_value_ref(PyObject * const mapping, PyObject * con
 
 	return PyDict_GetItemRef(mapping, key, &value) < 0 ? NULL : value;
 #else
-	return Py_XNewRef(PyDict_GetItem(mapping, key));
+	PyObject * const value = PyDict_GetItemWithError(mapping, key);
+
+	return value != NULL ? Py_XNewRef(value) : NULL;
 #endif
 }
 

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1042,8 +1042,18 @@ class HostileKey(str):
     "probed",
     (
         "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
         "__hash__",
+        "__repr__",
         "__setattr__",
+        "__delattr__",
+        "__init__",
+        "__post_init__",
+        "__new__",
         "__slots__",
         "__match_args__",
         "_struct_fields_",
@@ -1056,7 +1066,8 @@ def test_a_hostile_namespace_key_propagates_instead_of_reading_as_absent(probed)
     """A namespace key whose __eq__ raises makes the class-build dict probes
     fail; a probe that cannot see has not learned the name is absent, so the
     error propagates instead of the class building as if it were. One name
-    per probe the minimal build always makes.
+    per probe the minimal build always makes, plus every settle-table name
+    the pre-build sweep reads.
     """
 
     namespace = {"__annotations__": {"x": int}, HostileKey(probed): 1}
@@ -1078,3 +1089,56 @@ def test_a_hostile_not_equal_key_propagates_when_the_body_answers_equality():
 
     with pytest.raises(ValueError, match="nope"):
         type(Struct)("Hostile", (Struct,), namespace)
+
+
+def test_a_handoff_build_with_a_hostile_settle_name_propagates():
+    """The settle tables own __init__, and the handoff build used to hand a
+    body key that poisons its lookup to type.__new__, which misread the
+    failure as absence and built a half-settled class with no error.
+    """
+
+    class Delegating(META):
+        pass
+
+    class Base(Struct, metaclass=Delegating):
+        x: int
+
+    namespace = {"__annotations__": {"y": int}, HostileKey("__init__"): 1}
+
+    with pytest.raises(ValueError, match="nope"):
+        META("Built", (Base,), namespace, order=True)
+
+
+def test_a_hostile_key_for_a_defaulted_field_name_propagates():
+    """append_declared probes the namespace for each declared field name to
+    pick up its default; a key that poisons that probe propagates.
+    """
+
+    namespace = {"__annotations__": {"y": int}, HostileKey("y"): 5}
+
+    with pytest.raises(ValueError, match="nope"):
+        type(Struct)("Hostile", (Struct,), namespace)
+
+
+def test_a_hostile_annotations_key_propagates():
+    namespace = {HostileKey("__annotations__"): 1}
+
+    with pytest.raises(ValueError, match="nope"):
+        type(Struct)("Hostile", (Struct,), namespace)
+
+
+def test_a_hostile_key_injected_by_a_metaclass_new_propagates():
+    """A metaclass __new__ can write into the namespace before the build sees
+    it; a hostile key injected there is refused by the same sweep instead of
+    reaching type.__new__.
+    """
+
+    class Injecting(META):
+        def __new__(cls, name, bases, namespace, **kwargs):
+            namespace[HostileKey("__init__")] = 1
+
+            return super().__new__(cls, name, bases, namespace, **kwargs)
+
+    with pytest.raises(ValueError, match="nope"):
+        class Base(Struct, metaclass=Injecting):
+            x: int

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1029,3 +1029,21 @@ class TestAMetaclassSubclass:
 
         with pytest.raises(TypeError, match=r"Wrong\.__new__ returned .*is not a struct class"):
             META("Z", (Seeded,), {"__annotations__": {"b": int}})
+
+
+def test_a_hostile_namespace_key_propagates_instead_of_reading_as_absent():
+    """A namespace key whose __eq__ raises makes the dunder probes fail; a
+    probe that cannot see has not learned the name is absent, so the error
+    propagates instead of the class building as if it were.
+    """
+
+    class HostileKey(str):
+        __hash__ = str.__hash__
+
+        def __eq__(self, other):
+            raise ValueError("nope")
+
+    namespace = {"__annotations__": {"x": int}, HostileKey("__eq__"): 1}
+
+    with pytest.raises(ValueError, match="nope"):
+        type(Struct)("Hostile", (Struct,), namespace)

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1031,19 +1031,50 @@ class TestAMetaclassSubclass:
             META("Z", (Seeded,), {"__annotations__": {"b": int}})
 
 
-def test_a_hostile_namespace_key_propagates_instead_of_reading_as_absent():
-    """A namespace key whose __eq__ raises makes the dunder probes fail; a
-    probe that cannot see has not learned the name is absent, so the error
-    propagates instead of the class building as if it were.
+class HostileKey(str):
+    __hash__ = str.__hash__
+
+    def __eq__(self, other):
+        raise ValueError("nope")
+
+
+@pytest.mark.parametrize(
+    "probed",
+    (
+        "__eq__",
+        "__hash__",
+        "__setattr__",
+        "__slots__",
+        "__match_args__",
+        "_struct_fields_",
+        "_struct_defaults_",
+        "__struct_fields__",
+        "__struct_defaults__",
+    ),
+)
+def test_a_hostile_namespace_key_propagates_instead_of_reading_as_absent(probed):
+    """A namespace key whose __eq__ raises makes the class-build dict probes
+    fail; a probe that cannot see has not learned the name is absent, so the
+    error propagates instead of the class building as if it were. One name
+    per probe the minimal build always makes.
     """
 
-    class HostileKey(str):
-        __hash__ = str.__hash__
+    namespace = {"__annotations__": {"x": int}, HostileKey(probed): 1}
 
-        def __eq__(self, other):
-            raise ValueError("nope")
+    with pytest.raises(ValueError, match="nope"):
+        type(Struct)("Hostile", (Struct,), namespace)
 
-    namespace = {"__annotations__": {"x": int}, HostileKey("__eq__"): 1}
+
+def test_a_hostile_not_equal_key_propagates_when_the_body_answers_equality():
+    """The __ne__ probe runs only when the body answered equality; the same
+    hostile key then propagates there too.
+    """
+
+    namespace = {
+        "__annotations__": {"x": int},
+        "__eq__": lambda self, other: True,
+        HostileKey("__ne__"): 1,
+    }
 
     with pytest.raises(ValueError, match="nope"):
         type(Struct)("Hostile", (Struct,), namespace)


### PR DESCRIPTION
# A sweep ahead of `type.__new__`, for every name the settle tables own

## Round 4 — converged (score 0), scope decision recorded

Round 4 verified everything live on 3.12.3: all 19 parametrized pins raise; the handoff, body-eq `__ne__`, field-default, annotations, and injection repros raise; the round-3 corruption repro raises while the clean control is unchanged. The two remaining findings are nits about pin maintenance, and the systemic (`sweep-not-mechanically-enforced`, severity nit) is at its third consecutive round. The scope decision, recorded here before merge:

- **Boundary (this PR body, corrected):** the sweep governs the settle tables and salix's own probe sites; every reachable hostile-key path is pinned. The residues below are out of scope for this PR and filed.
- **Filed issue:** re-entered-frame sweep pin + mechanical tie between the pin list and the probe sites.

### Boundary — corrected with the measured behavior

The round-3 writeup misstated this boundary in two places, both corrected:

- **The injection test pins the outer frame, not the re-entered frame.** `test_a_hostile_key_injected_by_a_metaclass_new_propagates` injects before `super().__new__`, so the poisoned namespace arrives at the first `build_struct_class` frame and is refused there. The re-entered frame's sweep (the guard for a metaclass `__new__` that injects into the built namespace during the outer `create_class` handoff, `handoff->tp_new != StructMeta_new`) is correct by construction — every frame sweeps before `create_class` — but has no hostile-key pin. Filed as the residue issue.
- **The `__init_subclass__` example was wrong.** Measured on 3.12.3 by round 4: `HostileKey("__init_subclass__")` **propagates** — CPython's `type_new` reads that name with error-reporting probes. The names CPython silently misreads are the slot-derivation ones, e.g. `HostileKey("__str__")` builds with the slot misread. So the boundary is: salix-owned names are swept; slot-derivation names salix does not own (like `__str__`) still meet CPython's silent misread — that is the minimal repro below, a CPython behavior outside salix's domain.

The other boundary claims stand as written: a poisoned base type dict is unconstructible (the base's own creation refuses; `setattr` interns str-subclass names, measured), so the MRO walk's error path has no pin and stays defense-in-depth.

## Rounds 1–3 (context)

<details>
<summary>The prior rounds</summary>

- **Round 1** (score 3.23): the helper's pre-3.13 fallback swallowed errors; bare `PyDict_GetItem` probes remained in the settle and annotations paths. Answered in `c9c48a6`: `PyDict_GetItemWithError`-based helpers on every version, the first sweep of the class-build probes, parametrized hostile pins.
- **Round 2** (1.32): an error-path `field_plan_clear` leak, the MRO-walk swallow, an eager hoist. Answered in `2413f24`: `resolve_dunder` for the MRO walk, the leak closed, the settle short-circuit restored.
- **Round 3** (1.30): the reported "silent corruption" reproduced live and was traced frame by frame. The repro never enters the settle loop (`create_class` builds fresh, no re-entry), and the identical corruption reproduces on `main` and with zero salix code:

  ```python
  class HK(str):
      __hash__ = str.__hash__
      def __eq__(self, other): raise ValueError("nope")

  class X:
      def __init__(self, a): self.a = a

  Y = type("Y", (X,), {HK("__init__"): 1})
  Y(5)  # AttributeError: 'Y' object has no attribute 'a' — the arg was silently dropped
  ```

  The failing frame is CPython's `type_new` slot derivation. Answered in `107c620` with `verify_settle_names_readable`: a pre-`create_class` sweep of the settle tables, gated on "any key is not an exact str" (exact-str keys answer probes by identity or in C; measured 11.39 → 11.51 µs/16-field build). The five-line handoff repro raises; the clean control honours everything.
</details>

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: drive PR #120 (the issue #117 dict-probe sweep) through the code-review loop, and record each round's disposition and the round-4 scope decision here.
