### PR TITLE
Pin the arm, not the end state: the repair must not fire for the divert scenario

### DIFF
--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -20,6 +20,10 @@
 #include "../types.h"
 #include "../hash.h"
 
+#ifdef TESTING
+static bool frozen_column_repair_fired = false;
+#endif
+
 static StructType * create_class(
 	PyTypeObject * metatype,
 	PyTypeObject * handoff,
@@ -878,6 +882,9 @@ static enum result settle_mro_bindings(
 	 * CPython's own dispatch honours hooks and foreign C-level slots exactly
 	 * as it does for plain classes. */
 	if (options.frozen && type->tp_setattro != StructMixin_Type.tp_setattro) {
+#ifdef TESTING
+		frozen_column_repair_fired = true;
+#endif
 		if (settle_rebind(struct_class, original_namespace, rebind_mutability, true) != RESULT_OK) {
 			return RESULT_ERROR;
 		}
@@ -1535,6 +1542,24 @@ static PyObject * struct_class_with_field(PyObject * bases, PyObject * keywords)
 	return PyObject_Call((PyObject *) &StructMeta_Type, args, keywords);
 }
 
+static PyObject * struct_class_with_body_setattr(PyObject * bases) {
+	PY_OWNED(name, PyUnicode_FromString("Built"));
+	PY_OWNED(namespace, PyDict_New());
+	PY_OWNED(annotations, PyDict_New());
+
+	if (
+		PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type) < 0 ||
+		PyDict_SetItemString(namespace, "__annotations__", annotations) < 0 ||
+		PyDict_SetItemString(namespace, "__setattr__", Py_None) < 0
+	) {
+		return NULL;
+	}
+
+	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
+
+	return PyObject_Call((PyObject *) &StructMeta_Type, args, NULL);
+}
+
 static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void) {
 	TEST_ASSERT_EQUAL_INT(0, PyType_Ready(&SwallowingType));
 
@@ -1571,9 +1596,11 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PY_OWNED(frozen_base, struct_class_with_field(struct_bases, NULL));
 	TEST_ASSERT_NOT_NULL(frozen_base);
 
+	frozen_column_repair_fired = false;
 	PY_OWNED(frozen_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, frozen_base));
 	PY_OWNED(frozen_child, struct_class_with_field(frozen_bases, NULL));
 	TEST_ASSERT_NOT_NULL(frozen_child);
+	TEST_ASSERT_FALSE(frozen_column_repair_fired);
 	TEST_ASSERT_EQUAL_PTR(
 		StructMixin_Type.tp_setattro,
 		((PyTypeObject *) frozen_child)->tp_setattro
@@ -1582,6 +1609,11 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 		1,
 		dict_has_string(((PyTypeObject *) frozen_child)->tp_dict, "__setattr__")
 	);
+
+	frozen_column_repair_fired = false;
+	PY_OWNED(escaped_child, struct_class_with_body_setattr(frozen_bases));
+	TEST_ASSERT_NOT_NULL(escaped_child);
+	TEST_ASSERT_TRUE(frozen_column_repair_fired);
 
 	PY_OWNED(frozen_instance, PyObject_CallFunction(frozen_child, "i", 1));
 	TEST_ASSERT_NOT_NULL(frozen_instance);

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -21,7 +21,7 @@
 #include "../hash.h"
 
 #ifdef TESTING
