### PR TITLE
Pin the re-entered sweep, and let the settle table pin itself

### DIFF
--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -22,6 +22,7 @@
 
 #ifdef TESTING
 static PyTypeObject * frozen_column_repair_owner = NULL;
+static bool settle_sweep_refused = false;
 #endif
 
 static StructType * create_class(
@@ -123,6 +124,33 @@ static char const * const * const settle_tables[] = {
 	NULL,
 };
 
+static void for_each_settle_name(
+	void (*visit)(char const * const name, void * const context),
+	void * const context
+) {
+	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
+		for (char const * const * name = *tables; *name != NULL; name += 1) {
+			visit(*name, context);
+		}
+	}
+}
+
+struct sweep_state {
+	PyObject * namespace;
+	bool failed;
+};
+
+static void probe_settle_name(char const * const name, void * const context) {
+	struct sweep_state * const state = context;
+
+	if (!state->failed && dict_has_string(state->namespace, name) < 0) {
+#ifdef TESTING
+		settle_sweep_refused = true;
+#endif
+		state->failed = true;
+	}
+}
+
 /* An exact-str key answers a probe by identity or in C, so a namespace of
  * them cannot fail the sweep; anything else might. The sweep is what turns
  * a poisoned lookup into a propagated error before type.__new__ misreads it
@@ -134,19 +162,11 @@ static enum result verify_settle_names_readable(PyObject * const original_namesp
 
 	while (PyDict_Next(original_namespace, &position, &key, &value)) {
 		if (!PyUnicode_CheckExact(key)) {
-			for (
-				char const * const * const * tables = settle_tables;
-				*tables != NULL;
-				tables += 1
-			) {
-				for (char const * const * name = *tables; *name != NULL; name += 1) {
-					if (dict_has_string(original_namespace, *name) < 0) {
-						return RESULT_ERROR;
-					}
-				}
-			}
+			struct sweep_state state = {.namespace = original_namespace, .failed = false};
 
-			return RESULT_OK;
+			for_each_settle_name(probe_settle_name, &state);
+
+			return state.failed ? RESULT_ERROR : RESULT_OK;
 		}
 	}
 
@@ -1662,6 +1682,44 @@ static void test_a_later_bases_slot_forces_the_record(void) {
 	TEST_ASSERT_TRUE(carries_weakref_slot((PyTypeObject *) mixed_child));
 }
 
+struct hostile_probe_state {
+	PyObject * hostile_class;
+	PyObject * bases;
+	PyObject * class_name;
+};
+
+static void probe_a_hostile_settle_name(char const * const name, void * const context) {
+	struct hostile_probe_state const * const state = context;
+
+	PY_OWNED(namespace, PyDict_New());
+	PY_OWNED(annotations, PyDict_New());
+	PY_OWNED(hostile_key, PyObject_CallFunction(state->hostile_class, "s", name));
+	TEST_ASSERT_NOT_NULL(namespace);
+	TEST_ASSERT_NOT_NULL(annotations);
+	TEST_ASSERT_NOT_NULL(hostile_key);
+
+	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type));
+	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItemString(namespace, "__annotations__", annotations));
+	TEST_ASSERT_EQUAL_INT(0, PyDict_SetItem(namespace, hostile_key, Py_True));
+
+	PY_OWNED(args, PyTuple_Pack(3, state->class_name, state->bases, namespace));
+	TEST_ASSERT_NOT_NULL(args);
+
+	settle_sweep_refused = false;
+	PY_OWNED(built, PyObject_Call((PyObject *) &StructMeta_Type, args, NULL));
+	TEST_ASSERT_NULL(built);
+
+	PyObject * exception_type;
+	PyObject * exception_value;
+	PyObject * traceback;
+	PyErr_Fetch(&exception_type, &exception_value, &traceback);
+	TEST_ASSERT_TRUE(PyErr_GivenExceptionMatches(exception_value, PyExc_ValueError));
+	TEST_ASSERT_TRUE(settle_sweep_refused);
+	Py_XDECREF(exception_type);
+	Py_XDECREF(exception_value);
+	Py_XDECREF(traceback);
+}
+
 static void test_every_settle_name_refuses_a_hostile_key(void) {
 	PY_OWNED(
 		hostile_class,
@@ -1687,27 +1745,13 @@ static void test_every_settle_name_refuses_a_hostile_key(void) {
 	PY_OWNED(class_name, PyUnicode_FromString("Hostile"));
 	TEST_ASSERT_NOT_NULL(class_name);
 
-	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
-		for (char const * const * name = *tables; *name != NULL; name += 1) {
-			PY_OWNED(namespace, PyDict_New());
-			PY_OWNED(annotations, PyDict_New());
-			PY_OWNED(hostile_key, PyObject_CallFunction(hostile_class, "s", *name));
+	struct hostile_probe_state const state = {
+		.hostile_class = hostile_class,
+		.bases = bases,
+		.class_name = class_name,
+	};
 
-			if (
-				PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type) < 0 ||
-				PyDict_SetItemString(namespace, "__annotations__", annotations) < 0 ||
-				PyDict_SetItem(namespace, hostile_key, Py_True) < 0
-			) {
-				TEST_FAIL();
-			}
-
-			PY_OWNED(args, PyTuple_Pack(3, class_name, bases, namespace));
-			PY_OWNED(built, PyObject_Call((PyObject *) &StructMeta_Type, args, NULL));
-			TEST_ASSERT_NULL(built);
-			TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_ValueError));
-			PyErr_Clear();
-		}
-	}
+	for_each_settle_name(probe_a_hostile_settle_name, (void *) &state);
 }
 
 void class_tests(void) {

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -1662,12 +1662,61 @@ static void test_a_later_bases_slot_forces_the_record(void) {
 	TEST_ASSERT_TRUE(carries_weakref_slot((PyTypeObject *) mixed_child));
 }
 
+static void test_every_settle_name_refuses_a_hostile_key(void) {
+	PY_OWNED(
+		hostile_class,
+		testing_evaluate(
+			"class HostileKey(str):\n"
+			"    __hash__ = str.__hash__\n"
+			"    def __eq__(self, other):\n"
+			"        raise ValueError('nope')\n"
+			"result = HostileKey\n"
+		)
+	);
+	TEST_ASSERT_NOT_NULL(hostile_class);
+
+	PY_OWNED(salix, PyImport_ImportModule("salix"));
+	TEST_ASSERT_NOT_NULL(salix);
+
+	PY_OWNED(struct_base, PyObject_GetAttrString(salix, "Struct"));
+	TEST_ASSERT_NOT_NULL(struct_base);
+
+	PY_OWNED(bases, PyTuple_Pack(1, struct_base));
+	TEST_ASSERT_NOT_NULL(bases);
+
+	PY_OWNED(class_name, PyUnicode_FromString("Hostile"));
+	TEST_ASSERT_NOT_NULL(class_name);
+
+	for (char const * const * const * tables = settle_tables; *tables != NULL; tables += 1) {
+		for (char const * const * name = *tables; *name != NULL; name += 1) {
+			PY_OWNED(namespace, PyDict_New());
+			PY_OWNED(annotations, PyDict_New());
+			PY_OWNED(hostile_key, PyObject_CallFunction(hostile_class, "s", *name));
+
+			if (
+				PyDict_SetItemString(annotations, "x", (PyObject *) &PyLong_Type) < 0 ||
+				PyDict_SetItemString(namespace, "__annotations__", annotations) < 0 ||
+				PyDict_SetItem(namespace, hostile_key, Py_True) < 0
+			) {
+				TEST_FAIL();
+			}
+
+			PY_OWNED(args, PyTuple_Pack(3, class_name, bases, namespace));
+			PY_OWNED(built, PyObject_Call((PyObject *) &StructMeta_Type, args, NULL));
+			TEST_ASSERT_NULL(built);
+			TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_ValueError));
+			PyErr_Clear();
+		}
+	}
+}
+
 void class_tests(void) {
 	/* Unity takes its file from UNITY_BEGIN, which is the runner's. */
 	Unity.TestFile = __FILE__;
 
 	RUN_TEST(test_a_raw_tp_setattro_co_base_does_not_divert_the_struct_slot);
 	RUN_TEST(test_a_later_bases_slot_forces_the_record);
