### PR TITLE
The comparison repair rebinds per name, so honoured body ordering dunders survive

### DIFF
--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -704,16 +704,11 @@ static int struct_base_count(PyObject * const bases) {
 	return count;
 }
 
-static PyInterpreterState * binding_interpreter = NULL;
 static PyObject * mixin_bindings[7];
 static PyObject * object_bindings[7];
-struct settle_targets {
-	PyObject * const * mixin;
-	PyObject * const * object;
-	bool readable;
-};
-
-static struct settle_targets settle_candidates(void) {
+/* Filled once at module init, before any class can be built, so the settle
+ * only ever reads these: no post-init mutation, no keying, no lock. */
+void settle_cache_fill(void) {
 	static char const * const names[7] = {
 		"__eq__",
 		"__ne__",
@@ -724,25 +719,19 @@ static struct settle_targets settle_candidates(void) {
 		"__repr__",
 	};
 
-	if (binding_interpreter != PyInterpreterState_Get()) {
-		for (Py_ssize_t i = 0; i < 7; ++i) {
-			Py_CLEAR(mixin_bindings[i]);
-			Py_CLEAR(object_bindings[i]);
-		}
-
-		binding_interpreter = PyInterpreterState_Get();
-	}
-
 	for (Py_ssize_t i = 0; i < 7; ++i) {
-		if (mixin_bindings[i] == NULL) {
-			mixin_bindings[i] = PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i]);
-		}
-
-		if (object_bindings[i] == NULL) {
-			object_bindings[i] = PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, names[i]);
-		}
+		mixin_bindings[i] = PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i]);
+		object_bindings[i] = PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, names[i]);
 	}
+}
 