-static bool frozen_column_repair_fired = false;
+static PyTypeObject * frozen_column_repair_owner = NULL;
 #endif
 
 static StructType * create_class(
@@ -883,7 +883,7 @@ static enum result settle_mro_bindings(
 	 * as it does for plain classes. */
 	if (options.frozen && type->tp_setattro != StructMixin_Type.tp_setattro) {
 #ifdef TESTING
-		frozen_column_repair_fired = true;
+		frozen_column_repair_owner = type;
 #endif
 		if (settle_rebind(struct_class, original_namespace, rebind_mutability, true) != RESULT_OK) {
 			return RESULT_ERROR;
@@ -1525,24 +1525,11 @@ static PyTypeObject SwallowingType = {
 	.tp_setattro = swallowing_setattro,
 };
 
-static PyObject * struct_class_with_field(PyObject * bases, PyObject * keywords) {
-	PY_OWNED(name, PyUnicode_FromString("Built"));
-	PY_OWNED(namespace, PyDict_New());
-	PY_OWNED(annotations, PyDict_New());
-
-	if (
-		PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type) < 0 ||
-		PyDict_SetItemString(namespace, "__annotations__", annotations) < 0
-	) {
-		return NULL;
-	}
-
-	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
-
-	return PyObject_Call((PyObject *) &StructMeta_Type, args, keywords);
-}
-
-static PyObject * struct_class_with_body_setattr(PyObject * bases) {
+static PyObject * struct_class_with_field(
+	PyObject * bases,
+	PyObject * keywords,
+	bool const body_setattr
+) {
 	PY_OWNED(name, PyUnicode_FromString("Built"));
 	PY_OWNED(namespace, PyDict_New());
 	PY_OWNED(annotations, PyDict_New());
@@ -1550,14 +1537,14 @@ static PyObject * struct_class_with_body_setattr(PyObject * bases) {
 	if (
 		PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type) < 0 ||
 		PyDict_SetItemString(namespace, "__annotations__", annotations) < 0 ||
-		PyDict_SetItemString(namespace, "__setattr__", Py_None) < 0
+		(body_setattr && PyDict_SetItemString(namespace, "__setattr__", Py_None) < 0)
 	) {
 		return NULL;
 	}
 
 	PY_OWNED(args, PyTuple_Pack(3, name, bases, namespace));
 
-	return PyObject_Call((PyObject *) &StructMeta_Type, args, NULL);
+	return PyObject_Call((PyObject *) &StructMeta_Type, args, keywords);
 }
 
 static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void) {
@@ -1573,11 +1560,11 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	PY_OWNED(mutable_keywords, PyDict_New());
 	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItemString(mutable_keywords, "frozen", Py_False));
 
-	PY_OWNED(mutable_base, struct_class_with_field(struct_bases, mutable_keywords));
+	PY_OWNED(mutable_base, struct_class_with_field(struct_bases, mutable_keywords, false));
 	TEST_ASSERT_NOT_NULL(mutable_base);
 
 	PY_OWNED(raw_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, mutable_base));
-	PY_OWNED(mutable_child, struct_class_with_field(raw_bases, NULL));
+	PY_OWNED(mutable_child, struct_class_with_field(raw_bases, NULL, false));
 	TEST_ASSERT_NOT_NULL(mutable_child);
 	TEST_ASSERT_EQUAL_INT(
 		0,
@@ -1593,14 +1580,14 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 	TEST_ASSERT_EQUAL_INT(0, PyObject_DelAttr(instance, field_name));
 	TEST_ASSERT_EQUAL_INT(2, swallow_calls);
 
-	PY_OWNED(frozen_base, struct_class_with_field(struct_bases, NULL));
+	PY_OWNED(frozen_base, struct_class_with_field(struct_bases, NULL, false));
 	TEST_ASSERT_NOT_NULL(frozen_base);
 
-	frozen_column_repair_fired = false;
+	frozen_column_repair_owner = NULL;
 	PY_OWNED(frozen_bases, PyTuple_Pack(2, (PyObject *) &SwallowingType, frozen_base));
-	PY_OWNED(frozen_child, struct_class_with_field(frozen_bases, NULL));
+	PY_OWNED(frozen_child, struct_class_with_field(frozen_bases, NULL, false));
 	TEST_ASSERT_NOT_NULL(frozen_child);
-	TEST_ASSERT_FALSE(frozen_column_repair_fired);
+	TEST_ASSERT_EQUAL_PTR(NULL, frozen_column_repair_owner);
 	TEST_ASSERT_EQUAL_PTR(
 		StructMixin_Type.tp_setattro,
 		((PyTypeObject *) frozen_child)->tp_setattro
@@ -1610,10 +1597,15 @@ static void test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot(void)
 		dict_has_string(((PyTypeObject *) frozen_child)->tp_dict, "__setattr__")
 	);
 
-	frozen_column_repair_fired = false;
-	PY_OWNED(escaped_child, struct_class_with_body_setattr(frozen_bases));
+	frozen_column_repair_owner = NULL;
+	PY_OWNED(escaped_child, struct_class_with_field(frozen_bases, NULL, true));
 	TEST_ASSERT_NOT_NULL(escaped_child);
-	TEST_ASSERT_TRUE(frozen_column_repair_fired);
+	TEST_ASSERT_EQUAL_PTR((PyObject *) escaped_child, (PyObject *) frozen_column_repair_owner);
+
+	PY_OWNED(escaped_instance, PyObject_CallFunction(escaped_child, "i", 1));
+	TEST_ASSERT_NOT_NULL(escaped_instance);
+	TEST_ASSERT_EQUAL_INT(-1, PyObject_DelAttr(escaped_instance, field_name));
+	PyErr_Clear();
 
 	PY_OWNED(frozen_instance, PyObject_CallFunction(frozen_child, "i", 1));
 	TEST_ASSERT_NOT_NULL(frozen_instance);
@@ -1657,7 +1649,7 @@ static void test_a_later_bases_slot_forces_the_record(void) {
 	PY_OWNED(weak_base, struct_class_empty(struct_bases, weak_keywords));
 	TEST_ASSERT_NOT_NULL(weak_base);
 
-	PY_OWNED(plain_base, struct_class_with_field(struct_bases, NULL));
+	PY_OWNED(plain_base, struct_class_with_field(struct_bases, NULL, false));
 	TEST_ASSERT_NOT_NULL(plain_base);
 
 	PY_OWNED(mixed_bases, PyTuple_Pack(2, plain_base, weak_base));


### PR DESCRIPTION
# The C suite pins the arm, not its end state

Fixes #123 (the round-2 nit of #122, confirmed by mutation).

## Round 2 — converged (score 0.18), disposition recorded

<details>
<summary>The effect-pin claim, re-worded to what the pin actually asserts</summary>

Round 2's minor is accepted with a corrected claim. The reviewer's 3.12 experiments show: with the repair's `from_mixin` flipped, the delete still returns -1 — object's `__delattr__` wrapper raises a *different* TypeError ("can't apply this __delattr__") on 3.12, while on 3.14 the same mutation returns 0; and deleting the repair body entirely leaves the suite green because the arm's own pre-creation injection already bound the mixin's `__delattr__`, producing the identical end state. The earlier PR-body claim ("the delete succeeds") was true only on 3.14 and is withdrawn.

What the positive control does pin, per the reviewer's suggested re-wording: **the arm's other-half binding and the repair's entry** — the owner attribution and the refusal end state. The repair's *unique* contribution (its rebinding on re-entered builds) is observable only on the re-entered path and is deliberately out of this PR's scope; the negative half — arm off → 1 failure on the owner pin — reproduces on the reviewer's checkout.
</details>

<details>
<summary>The borrowed-owner nit, recorded</summary>

The TESTING owner flag stores a borrowed pointer to the class the repair ran for. It is never dereferenced — only compared and reset before the owning PY_OWNED scope frees the class — so the dangle is latent, not live. Recorded; a future pin iteration should take a reference.
</details>

## Round 1

<details>
<summary>The systemic and its answer</summary>

Round 1's systemic (`test-pin-records-firing-only`) held that the flag recorded only that *some* repair block ran. Answered: the flag became the owner type (provenance — the divert build asserts no repair fired for it at all), the positive control asserts the repair fired for exactly the escaped child and that the other half refuses (effect, per the round-2 re-wording), and the duplicated helper was folded into `struct_class_with_field`'s `body_setattr` flag. Mutation-verified: arm off → 1 failure on the owner pin.
</details>

<details>
<summary>Boundary: the sibling clauses</summary>

The pin covers the clause this PR added (the divert arm). The other two `rebind_mutability` clauses — the option transition and `frozen_across_bases` — keep their pre-existing end-state pins, and the repair masking a regression in *them* predates this PR; extending the mechanism pin to those clauses is out of scope, recorded.
</details>

## Verification

- C TESTING suite: 26/26 on 3.10–3.14; c_test green in the 3.12 matrix.
- pytest: 1237 passed on 3.14; full 3.12 matrix 15/15; scoped gate green.

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: resolve the #123 residue with the pre-repair-state pin, mutation-check it, answer the review rounds, and record the re-worded effect-pin claim and the dangling-owner note.
