### PR TITLE
Born frozen: the setattro wrappers land pre-creation, not by post-hoc slot surgery

### DIFF
--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -262,6 +262,17 @@ static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObj
 	return false;
 }
 
+static bool carries_diverting_setattro(PyTypeObject const * const base) {
+	return (
+		base->tp_setattro != StructMixin_Type.tp_setattro &&
+		base->tp_setattro != PyBaseObject_Type.tp_setattro
+	);
+}
+
+bool any_base_diverts_setattro(PyObject * const bases) {
+	return any_base_satisfies(bases, carries_diverting_setattro);
+}
+
 bool any_base_has_weakref_slot(PyObject * const bases) {
 	return any_base_satisfies(bases, carries_weakref_slot);
 }

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -311,6 +311,7 @@ PyObject * build_struct_class(
 
 	bool const inherits_body_eq = inherited_equality.from_a_body;
 	bool const frozen_across_bases = request.options.frozen && any_struct_base_is_mutable(bases);
+	bool const bases_divert_setattro = any_base_diverts_setattro(bases);
 
 	PY_OWNED(
 		namespace,
@@ -323,6 +324,7 @@ PyObject * build_struct_class(
 			bases,
 			inherited,
 			frozen_across_bases,
+			bases_divert_setattro,
 			body_defines_eq,
 			inherits_body_eq,
 			inherited_equality.needs_derived_not_equal
@@ -378,7 +380,7 @@ PyObject * build_struct_class(
 					request.options,
 					inherited,
 					frozen_across_bases,
-					any_base_diverts_setattro(bases),
+					bases_divert_setattro,
 					body_defines_eq,
 					inherits_body_eq,
 					inherited_equality.needs_derived_not_equal,
@@ -867,16 +869,14 @@ static enum result settle_mro_bindings(
 ) {
 	PyTypeObject * const type = (PyTypeObject *) struct_class;
 
-	/* A co-base carrying its own C-level tp_setattro can divert the child's
-	 * slot away from the frozen block, so the block's wrappers are rebound
-	 * into the class dict — the same rebind machinery every other dunder
-	 * repair uses — and the MRO-dispatching slot honours them. A body
-	 * __setattr__ or __delattr__ is skipped per name, so the escape hatch
-	 * works for either half. In a re-entered build the namespace carries the
-	 * outer build's rebind injections rather than the true body, and the
-	 * outer settle is the source of truth. The mutable column needs no
-	 * repair: CPython's own dispatch honours hooks and foreign C-level slots
-	 * exactly as it does for plain classes. */
+	/* The pre-creation rebind lands the slot on the block's own wrapper, so
+	 * this repair fires only when the body defines __setattr__: the escape
+	 * half is skipped per name and the other half is rebound so it keeps
+	 * refusing. In a re-entered build the namespace carries the outer
+	 * build's rebind injections rather than the true body, and the outer
+	 * settle is the source of truth. The mutable column needs no repair:
+	 * CPython's own dispatch honours hooks and foreign C-level slots exactly
+	 * as it does for plain classes. */
 	if (options.frozen && type->tp_setattro != StructMixin_Type.tp_setattro) {
 		if (settle_rebind(struct_class, original_namespace, rebind_mutability, true) != RESULT_OK) {
 			return RESULT_ERROR;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -378,6 +378,7 @@ PyObject * build_struct_class(
 					request.options,
 					inherited,
 					frozen_across_bases,
+					any_base_diverts_setattro(bases),
 					body_defines_eq,
 					inherits_body_eq,
 					inherited_equality.needs_derived_not_equal,
@@ -1088,6 +1089,7 @@ static enum result settle_planned(
 		options,
 		inherited,
 		frozen_across_bases,
+		any_base_diverts_setattro(bases),
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,
@@ -1552,6 +1554,10 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PY_OWNED(raw_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, mutable_base));
 	PY_OWNED(mutable_child, struct_class_with_field(raw_bases, NULL));
 	TEST_ASSERT_NOT_NULL(mutable_child);
+	TEST_ASSERT_EQUAL_INT(
+		0,
+		dict_has_string(((PyTypeObject *) mutable_child)->tp_dict, "__setattr__")
+	);
 
 	PY_OWNED(instance, PyObject_CallFunction(mutable_child, "i", 1));
 	TEST_ASSERT_NOT_NULL(instance);
@@ -1571,6 +1577,10 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	TEST_ASSERT_EQUAL_PTR(
 		StructMixin_Type.tp_setattro,
 		((PyTypeObject *) frozen_child)->tp_setattro
+	);
+	TEST_ASSERT_EQUAL_INT(
+		1,
+		dict_has_string(((PyTypeObject *) frozen_child)->tp_dict, "__setattr__")
 	);
 
 	PY_OWNED(frozen_instance, PyObject_CallFunction(frozen_child, "i", 1));

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -93,6 +93,7 @@ PyObject * build_class_namespace(
 	PyObject * bases,
 	struct options inherited,
 	bool frozen_across_bases,
+	bool bases_divert_setattro,
 	bool body_defines_eq,
 	bool inherits_body_eq,
 	bool derive_not_equal

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -61,6 +61,7 @@ struct options inherited_options(
 );
 bool any_struct_base_is_mutable(PyObject * bases);
 bool any_base_has_weakref_slot(PyObject * bases);
+bool any_base_diverts_setattro(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);
 bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
@@ -69,6 +70,7 @@ struct binding_plan binding_plan(
 	struct options options,
 	struct options inherited,
 	bool frozen_across_bases,
+	bool bases_divert_setattro,
 	bool body_defines_eq,
 	bool inherits_body_eq,
 	bool derive_not_equal,

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -39,6 +39,7 @@ static enum result apply_options(
 	struct options options,
 	struct options inherited,
 	bool frozen_across_bases,
+	bool bases_divert_setattro,
 	bool body_defines_eq,
 	bool inherits_body_eq,
 	bool derive_not_equal
@@ -87,6 +88,7 @@ PyObject * build_class_namespace(
 				options,
 				inherited,
 				frozen_across_bases,
+				any_base_diverts_setattro(bases),
 				body_defines_eq,
 				inherits_body_eq,
 				derive_not_equal
@@ -318,6 +320,7 @@ struct binding_plan binding_plan(
 	struct options const options,
 	struct options const inherited,
 	bool const frozen_across_bases,
+	bool const bases_divert_setattro,
 	bool const body_defines_eq,
 	bool const inherits_body_eq,
 	bool const derive_not_equal,
@@ -329,7 +332,11 @@ struct binding_plan binding_plan(
 		.rebind_comparison = options.eq != inherited.eq,
 		.rebind_not_equal = options.eq != inherited.eq && !(body_defines_eq || derive_not_equal),
 		.rebind_representation = options.repr != inherited.repr,
-		.rebind_mutability = options.frozen != inherited.frozen || frozen_across_bases,
+		.rebind_mutability = (
+			options.frozen != inherited.frozen ||
+			frozen_across_bases ||
+			(options.frozen && bases_divert_setattro)
+		),
 		.match_args_wanted = options.match_args,
 	};
 
@@ -351,6 +358,7 @@ static enum result apply_options(
 	struct options const options,
 	struct options const inherited,
 	bool const frozen_across_bases,
+	bool const bases_divert_setattro,
 	bool const body_defines_eq,
 	bool const inherits_body_eq,
 	bool const derive_not_equal
@@ -366,6 +374,7 @@ static enum result apply_options(
 		options,
 		inherited,
 		frozen_across_bases,
+		bases_divert_setattro,
 		body_defines_eq,
 		inherits_body_eq,
 		derive_not_equal,

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -70,6 +70,7 @@ PyObject * build_class_namespace(
 	PyObject * const bases,
 	struct options const inherited,
 	bool const frozen_across_bases,
+	bool const bases_divert_setattro,
 	bool const body_defines_eq,
 	bool const inherits_body_eq,
 	bool const derive_not_equal
@@ -88,7 +89,7 @@ PyObject * build_class_namespace(
 				options,
 				inherited,
 				frozen_across_bases,
-				any_base_diverts_setattro(bases),
+				bases_divert_setattro,
 				body_defines_eq,
 				inherits_body_eq,
 				derive_not_equal

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from values import EVERY, identify
 
@@ -187,6 +189,93 @@ def test_a_frozen_child_of_a_frozen_base_holds_beside_a_permissive_co_base():
 
         with pytest.raises(TypeError, match="does not support attribute"):
             del Child(1).x
+
+
+def test_a_frozen_setattr_escape_beside_a_permissive_co_base_keeps_answering():
+    """The body's own half is the escape; the pre-creation rebind skips it
+    and injects the other half, which stays refused, in either order. An
+    escape written by a base is shadowed by the child's injected half, the
+    same way the post-hoc repair shadowed it before."""
+
+    class Permissive:
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+        def __delattr__(self, name: str) -> None:
+            object.__delattr__(self, name)
+
+    class FrozenBase(Struct, frozen=True):
+        x: int
+
+    class EscapedAhead(Permissive, FrozenBase):
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    class EscapedBehind(FrozenBase, Permissive):
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    for Child in (EscapedAhead, EscapedBehind):
+        if sys.version_info >= (3, 13):
+            instance = Child(1)
+            instance.x = 9
+
+            assert instance.x == 9
+
+            with pytest.raises(TypeError, match="does not support attribute"):
+                del instance.x
+        else:
+            # The parent build refuses the escape the same way on 3.10-3.12:
+            # the mixed wrapper/function slot derivation lands on a slot the
+            # body's own half cannot answer. Parity, not a promise.
+            with pytest.raises(TypeError):
+                Child(1).x = 9
+
+            with pytest.raises(TypeError):
+                del Child(1).x
+
+    class Escaping(FrozenBase):
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    class InheritedAhead(Permissive, Escaping):
+        pass
+
+    with pytest.raises(TypeError, match="does not support attribute"):
+        InheritedAhead(1).x = 9
+
+
+def test_a_frozen_delattr_escape_beside_a_permissive_co_base_keeps_answering():
+    class Permissive:
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+        def __delattr__(self, name: str) -> None:
+            object.__delattr__(self, name)
+
+    class FrozenBase(Struct, frozen=True):
+        x: int
+
+    class EscapedAhead(Permissive, FrozenBase):
+        def __delattr__(self, name: str) -> None:
+            object.__delattr__(self, name)
+
+    class EscapedBehind(FrozenBase, Permissive):
+        def __delattr__(self, name: str) -> None:
+            object.__delattr__(self, name)
+
+    for Child in (EscapedAhead, EscapedBehind):
+        if sys.version_info >= (3, 13):
+            del Child(1).x
+
+            with pytest.raises(TypeError, match="does not support attribute"):
+                Child(1).x = 9
+        else:
+            with pytest.raises(TypeError):
+                del Child(1).x
+
+            with pytest.raises(TypeError):
+                Child(1).x = 9
 
 
 def test_a_fieldless_frozen_base_promises_nothing_to_a_mutable_class():

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -160,6 +160,35 @@ def test_frozen_true_over_a_mutable_base_holds_beside_a_permissive_co_base():
             del Child(1).x
 
 
+def test_a_frozen_child_of_a_frozen_base_holds_beside_a_permissive_co_base():
+    """No option transition fires the rebind, so a co-base whose own
+    __setattr__ slot would answer is met pre-creation: the namespace is born
+    with the block's wrappers, and CPython's slot inheritance lands on them
+    in either order."""
+
+    class Permissive:
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    class FrozenBase(Struct, frozen=True):
+        x: int
+
+    class Ahead(Permissive, FrozenBase):
+        pass
+
+    class Behind(FrozenBase, Permissive):
+        pass
+
+    for Child in (Ahead, Behind):
+        assert "__setattr__" in Child.__dict__
+
+        with pytest.raises(TypeError, match="does not support attribute"):
+            Child(1).x = 9
+
+        with pytest.raises(TypeError, match="does not support attribute"):
+            del Child(1).x
+
+
 def test_a_fieldless_frozen_base_promises_nothing_to_a_mutable_class():
     """A fieldless frozen base made no promise, so frozen=False over one is
     free, in either order."""


### PR DESCRIPTION
# The frozen column's wrappers land pre-creation; no post-hoc slot surgery

Fixes #112 (the frozen-column repair residue from #77's round 6).

## Round 2 — converged (score 0.14), disposition recorded

<details>
<summary>The re-entered-build minor, refuted by measurement on both sides</summary>

Round 2's minor feared that in a re-entered build the injected `__setattr__` is misread as a body definition, flipping the inner frame's hash plan to `HASH_NONE` and leaving the class unhashable. Measured the exact configuration (foreign-metaclass handoff that re-enters, frozen, diverting co-base, `hash()` checked):

- **This branch**: builds, `__hash__` in the dict is the mixin's wrapper, `hash()` works, writes refused — the outer settle's `HASH_BIND` arm (computed from the true body) repairs the inner frame's `__hash__ = None` before the class escapes, exactly as the settle design intends.
- **The parent (main)**: the same configuration is **refused outright** (`"returned a struct class this call did not plan"`).

So the branch turns a refusal into a correct, hashable, frozen build; the feared unhashable end state does not occur on any path.
</details>

<details>
<summary>The mechanism-pin nit, confirmed by mutation — residue filed</summary>

Round 2's nit claimed reverting the arm leaves every new test green. Confirmed by mutation on this branch: with `carries_diverting_setattro` forced to `false`, the C suite stays 26/26 — in that construction the parent's post-hoc repair fires and writes the same wrapper into the dict, so the end-state assertions (dict presence, slot pointer, refusals) cannot distinguish the two mechanisms. The discriminating pin is a pre-repair-state observation (e.g. a TESTING flag set when the repair block runs, asserted never for the divert scenario), which is exactly the kind of code change the convergence rule stops me from making on a converged round. Filed as the residue issue; recorded here as the scope decision.
</details>

## Round 1

<details>
<summary>What was measured first, and the original change</summary>

Measured before choosing the arm: the dict write **does** update `tp_setattro` on 3.10–3.14 (probed by assigning `object.__setattr__` and checking the write goes through the C descriptor — an earlier probe read an unchanged helper field and wrongly said no). So the repair worked everywhere today; the reliance itself was the defect. Also: the old C pin's construction never fired the repair at all. The fix: a third `rebind_mutability` arm — a frozen class with any base whose `tp_setattro` is neither the mixin's nor object's is born with the wrappers in its namespace, so slot inheritance is correct by construction on every version. The repair stays as defense. C pin extended (wrapper presence in the frozen child's dict, absence in the mutable child's), plus the no-transition divert pin, both orders.
</details>

<details>
<summary>The slot-reliance finding: the mechanism, documented with the source</summary>

The direct slot comes from `update_one_slot` (Objects/typeobject.c, byte-identical across 3.10.11/3.11.9/3.12.3/3.13.1/3.14.0): a namespace entry that is a `PyWrapperDescr` whose `d_base` is a type the new class is a subtype of, with matching `name_strobj` and `wrapper` signature, installs the wrapper's raw C slot (`specific = d->d_wrapped`); anything else falls back to `slot_tp_setattro`. Every struct class is a `_StructMixin` subtype, so the direct slot lands; the round-1 probe that observed `slot_tp_setattro` built its class over a non-mixin base, which fails the subtype condition by construction. The fallback also preserves behavior — the generic slot dispatches through the dict to the same injected wrapper — so the worst case is slower dispatch, never a diverted column. The behavior is pinned per-interpreter in CI by the pytest matrix; the C suite runs 26/26 on 3.10–3.14 locally. Retiring the dependency class entirely would require CPython to document its slot derivation; salix pins the behavior instead.
</details>

## Verification

- pytest: 1237 passed on 3.14; green on 3.10/3.11/3.12/3.13/3.14 + 3.14t; scoped gate green; full 3.12 matrix 15/15.
- C TESTING suite: **26/26 on 3.10, 3.11, 3.12, 3.13, 3.14**.

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: resolve the #112 residue with the pre-creation arm, measure the repair's premise per interpreter first, and answer the review rounds with the mechanism documented and the residue filed.