+	RUN_TEST(test_every_settle_name_refuses_a_hostile_key);
 }
 
 #endif

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1152,7 +1152,7 @@ def test_a_hostile_key_injected_during_the_reentered_handoff_propagates():
 
     class Injecting(META):
         def __new__(cls, name, bases, namespace, **kwargs):
-            if kwargs:
+            if "__slots__" in namespace:
                 namespace[HostileKey("__init__")] = 1
 
             return super().__new__(cls, name, bases, namespace, **kwargs)

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -1142,3 +1142,23 @@ def test_a_hostile_key_injected_by_a_metaclass_new_propagates():
     with pytest.raises(ValueError, match="nope"):
         class Base(Struct, metaclass=Injecting):
             x: int
+
+
+def test_a_hostile_key_injected_during_the_reentered_handoff_propagates():
+    """The injection above lands before the first build frame; this one lands
+    between the outer frame's sweep and the re-entered frame's, so only the
+    re-entered frame's sweep can refuse it.
+    """
+
+    class Injecting(META):
+        def __new__(cls, name, bases, namespace, **kwargs):
+            if kwargs:
+                namespace[HostileKey("__init__")] = 1
+
+            return super().__new__(cls, name, bases, namespace, **kwargs)
+
+    class Base(Struct, metaclass=Injecting):
+        x: int
+
+    with pytest.raises(ValueError, match="nope"):
+        META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)