+struct settle_targets {
+	PyObject * const * mixin;
+	PyObject * const * object;
+	bool readable;
+};
+
+static struct settle_targets settle_candidates(void) {
 	for (Py_ssize_t i = 0; i < 7; ++i) {
 		if (mixin_bindings[i] == NULL || object_bindings[i] == NULL) {
 			return (struct settle_targets){.readable = false};
@@ -789,24 +778,72 @@ static enum result mro_dunders_of(
 	PyObject * * const resolved_repr,
 	PyTypeObject * * const eq_owner,
 	PyTypeObject * * const ne_owner,
-	PyTypeObject * * const repr_owner
+	PyTypeObject * * const repr_owner,
+	PyObject * * const resolved_lt,
+	PyObject * * const resolved_le,
+	PyObject * * const resolved_gt,
+	PyObject * * const resolved_ge,
+	PyTypeObject * * const lt_owner,
+	PyTypeObject * * const le_owner,
+	PyTypeObject * * const gt_owner,
+	PyTypeObject * * const ge_owner
 ) {
 	*resolved_eq = NULL;
 	*resolved_ne = NULL;
 	*resolved_repr = NULL;
+	*resolved_lt = NULL;
+	*resolved_le = NULL;
+	*resolved_gt = NULL;
+	*resolved_ge = NULL;
 	*eq_owner = NULL;
 	*ne_owner = NULL;
 	*repr_owner = NULL;
+	*lt_owner = NULL;
+	*le_owner = NULL;
+	*gt_owner = NULL;
+	*ge_owner = NULL;
 
 	PY_OWNED(eq_name, PyUnicode_InternFromString("__eq__"));
 	PY_OWNED(ne_name, PyUnicode_InternFromString("__ne__"));
 	PY_OWNED(repr_name, PyUnicode_InternFromString("__repr__"));
+	PY_OWNED(lt_name, PyUnicode_InternFromString("__lt__"));
+	PY_OWNED(le_name, PyUnicode_InternFromString("__le__"));
+	PY_OWNED(gt_name, PyUnicode_InternFromString("__gt__"));
+	PY_OWNED(ge_name, PyUnicode_InternFromString("__ge__"));
 
-	if (eq_name == NULL || ne_name == NULL || repr_name == NULL) {
+	if (
+		eq_name == NULL ||
+		ne_name == NULL ||
+		repr_name == NULL ||
+		lt_name == NULL ||
+		le_name == NULL ||
+		gt_name == NULL ||
+		ge_name == NULL
+	) {
 		return RESULT_ERROR;
 	}
 
 	PyObject * const mro = type->tp_mro;
+
+	/* The ordering names read the class's own dict too: a pre-creation
+	 * rebind injected the comparison family there on an eq-option change,
+	 * and the honoured-body decision must see that injection rather than
+	 * decide behind its back. */
+	PyTypeObject * const own = (PyTypeObject *) PyTuple_GET_ITEM(mro, 0);
+	PY_OWNED(own_dict, struct_type_dict(own));
+
+	if (own_dict == NULL) {
+		return RESULT_ERROR;
+	}
+
+	if (
+		resolve_dunder(own_dict, lt_name, resolved_lt, own, lt_owner) != RESULT_OK ||
+		resolve_dunder(own_dict, le_name, resolved_le, own, le_owner) != RESULT_OK ||
+		resolve_dunder(own_dict, gt_name, resolved_gt, own, gt_owner) != RESULT_OK ||
+		resolve_dunder(own_dict, ge_name, resolved_ge, own, ge_owner) != RESULT_OK
+	) {
+		return RESULT_ERROR;
+	}
 
 	for (Py_ssize_t i = 1; i < PyTuple_GET_SIZE(mro); ++i) {
 		PyTypeObject * const entry = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
@@ -819,49 +856,24 @@ static enum result mro_dunders_of(
 		if (
 			resolve_dunder(dict, eq_name, resolved_eq, entry, eq_owner) != RESULT_OK ||
 			resolve_dunder(dict, ne_name, resolved_ne, entry, ne_owner) != RESULT_OK ||
-			resolve_dunder(dict, repr_name, resolved_repr, entry, repr_owner) != RESULT_OK
+			resolve_dunder(dict, repr_name, resolved_repr, entry, repr_owner) != RESULT_OK ||
+			resolve_dunder(dict, lt_name, resolved_lt, entry, lt_owner) != RESULT_OK ||
+			resolve_dunder(dict, le_name, resolved_le, entry, le_owner) != RESULT_OK ||
+			resolve_dunder(dict, gt_name, resolved_gt, entry, gt_owner) != RESULT_OK ||
+			resolve_dunder(dict, ge_name, resolved_ge, entry, ge_owner) != RESULT_OK
 		) {
 			return RESULT_ERROR;
 		}
 
-		if (*resolved_eq != NULL && *resolved_ne != NULL && *resolved_repr != NULL) {
-			break;
-		}
-	}
-
-	return RESULT_OK;
-}
-
-static enum result mro_dunder_of(
-	PyTypeObject * const type,
-	char const * const name_text,
-	PyObject * * const resolved,
-	PyTypeObject * * const owner
-) {
-	*resolved = NULL;
-	*owner = NULL;
-
-	PY_OWNED(name, PyUnicode_InternFromString(name_text));
-
-	if (name == NULL) {
-		return RESULT_ERROR;
-	}
-
-	PyObject * const mro = type->tp_mro;
-
-	for (Py_ssize_t i = 1; i < PyTuple_GET_SIZE(mro); ++i) {
-		PyTypeObject * const entry = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
-		PY_OWNED(dict, struct_type_dict(entry));
-
-		if (dict == NULL) {
-			return RESULT_ERROR;
-		}
-
-		if (resolve_dunder(dict, name, resolved, entry, owner) != RESULT_OK) {
-			return RESULT_ERROR;
-		}
-
-		if (*resolved != NULL) {
+		if (
+			*resolved_eq != NULL &&
+			*resolved_ne != NULL &&
+			*resolved_repr != NULL &&
+			*resolved_lt != NULL &&
+			*resolved_le != NULL &&
+			*resolved_gt != NULL &&
+			*resolved_ge != NULL
+		) {
 			break;
 		}
 	}
@@ -976,9 +988,17 @@ static enum result settle_mro_bindings(
 	PY_MOVABLE(resolved_eq, NULL);
 	PY_MOVABLE(resolved_ne, NULL);
 	PY_MOVABLE(resolved_repr, NULL);
+	PY_MOVABLE(resolved_lt, NULL);
+	PY_MOVABLE(resolved_le, NULL);
+	PY_MOVABLE(resolved_gt, NULL);
+	PY_MOVABLE(resolved_ge, NULL);
 	PyTypeObject * eq_owner = NULL;
 	PyTypeObject * ne_owner = NULL;
 	PyTypeObject * repr_owner = NULL;
+	PyTypeObject * lt_owner = NULL;
+	PyTypeObject * le_owner = NULL;
+	PyTypeObject * gt_owner = NULL;
+	PyTypeObject * ge_owner = NULL;
 
 	if (
 		!targets.readable ||
@@ -989,7 +1009,15 @@ static enum result settle_mro_bindings(
 				&resolved_repr,
 				&eq_owner,
 				&ne_owner,
-				&repr_owner
+				&repr_owner,
+				&resolved_lt,
+				&resolved_le,
+				&resolved_gt,
+				&resolved_ge,
+				&lt_owner,
+				&le_owner,
+				&gt_owner,
+				&ge_owner
 			) !=
 			RESULT_OK
 	) {
@@ -1024,27 +1052,24 @@ static enum result settle_mro_bindings(
 		}
 	}
 
-	struct comparison_binding {
+	struct ordering_binding {
 		char const * name;
 		Py_ssize_t slot;
+		PyObject * resolved;
+		PyTypeObject * owner;
 	};
-	static struct comparison_binding const comparison_bindings[] = {
-		{"__lt__", 2},
-		{"__le__", 3},
-		{"__gt__", 4},
-		{"__ge__", 5},
+	struct ordering_binding const orderings[4] = {
+		{"__lt__", 2, resolved_lt, lt_owner},
+		{"__le__", 3, resolved_le, le_owner},
+		{"__gt__", 4, resolved_gt, gt_owner},
+		{"__ge__", 5, resolved_ge, ge_owner},
 	};
 
 	for (Py_ssize_t i = 0; i < 4; ++i) {
-		Py_ssize_t const slot = comparison_bindings[i].slot;
+		Py_ssize_t const slot = orderings[i].slot;
 		PyObject * const target = options.eq ? targets.mixin[slot] : targets.object[slot];
-		PY_MOVABLE(resolved_i, NULL);
-		PyTypeObject * owner_i = NULL;
-
-		if (mro_dunder_of(type, comparison_bindings[i].name, &resolved_i, &owner_i) != RESULT_OK) {
-			return RESULT_ERROR;
-		}
-
+		PyObject * const resolved_i = orderings[i].resolved;
+		PyTypeObject * const owner_i = orderings[i].owner;
 		bool const salix_owned = (
 			resolved_i == targets.mixin[slot] ||
 			resolved_i == targets.object[slot]
@@ -1055,7 +1080,7 @@ static enum result settle_mro_bindings(
 				settle_rebind_one(
 					struct_class,
 					original_namespace,
-					comparison_bindings[i].name,
+					orderings[i].name,
 					options.eq
 				) !=
 				RESULT_OK

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -631,36 +631,48 @@ static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject 
 	return winner;
 }
 
+static enum result settle_rebind_one(
+	StructType * const struct_class,
+	PyObject * const original_namespace,
+	char const * const name,
+	bool const from_mixin
+) {
+	int const present = dict_has_string(original_namespace, name);
+
+	if (present < 0) {
+		return RESULT_ERROR;
+	}
+
+	if (present == 1) {
+		return RESULT_OK;
+	}
+
+	PyObject * const source = (
+		from_mixin ? (PyObject *) &StructMixin_Type :
+		(PyObject *) &PyBaseObject_Type
+	);
+	PY_OWNED(bound, PyObject_GetAttrString(source, name));
+	PY_OWNED(unicode_name, PyUnicode_FromString(name));
+
+	if (
+		bound == NULL ||
+		unicode_name == NULL ||
+		PyType_Type.tp_setattro((PyObject *) struct_class, unicode_name, bound) < 0
+	) {
+		return RESULT_ERROR;
+	}
+
+	return RESULT_OK;
+}
+
 static enum result settle_rebind(
 	StructType * const struct_class,
 	PyObject * const original_namespace,
 	char const * const * const names,
 	bool const from_mixin
 ) {
-	PyObject * const source = (
-		from_mixin ? (PyObject *) &StructMixin_Type :
-		(PyObject *) &PyBaseObject_Type
-	);
-
 	for (char const * const * name = names; *name != NULL; name += 1) {
-		int const present = dict_has_string(original_namespace, *name);
-
-		if (present < 0) {
-			return RESULT_ERROR;
-		}
-
-		if (present == 1) {
-			continue;
-		}
-
-		PY_OWNED(bound, PyObject_GetAttrString(source, *name));
-		PY_OWNED(unicode_name, PyUnicode_FromString(*name));
-
-		if (
-			bound == NULL ||
-			unicode_name == NULL ||
-			PyType_Type.tp_setattro((PyObject *) struct_class, unicode_name, bound) < 0
-		) {
+		if (settle_rebind_one(struct_class, original_namespace, * name, from_mixin) != RESULT_OK) {
 			return RESULT_ERROR;
 		}
 	}
@@ -692,17 +704,17 @@ static int struct_base_count(PyObject * const bases) {
 	return count;
 }
 
+static PyInterpreterState * binding_interpreter = NULL;
 static PyObject * mixin_bindings[7];
 static PyObject * object_bindings[7];
-static int settle_candidates(
-	PyObject * * const mixin_eq,
-	PyObject * * const object_eq,
-	PyObject * * const mixin_ne,
-	PyObject * * const object_ne,
-	PyObject * * const mixin_repr,
-	PyObject * * const object_repr
-) {
-	char const * const names[7] = {
+struct settle_targets {
+	PyObject * const * mixin;
+	PyObject * const * object;
+	bool readable;
+};
+
+static struct settle_targets settle_candidates(void) {
+	static char const * const names[7] = {
 		"__eq__",
 		"__ne__",
 		"__lt__",
@@ -711,6 +723,15 @@ static int settle_candidates(
 		"__ge__",
 		"__repr__",
 	};
+
+	if (binding_interpreter != PyInterpreterState_Get()) {
+		for (Py_ssize_t i = 0; i < 7; ++i) {
+			Py_CLEAR(mixin_bindings[i]);
+			Py_CLEAR(object_bindings[i]);
+		}
+
+		binding_interpreter = PyInterpreterState_Get();
+	}
 
 	for (Py_ssize_t i = 0; i < 7; ++i) {
 		if (mixin_bindings[i] == NULL) {
@@ -724,18 +745,15 @@ static int settle_candidates(
 
 	for (Py_ssize_t i = 0; i < 7; ++i) {
 		if (mixin_bindings[i] == NULL || object_bindings[i] == NULL) {
-			return -1;
+			return (struct settle_targets){.readable = false};
 		}
 	}
 
-	*mixin_eq = Py_NewRef(mixin_bindings[0]);
-	*object_eq = Py_NewRef(object_bindings[0]);
-	*mixin_ne = Py_NewRef(mixin_bindings[1]);
-	*object_ne = Py_NewRef(object_bindings[1]);
-	*mixin_repr = Py_NewRef(mixin_bindings[6]);
-	*object_repr = Py_NewRef(object_bindings[6]);
-
-	return 0;
+	return (struct settle_targets){
+		.mixin = mixin_bindings,
+		.object = object_bindings,
+		.readable = true,
+	};
 }
 
 /* What the class's MRO hands out below the class's own dict for the three
@@ -807,6 +825,43 @@ static enum result mro_dunders_of(
 		}
 
 		if (*resolved_eq != NULL && *resolved_ne != NULL && *resolved_repr != NULL) {
+			break;
+		}
+	}
+
+	return RESULT_OK;
+}
+
+static enum result mro_dunder_of(
+	PyTypeObject * const type,
+	char const * const name_text,
+	PyObject * * const resolved,
+	PyTypeObject * * const owner
+) {
+	*resolved = NULL;
+	*owner = NULL;
+
+	PY_OWNED(name, PyUnicode_InternFromString(name_text));
+
+	if (name == NULL) {
+		return RESULT_ERROR;
+	}
+
+	PyObject * const mro = type->tp_mro;
+
+	for (Py_ssize_t i = 1; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyTypeObject * const entry = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
+		PY_OWNED(dict, struct_type_dict(entry));
+
+		if (dict == NULL) {
+			return RESULT_ERROR;
+		}
+
+		if (resolve_dunder(dict, name, resolved, entry, owner) != RESULT_OK) {
+			return RESULT_ERROR;
+		}
+
+		if (*resolved != NULL) {
 			break;
 		}
 	}
@@ -916,12 +971,8 @@ static enum result settle_mro_bindings(
 
 	PyTypeObject * const first_struct = (PyTypeObject *) find_behaviour_base(bases);
 
-	PY_MOVABLE(mixin_eq, NULL);
-	PY_MOVABLE(object_eq, NULL);
-	PY_MOVABLE(mixin_ne, NULL);
-	PY_MOVABLE(object_ne, NULL);
-	PY_MOVABLE(mixin_repr, NULL);
-	PY_MOVABLE(object_repr, NULL);
+	struct settle_targets const targets = settle_candidates();
+
 	PY_MOVABLE(resolved_eq, NULL);
 	PY_MOVABLE(resolved_ne, NULL);
 	PY_MOVABLE(resolved_repr, NULL);
@@ -930,15 +981,7 @@ static enum result settle_mro_bindings(
 	PyTypeObject * repr_owner = NULL;
 
 	if (
-		settle_candidates(
-				&mixin_eq,
-				&object_eq,
-				&mixin_ne,
-				&object_ne,
-				&mixin_repr,
-				&object_repr
-			) <
-			0 ||
+		!targets.readable ||
 		mro_dunders_of(
 				type,
 				&resolved_eq,
@@ -963,25 +1006,76 @@ static enum result settle_mro_bindings(
 		type->tp_richcompare = Struct_rich_compare;
 	}
 
-	PyObject * const target_eq = options.eq ? mixin_eq : object_eq;
-	bool const eq_is_salix_owned = resolved_eq == mixin_eq || resolved_eq == object_eq;
+	PyObject * const target_eq = options.eq ? targets.mixin[0] : targets.object[0];
+	bool const eq_is_salix_owned = (
+		resolved_eq == targets.mixin[0] ||
+		resolved_eq == targets.object[0]
+	);
 
 	if (
 		resolved_eq != target_eq &&
 		(eq_is_salix_owned || !honoured_owner(eq_owner, first_struct))
 	) {
 		if (
-			settle_rebind(struct_class, original_namespace, rebind_comparison, options.eq) !=
+			settle_rebind_one(struct_class, original_namespace, "__eq__", options.eq) !=
 			RESULT_OK
 		) {
 			return RESULT_ERROR;
 		}
 	}
 
+	struct comparison_binding {
+		char const * name;
+		Py_ssize_t slot;
+	};
+	static struct comparison_binding const comparison_bindings[] = {
+		{"__lt__", 2},
+		{"__le__", 3},
+		{"__gt__", 4},
+		{"__ge__", 5},
+	};
+
+	for (Py_ssize_t i = 0; i < 4; ++i) {
+		Py_ssize_t const slot = comparison_bindings[i].slot;
+		PyObject * const target = options.eq ? targets.mixin[slot] : targets.object[slot];
+		PY_MOVABLE(resolved_i, NULL);
+		PyTypeObject * owner_i = NULL;
+
+		if (mro_dunder_of(type, comparison_bindings[i].name, &resolved_i, &owner_i) != RESULT_OK) {
+			return RESULT_ERROR;
+		}
+
+		bool const salix_owned = (
+			resolved_i == targets.mixin[slot] ||
+			resolved_i == targets.object[slot]
+		);
+
+		if (resolved_i != target && (salix_owned || !honoured_owner(owner_i, first_struct))) {
+			if (
+				settle_rebind_one(
+					struct_class,
+					original_namespace,
+					comparison_bindings[i].name,
+					options.eq
+				) !=
+				RESULT_OK
+			) {
+				return RESULT_ERROR;
+			}
+		}
+	}
+
 	bool const body_eq_answers = !eq_is_salix_owned && honoured_owner(eq_owner, first_struct);
 
-	PyObject * const target_ne = body_eq_answers ? object_ne : options.eq ? mixin_ne : object_ne;
-	bool const ne_is_salix_owned = resolved_ne == mixin_ne || resolved_ne == object_ne;
+	PyObject * const target_ne = (
+		body_eq_answers ? targets.object[1] :
+		options.eq ? targets.mixin[1] :
+		targets.object[1]
+	);
+	bool const ne_is_salix_owned = (
+		resolved_ne == targets.mixin[1] ||
+		resolved_ne == targets.object[1]
+	);
 
 	if (
 		resolved_ne != target_ne &&
@@ -1000,8 +1094,11 @@ static enum result settle_mro_bindings(
 		}
 	}
 
-	PyObject * const target_repr = options.repr ? mixin_repr : object_repr;
-	bool const repr_is_salix_owned = resolved_repr == mixin_repr || resolved_repr == object_repr;
+	PyObject * const target_repr = options.repr ? targets.mixin[6] : targets.object[6];
+	bool const repr_is_salix_owned = (
+		resolved_repr == targets.mixin[6] ||
+		resolved_repr == targets.object[6]
+	);
 
 	if (
 		resolved_repr != target_repr &&

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -60,6 +60,7 @@ struct options inherited_options(
 	bool * promised_frozen
 );
 bool any_struct_base_is_mutable(PyObject * bases);
+void settle_cache_fill(void);
 bool any_base_has_weakref_slot(PyObject * bases);
 bool any_base_diverts_setattro(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);

--- a/src/salix.c
+++ b/src/salix.c
@@ -58,6 +58,8 @@ static int struct_exec(PyObject * const module) {
 		return RESULT_ERROR;
 	}
 
+	settle_cache_fill();
+
 	return add_struct_base(module);
 }
 

--- a/tests/test_multiple_bases.py
+++ b/tests/test_multiple_bases.py
@@ -225,6 +225,30 @@ class TestWhichBaseAnswers:
         assert hash(first) == hash(first)
         assert first in {first}
 
+    def test_a_honoured_body_ordering_dunder_survives_the_eq_repair(self):
+        """A later base's __eq__ triggers the comparison repair; the first
+        base's own body __lt__ is honoured, so the repair rebinds per name
+        and leaves it answering.
+        """
+
+        class ByOrder(Struct):
+            def __lt__(self, other: object) -> object:
+                return "by-order"
+
+        class ByEq(Struct):  # noqa: PLW1641 -- the body pair is the trigger
+            b: int
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+        class Both(ByOrder, ByEq):
+            c: int
+
+        first, second = Both(1, 2), Both(1, 2)
+
+        assert first.__lt__(second) == "by-order"
+
+
     def test_a_body_eq_on_a_base_that_is_not_the_layout_one_still_carries_its_hash(self):
         """Equal objects hashing differently is the shape that broke here.
 

--- a/tests/test_multiple_bases.py
+++ b/tests/test_multiple_bases.py
@@ -228,12 +228,16 @@ class TestWhichBaseAnswers:
     def test_a_honoured_body_ordering_dunder_survives_the_eq_repair(self):
         """A later base's __eq__ triggers the comparison repair; the first
         base's own body __lt__ is honoured, so the repair rebinds per name
-        and leaves it answering.
+        and leaves it answering. The body pair keeps the dict-dispatching
+        comparison slot, so the operators answer it too.
         """
 
         class ByOrder(Struct):
             def __lt__(self, other: object) -> object:
                 return "by-order"
+
+            def __le__(self, other: object) -> object:
+                return "by-order-or-equal"
 
         class ByEq(Struct):  # noqa: PLW1641 -- the body pair is the trigger
             b: int
@@ -247,6 +251,60 @@ class TestWhichBaseAnswers:
         first, second = Both(1, 2), Both(1, 2)
 
         assert first.__lt__(second) == "by-order"
+        assert first.__le__(second) == "by-order-or-equal"
+        assert (first < second) == "by-order"
+        assert (first <= second) == "by-order-or-equal"
+
+    def test_a_later_bases_body_ordering_dunder_is_shadowed_by_the_record(self):
+        """The record's answer for a class it never said orders is the
+        unsupported comparison, so a body __gt__ on a base the first struct
+        base never honoured is shadowed by it rather than answering.
+        """
+
+        class ByOrder(Struct):
+            pass
+
+        class ByEq(Struct):  # noqa: PLW1641 -- the body pair is the trigger
+            b: int
+
+            def __eq__(self, other: object) -> bool:
+                return True
+
+            def __gt__(self, other: object) -> object:
+                return "by-eq"
+
+        class Both(ByOrder, ByEq):
+            c: int
+
+        first, second = Both(1, 2), Both(1, 2)
+
+        assert first.__gt__(second) is NotImplemented
+
+        with pytest.raises(TypeError):
+            _ = first > second
+
+    def test_an_eq_false_record_shadows_a_honoured_body_ordering_dunder(self):
+        """The eq=False transition lands the object wrappers in the class's
+        own dict, and the class's own dict answers before any base -- even a
+        body __lt__ the single-base path would have honoured.
+        """
+
+        class ByOrder(Struct):
+            def __lt__(self, other: object) -> object:
+                return "by-order"
+
+        class ByEq(Struct):
+            b: int
+
+        class Both(ByOrder, ByEq, eq=False):
+            c: int
+
+        first, second = Both(1, 2), Both(1, 2)
+
+        assert Both.__lt__ is object.__lt__
+
+        with pytest.raises(TypeError):
+            _ = first < second
 
 
     def test_a_body_eq_on_a_base_that_is_not_the_layout_one_still_carries_its_hash(self):


### PR DESCRIPTION
# The comparison repair rebinds per name; honoured body ordering dunders survive

Fixes #110 (the #76 round-4 residue).

<details>
<summary>Round 2: the cache is filled eagerly, and the ordering repair reads the class's own dict</summary>

Round-1 review's systemic finding was the lifetime/sync discipline of the module-level binding cache. The answer removes the mutation: the seven bindings per source (the mixin and object) are fetched once in `struct_exec` after `PyType_Ready`, and the settle only ever reads them. Each interpreter owns its own module (`Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED`), init is single-threaded, and the arrays are then read-only — so the fill needs no keying and no lock. A failed fetch still surfaces through the existing `readable` refusal.

The ordering repair also now reads the class's own dict first. Round 1 walked the MRO from the second entry, so a pre-creation rebind (an eq-option transition injects the comparison family into the namespace) was invisible to the honoured-body decision: the walk would weigh a later base's body dunder while the injection already owned the class dict. The four ordering names are resolved in the same walk as eq/ne/repr, own dict first, so the decision sees the injection as salix's own binding.

**Disclosed behavior widening**: the repair now fires without an eq-option trigger. A body ordering dunder on a later struct base — one the first struct base never honoured — is shadowed by the record's answer even when no option transition happened. That is the shape the shadow pin covers: the child's `__gt__` answers the record's unsupported comparison, not the later base's body.
</details>

<details>
<summary>The pins</summary>

- The honoured pair: a fieldless first base with body `__lt__`/`__le__`, a later base with a body `__eq__` (the trigger). The child's `__lt__`/`__le__` are the body functions, and the operators answer them too (the body pair keeps the dict-dispatching slot). Mutation-verified: `honoured_owner` forced false → the pin fails.
- The shadow: a later base's body `__gt__` is shadowed by the record's answer.
- The injection: an eq=False record lands object's wrappers in the class's own dict, which shadows even a first base's honoured body `__lt__`.
</details>

<details>
<summary>Recorded, not chased here</summary>

The issue's other two nits weigh zero and predate this PR (the body-aliasing nit — a body writing `__eq__ = object.__eq__` resolves to the salix-owned pointer and is misclassified — and the hash-clobber nit — the unhashable pairing overwrites a `__hash__` the honoured body-eq owner defined); they stay recorded on #110. The round-2 review's one surviving finding — on 3.10/3.11, where `Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED` does not exist, a second subinterpreter's import overwrites the process-global binding cache and can make the first interpreter's eq=False multi-base classes unhashable (minor, confidence 0.7, likelihood 0.1) — is filed as #127, the same mechanism this PR's eager fill narrowed but did not eliminate.
</details>

## Verification

- C TESTING suite: 27/27 on 3.10–3.14 (per-interpreter builds); `c_test` green.
- pytest green on 3.14 and the full 3.12 matrix; scoped gate green.
- Mutation check: `honoured_owner` forced false → both honoured-path pins fail.

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: resolve the #110 residue with a per-name comparison repair, answer the round-1 review (eager cache fill, own-dict-first ordering resolution, the disclosed behavior widening), and drive the PR through the review loop.