### PR DESCRIPTION
# The hostile-key pins: the re-entered frame is pinned, and the table pins itself

Fixes #121 (the #120 round-4 residue).

## Round 2 — converged (score 0), disposition recorded

<details>
<summary>The four nits, recorded</summary>

- **`given-exception-matches-null-deref`**: on the pin's own red path — the build unexpectedly succeeding — `PyErr_Fetch` yields NULLs and `PyErr_GivenExceptionMatches(NULL, ...)` dereferences. Test-code, red-path only; the first thing any future iteration of this pin should do is assert `exception_value != NULL` before matching.
- **`table-walker-not-generalized`**: `restore_stripped`'s identical two-level table walk could share the walker; left as-is to keep this PR's scope.
- **`per-name-attribution-untagged`**: the flag is a bare bool, so each iteration proves "some settle probe refused", not that the probed name's own probe did — the backstop analysis makes the bool sufficient today (no other settle-name probe runs before the sweep in this build shape), and tagging the name is the natural upgrade if the shape ever changes.
- **`injection-site-shadows-sweep`**: the Python pin's injection is itself a dict insert with the hostile key, which would raise the same `ValueError` if the built namespace ever gained an `__init__`-hash key — that hypothetical would un-pin the sweep and should be revisited alongside any built-namespace change.
</details>

## Round 1 — the systemic and its answer

<details>
<summary>Mechanism attribution, by construction</summary>

Round 1's systemic (`outcome-pins-not-mechanism-pins`) held that both pins assert the refusal outcome, which adjacent probes can produce without the mechanism. Answered: the sweep and the pin share one `for_each_settle_name` walker (the tie is by construction), a TESTING flag records when the sweep itself refuses and the pin asserts it per entry (sweep disabled → the C suite fails, mutation-verified, even for `__eq__`/`__hash__`/`__setattr__` whose later probes mask it), the Python pin's gate reads the built namespace's `__slots__` — a mark only the outer frame's construction carries — and the hygiene nits (NULL checks, portable `PyErr_Fetch` + `GivenExceptionMatches`) were applied.
</details>

## Verification

- C TESTING suite: 27/27 on 3.10–3.14; c_test green in the 3.12 matrix.
- pytest: 1238 passed on 3.14; full 3.12 matrix 15/15; scoped gate green.

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: resolve the #121 residue with the re-entered-sweep pin and the C table walk, answer the review rounds with mechanism attribution, and record the converged round's nits.
