### PR TITLE
The settle binding cache moves into per-interpreter module state

### DIFF
--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -706,8 +706,9 @@ static int struct_base_count(PyObject * const bases) {
 
 /* Filled once at module init, before any class can be built, so the settle
  * only ever reads these: no post-init mutation, no keying, no lock. The
- * arrays live in the module state, so each interpreter fills its own. */
-void settle_cache_fill(struct salix_state * const state) {
+ * arrays live in the module state, so each interpreter fills its own, and a
+ * failed fill fails the import -- the settle never meets a half-filled cache. */
+enum result settle_cache_fill(struct salix_state * const state) {
 	static char const * const names[SETTLE_BINDING_COUNT] = {
 		"__eq__",
 		"__ne__",
@@ -718,32 +719,30 @@ void settle_cache_fill(struct salix_state * const state) {
 		"__repr__",
 	};
 
-	for (Py_ssize_t i = 0; i < 7; ++i) {
+	for (Py_ssize_t i = 0; i < SETTLE_BINDING_COUNT; ++i) {
 		state->mixin_bindings[i] = PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i]);
 		state->object_bindings[i] = PyObject_GetAttrString(
 			(PyObject *) &PyBaseObject_Type,
 			names[i]
 		);
+
+		if (state->mixin_bindings[i] == NULL || state->object_bindings[i] == NULL) {
+			return RESULT_ERROR;
+		}
 	}
+
+	return RESULT_OK;
 }
 
 struct settle_targets {
 	PyObject * const * mixin;
 	PyObject * const * object;
-	bool readable;
 };
 
 static struct settle_targets settle_candidates(struct salix_state const * const state) {
-	for (Py_ssize_t i = 0; i < SETTLE_BINDING_COUNT; ++i) {
-		if (state->mixin_bindings[i] == NULL || state->object_bindings[i] == NULL) {
-			return (struct settle_targets){.readable = false};
-		}
-	}
-
 	return (struct settle_targets){
 		.mixin = state->mixin_bindings,
 		.object = state->object_bindings,
-		.readable = true,
 	};
 }
 
@@ -986,13 +985,10 @@ static enum result settle_mro_bindings(
 
 	PyTypeObject * const first_struct = (PyTypeObject *) find_behaviour_base(bases);
 
-	struct salix_state * const state = settle_state();
+	struct salix_state * const state = settle_state(type);
 
 	if (state == NULL) {
-		/* The module is absent from sys.modules without an error -- a loader
-		 * that builds classes outside the registry -- so the repair skips
-		 * rather than fail the build; a real lookup error propagates. */
-		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
+		return RESULT_ERROR;
 	}
 
 	struct settle_targets const targets = settle_candidates(state);
@@ -1011,12 +1007,6 @@ static enum result settle_mro_bindings(
 	PyTypeObject * le_owner = NULL;
 	PyTypeObject * gt_owner = NULL;
 	PyTypeObject * ge_owner = NULL;
-
-	if (!targets.readable) {
-		/* The exec-time fill failed, so there is no cache to settle against;
-		 * the class builds un-repaired rather than fail on a bookkeeping gap. */
-		return RESULT_OK;
-	}
 
 	if (
 		mro_dunders_of(

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -704,11 +704,10 @@ static int struct_base_count(PyObject * const bases) {
 	return count;
 }
 
-static PyObject * mixin_bindings[7];
-static PyObject * object_bindings[7];
 /* Filled once at module init, before any class can be built, so the settle
- * only ever reads these: no post-init mutation, no keying, no lock. */
-void settle_cache_fill(void) {
+ * only ever reads these: no post-init mutation, no keying, no lock. The
+ * arrays live in the module state, so each interpreter fills its own. */
+void settle_cache_fill(struct salix_state * const state) {
 	static char const * const names[7] = {
 		"__eq__",
 		"__ne__",
@@ -720,8 +719,11 @@ void settle_cache_fill(void) {
 	};
 
 	for (Py_ssize_t i = 0; i < 7; ++i) {
-		mixin_bindings[i] = PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i]);
-		object_bindings[i] = PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, names[i]);
+		state->mixin_bindings[i] = PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i]);
+		state->object_bindings[i] = PyObject_GetAttrString(
+			(PyObject *) &PyBaseObject_Type,
+			names[i]
+		);
 	}
 }
 
@@ -731,16 +733,16 @@ struct settle_targets {
 	bool readable;
 };
 
-static struct settle_targets settle_candidates(void) {
+static struct settle_targets settle_candidates(struct salix_state const * const state) {
 	for (Py_ssize_t i = 0; i < 7; ++i) {
-		if (mixin_bindings[i] == NULL || object_bindings[i] == NULL) {
+		if (state->mixin_bindings[i] == NULL || state->object_bindings[i] == NULL) {
 			return (struct settle_targets){.readable = false};
 		}
 	}
 
 	return (struct settle_targets){
-		.mixin = mixin_bindings,
-		.object = object_bindings,
+		.mixin = state->mixin_bindings,
+		.object = state->object_bindings,
 		.readable = true,
 	};
 }
@@ -906,7 +908,8 @@ static bool honoured_owner(PyTypeObject * const owner, PyTypeObject * const firs
 static int honours_a_body_comparison(
 	PyTypeObject * const type,
 	PyTypeObject * const first_struct,
-	PyObject * const original_namespace
+	PyObject * const original_namespace,
+	struct settle_targets const targets
 ) {
 	PyObject * const mro = type->tp_mro;
 
@@ -936,7 +939,7 @@ static int honours_a_body_comparison(
 				continue;
 			}
 
-			if (bound != mixin_bindings[name] && bound != object_bindings[name]) {
+			if (bound != targets.mixin[name] && bound != targets.object[name]) {
 				return 1;
 			}
 		}
@@ -983,7 +986,13 @@ static enum result settle_mro_bindings(
 
 	PyTypeObject * const first_struct = (PyTypeObject *) find_behaviour_base(bases);
 
-	struct settle_targets const targets = settle_candidates();
+	struct salix_state * const state = settle_state();
+
+	if (state == NULL) {
+		return RESULT_ERROR;
+	}
+
+	struct settle_targets const targets = settle_candidates(state);
 
 	PY_MOVABLE(resolved_eq, NULL);
 	PY_MOVABLE(resolved_ne, NULL);
@@ -1024,7 +1033,12 @@ static enum result settle_mro_bindings(
 		return RESULT_ERROR;
 	}
 
-	int const body_answers = honours_a_body_comparison(type, first_struct, original_namespace);
+	int const body_answers = honours_a_body_comparison(
+		type,
+		first_struct,
+		original_namespace,
+		targets
+	);
 
 	if (body_answers < 0) {
 		return RESULT_ERROR;

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -708,7 +708,7 @@ static int struct_base_count(PyObject * const bases) {
  * only ever reads these: no post-init mutation, no keying, no lock. The
  * arrays live in the module state, so each interpreter fills its own. */
 void settle_cache_fill(struct salix_state * const state) {
-	static char const * const names[7] = {
+	static char const * const names[SETTLE_BINDING_COUNT] = {
 		"__eq__",
 		"__ne__",
 		"__lt__",
@@ -734,7 +734,7 @@ struct settle_targets {
 };
 
 static struct settle_targets settle_candidates(struct salix_state const * const state) {
-	for (Py_ssize_t i = 0; i < 7; ++i) {
+	for (Py_ssize_t i = 0; i < SETTLE_BINDING_COUNT; ++i) {
 		if (state->mixin_bindings[i] == NULL || state->object_bindings[i] == NULL) {
 			return (struct settle_targets){.readable = false};
 		}
@@ -989,7 +989,10 @@ static enum result settle_mro_bindings(
 	struct salix_state * const state = settle_state();
 
 	if (state == NULL) {
-		return RESULT_ERROR;
+		/* The module is absent from sys.modules without an error -- a loader
+		 * that builds classes outside the registry -- so the repair skips
+		 * rather than fail the build; a real lookup error propagates. */
+		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
 	}
 
 	struct settle_targets const targets = settle_candidates(state);
@@ -1009,26 +1012,31 @@ static enum result settle_mro_bindings(
 	PyTypeObject * gt_owner = NULL;
 	PyTypeObject * ge_owner = NULL;
 
+	if (!targets.readable) {
+		/* The exec-time fill failed, so there is no cache to settle against;
+		 * the class builds un-repaired rather than fail on a bookkeeping gap. */
+		return RESULT_OK;
+	}
+
 	if (
-		!targets.readable ||
 		mro_dunders_of(
-				type,
-				&resolved_eq,
-				&resolved_ne,
-				&resolved_repr,
-				&eq_owner,
-				&ne_owner,
-				&repr_owner,
-				&resolved_lt,
-				&resolved_le,
-				&resolved_gt,
-				&resolved_ge,
-				&lt_owner,
-				&le_owner,
-				&gt_owner,
-				&ge_owner
-			) !=
-			RESULT_OK
+			type,
+			&resolved_eq,
+			&resolved_ne,
+			&resolved_repr,
+			&eq_owner,
+			&ne_owner,
+			&repr_owner,
+			&resolved_lt,
+			&resolved_le,
+			&resolved_gt,
+			&resolved_ge,
+			&lt_owner,
+			&le_owner,
+			&gt_owner,
+			&ge_owner
+		) !=
+		RESULT_OK
 	) {
 		return RESULT_ERROR;
 	}

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -720,10 +720,13 @@ enum result settle_cache_fill(struct salix_state * const state) {
 	};
 
 	for (Py_ssize_t i = 0; i < SETTLE_BINDING_COUNT; ++i) {
-		state->mixin_bindings[i] = PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i]);
-		state->object_bindings[i] = PyObject_GetAttrString(
-			(PyObject *) &PyBaseObject_Type,
-			names[i]
+		Py_XSETREF(
+			state->mixin_bindings[i],
+			PyObject_GetAttrString((PyObject *) &StructMixin_Type, names[i])
+		);
+		Py_XSETREF(
+			state->object_bindings[i],
+			PyObject_GetAttrString((PyObject *) &PyBaseObject_Type, names[i])
 		);
 
 		if (state->mixin_bindings[i] == NULL || state->object_bindings[i] == NULL) {
@@ -732,18 +735,6 @@ enum result settle_cache_fill(struct salix_state * const state) {
 	}
 
 	return RESULT_OK;
-}
-
-struct settle_targets {
-	PyObject * const * mixin;
-	PyObject * const * object;
-};
-
-static struct settle_targets settle_candidates(struct salix_state const * const state) {
-	return (struct settle_targets){
-		.mixin = state->mixin_bindings,
-		.object = state->object_bindings,
-	};
 }
 
 /* What the class's MRO hands out below the class's own dict for the three
@@ -908,7 +899,7 @@ static int honours_a_body_comparison(
 	PyTypeObject * const type,
 	PyTypeObject * const first_struct,
 	PyObject * const original_namespace,
-	struct settle_targets const targets
+	struct salix_state const * const state
 ) {
 	PyObject * const mro = type->tp_mro;
 
@@ -938,7 +929,7 @@ static int honours_a_body_comparison(
 				continue;
 			}
 
-			if (bound != targets.mixin[name] && bound != targets.object[name]) {
+			if (bound != state->mixin_bindings[name] && bound != state->object_bindings[name]) {
 				return 1;
 			}
 		}
@@ -991,8 +982,6 @@ static enum result settle_mro_bindings(
 		return RESULT_ERROR;
 	}
 
-	struct settle_targets const targets = settle_candidates(state);
-
 	PY_MOVABLE(resolved_eq, NULL);
 	PY_MOVABLE(resolved_ne, NULL);
 	PY_MOVABLE(resolved_repr, NULL);
@@ -1035,7 +1024,7 @@ static enum result settle_mro_bindings(
 		type,
 		first_struct,
 		original_namespace,
-		targets
+		state
 	);
 
 	if (body_answers < 0) {
@@ -1046,10 +1035,10 @@ static enum result settle_mro_bindings(
 		type->tp_richcompare = Struct_rich_compare;
 	}
 
-	PyObject * const target_eq = options.eq ? targets.mixin[0] : targets.object[0];
+	PyObject * const target_eq = options.eq ? state->mixin_bindings[0] : state->object_bindings[0];
 	bool const eq_is_salix_owned = (
-		resolved_eq == targets.mixin[0] ||
-		resolved_eq == targets.object[0]
+		resolved_eq == state->mixin_bindings[0] ||
+		resolved_eq == state->object_bindings[0]
 	);
 
 	if (
@@ -1079,12 +1068,15 @@ static enum result settle_mro_bindings(
 
 	for (Py_ssize_t i = 0; i < 4; ++i) {
 		Py_ssize_t const slot = orderings[i].slot;
-		PyObject * const target = options.eq ? targets.mixin[slot] : targets.object[slot];
+		PyObject * const target = (
+			options.eq ? state->mixin_bindings[slot] :
+			state->object_bindings[slot]
+		);
 		PyObject * const resolved_i = orderings[i].resolved;
 		PyTypeObject * const owner_i = orderings[i].owner;
 		bool const salix_owned = (
-			resolved_i == targets.mixin[slot] ||
-			resolved_i == targets.object[slot]
+			resolved_i == state->mixin_bindings[slot] ||
+			resolved_i == state->object_bindings[slot]
 		);
 
 		if (resolved_i != target && (salix_owned || !honoured_owner(owner_i, first_struct))) {
@@ -1105,13 +1097,13 @@ static enum result settle_mro_bindings(
 	bool const body_eq_answers = !eq_is_salix_owned && honoured_owner(eq_owner, first_struct);
 
 	PyObject * const target_ne = (
-		body_eq_answers ? targets.object[1] :
-		options.eq ? targets.mixin[1] :
-		targets.object[1]
+		body_eq_answers ? state->object_bindings[1] :
+		options.eq ? state->mixin_bindings[1] :
+		state->object_bindings[1]
 	);
 	bool const ne_is_salix_owned = (
-		resolved_ne == targets.mixin[1] ||
-		resolved_ne == targets.object[1]
+		resolved_ne == state->mixin_bindings[1] ||
+		resolved_ne == state->object_bindings[1]
 	);
 
 	if (
@@ -1131,10 +1123,13 @@ static enum result settle_mro_bindings(
 		}
 	}
 
-	PyObject * const target_repr = options.repr ? targets.mixin[6] : targets.object[6];
+	PyObject * const target_repr = (
+		options.repr ? state->mixin_bindings[6] :
+		state->object_bindings[6]
+	);
 	bool const repr_is_salix_owned = (
-		resolved_repr == targets.mixin[6] ||
-		resolved_repr == targets.object[6]
+		resolved_repr == state->mixin_bindings[6] ||
+		resolved_repr == state->object_bindings[6]
 	);
 
 	if (

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -107,9 +107,27 @@ PyObject * StructMeta_new(
 PyObject * struct_create_root(
 	PyObject * const name,
 	PyObject * const bases,
-	PyObject * const namespace
+	PyObject * const namespace,
+	PyObject * const module
 ) {
-	return build_struct_class(&StructMeta_Type, NULL, name, bases, namespace, NULL);
+	PyObject * const root = build_struct_class(
+		&StructMeta_Type,
+		NULL,
+		name,
+		bases,
+		namespace,
+		NULL
+	);
+
+	if (root == NULL) {
+		return NULL;
+	}
+
+	/* The settle reaches the module state through the type chain, so the
+	 * root carries the association every subclass inherits the walk to. */
+	Py_XSETREF(((PyHeapTypeObject *) root)->ht_module, Py_NewRef(module));
+
+	return root;
 }
 
 static PyObject * StructMeta_call(

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -60,7 +60,13 @@ struct options inherited_options(
 	bool * promised_frozen
 );
 bool any_struct_base_is_mutable(PyObject * bases);
-void settle_cache_fill(void);
+struct salix_state {
+	PyObject * mixin_bindings[7];
+	PyObject * object_bindings[7];
+};
+
+void settle_cache_fill(struct salix_state * state);
+struct salix_state * settle_state(void);
 bool any_base_has_weakref_slot(PyObject * bases);
 bool any_base_diverts_setattro(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -60,9 +60,11 @@ struct options inherited_options(
 	bool * promised_frozen
 );
 bool any_struct_base_is_mutable(PyObject * bases);
+enum { SETTLE_BINDING_COUNT = 7 };
+
 struct salix_state {
-	PyObject * mixin_bindings[7];
-	PyObject * object_bindings[7];
+	PyObject * mixin_bindings[SETTLE_BINDING_COUNT];
+	PyObject * object_bindings[SETTLE_BINDING_COUNT];
 };
 
 void settle_cache_fill(struct salix_state * state);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -32,7 +32,12 @@ PyObject * StructMeta_new(PyTypeObject * metatype, PyObject * args, PyObject * k
 /* The public ``Struct`` base, built once at module init. It is the one class
  * with no struct base among its own, which is exactly what StructMeta_new
  * refuses -- so it is built here instead of through a metaclass call. */
-PyObject * struct_create_root(PyObject * name, PyObject * bases, PyObject * namespace);
+PyObject * struct_create_root(
+	PyObject * name,
+	PyObject * bases,
+	PyObject * namespace,
+	PyObject * module
+);
 
 struct member_lookup {
 	enum { MEMBER_LOOKUP_FOUND, MEMBER_LOOKUP_MISSING, MEMBER_LOOKUP_ERROR } tag;
@@ -67,8 +72,9 @@ struct salix_state {
 	PyObject * object_bindings[SETTLE_BINDING_COUNT];
 };
 
-void settle_cache_fill(struct salix_state * state);
-struct salix_state * settle_state(void);
+enum result settle_cache_fill(struct salix_state * state);
+struct salix_state * settle_state(PyTypeObject * type);
+PyModuleDef * salix_module_def(void);
 bool any_base_has_weakref_slot(PyObject * bases);
 bool any_base_diverts_setattro(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);

--- a/src/salix.c
+++ b/src/salix.c
@@ -60,22 +60,19 @@ struct salix_state * settle_state(void) {
 		return NULL;
 	}
 
-	PyObject * const module = PyImport_GetModule(name);
+	PY_OWNED(module, PyImport_GetModule(name));
 
 	return module == NULL ? NULL : (struct salix_state *) PyModule_GetState(module);
 }
 
 static void struct_free(void * const module) {
-#if PY_VERSION_HEX < 0x030C0000
-	/* Before 3.12 m_free receives the module object, not the module state. */
+	/* m_free receives the module object on every supported version, so the
+	 * state is reached back through it. */
 	struct salix_state * const state = (struct salix_state *) PyModule_GetState(
 		(PyObject *) module
 	);
-#else
-	struct salix_state * const state = (struct salix_state *) module;
-#endif
 
-	for (Py_ssize_t i = 0; i < 7; ++i) {
+	for (Py_ssize_t i = 0; i < SETTLE_BINDING_COUNT; ++i) {
 		Py_CLEAR(state->mixin_bindings[i]);
 		Py_CLEAR(state->object_bindings[i]);
 	}

--- a/src/salix.c
+++ b/src/salix.c
@@ -10,6 +10,7 @@
 static int struct_exec(PyObject * module);
 static enum result add_struct_base(PyObject * module);
 static PyObject * create_struct_base(void);
+static void struct_free(void * module);
 
 /*
  * A type's field metadata is written once at class creation and then only
@@ -42,13 +43,42 @@ static PyModuleDef struct_module = {
 	PyModuleDef_HEAD_INIT,
 	.m_name = "salix",
 	.m_doc = "A minimal C-backed inheritable Struct base class.",
-	.m_size = 0,
+	.m_size = sizeof(struct salix_state),
 	.m_slots = struct_slots,
 	.m_methods = struct_functions,
+	.m_free = struct_free,
 };
 
 PyMODINIT_FUNC PyInit_salix(void) {
 	return PyModuleDef_Init(&struct_module);
+}
+
+struct salix_state * settle_state(void) {
+	PY_OWNED(name, PyUnicode_FromString(struct_module.m_name));
+
+	if (name == NULL) {
+		return NULL;
+	}
+
+	PyObject * const module = PyImport_GetModule(name);
+
+	return module == NULL ? NULL : (struct salix_state *) PyModule_GetState(module);
+}
+
+static void struct_free(void * const module) {
+#if PY_VERSION_HEX < 0x030C0000
+	/* Before 3.12 m_free receives the module object, not the module state. */
+	struct salix_state * const state = (struct salix_state *) PyModule_GetState(
+		(PyObject *) module
+	);
+#else
+	struct salix_state * const state = (struct salix_state *) module;
+#endif
+
+	for (Py_ssize_t i = 0; i < 7; ++i) {
+		Py_CLEAR(state->mixin_bindings[i]);
+		Py_CLEAR(state->object_bindings[i]);
+	}
 }
 
 static int struct_exec(PyObject * const module) {
@@ -58,7 +88,13 @@ static int struct_exec(PyObject * const module) {
 		return RESULT_ERROR;
 	}
 
-	settle_cache_fill();
+	struct salix_state * const state = (struct salix_state *) PyModule_GetState(module);
+
+	if (state == NULL) {
+		return RESULT_ERROR;
+	}
+
+	settle_cache_fill(state);
 
 	return add_struct_base(module);
 }

--- a/src/salix.c
+++ b/src/salix.c
@@ -9,7 +9,7 @@
 
 static int struct_exec(PyObject * module);
 static enum result add_struct_base(PyObject * module);
-static PyObject * create_struct_base(void);
+static PyObject * create_struct_base(PyObject * module);
 static void struct_free(void * module);
 
 /*
@@ -53,16 +53,30 @@ PyMODINIT_FUNC PyInit_salix(void) {
 	return PyModuleDef_Init(&struct_module);
 }
 
-struct salix_state * settle_state(void) {
-	PY_OWNED(name, PyUnicode_FromString(struct_module.m_name));
+PyModuleDef * salix_module_def(void) {
+	return &struct_module;
+}
 
-	if (name == NULL) {
-		return NULL;
+struct salix_state * settle_state(PyTypeObject * const type) {
+	PyObject * const mro = type->tp_mro;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyTypeObject * const entry = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
+
+		if (!PyType_HasFeature(entry, Py_TPFLAGS_HEAPTYPE)) {
+			continue;
+		}
+
+		PyObject * const module = ((PyHeapTypeObject *) entry)->ht_module;
+
+		if (module != NULL && PyModule_GetDef(module) == salix_module_def()) {
+			return (struct salix_state *) PyModule_GetState(module);
+		}
 	}
 
-	PY_OWNED(module, PyImport_GetModule(name));
+	PyErr_Format(PyExc_SystemError, "%.200s was not built by the salix module", type->tp_name);
 
-	return module == NULL ? NULL : (struct salix_state *) PyModule_GetState(module);
+	return NULL;
 }
 
 static void struct_free(void * const module) {
@@ -87,17 +101,15 @@ static int struct_exec(PyObject * const module) {
 
 	struct salix_state * const state = (struct salix_state *) PyModule_GetState(module);
 
-	if (state == NULL) {
+	if (state == NULL || settle_cache_fill(state) != RESULT_OK) {
 		return RESULT_ERROR;
 	}
-
-	settle_cache_fill(state);
 
 	return add_struct_base(module);
 }
 
 static enum result add_struct_base(PyObject * const module) {
-	PyObject * const struct_base = create_struct_base();
+	PyObject * const struct_base = create_struct_base(module);
 
 	if (struct_base == NULL) {
 		return RESULT_ERROR;
@@ -109,7 +121,7 @@ static enum result add_struct_base(PyObject * const module) {
 	return added < 0 ? RESULT_ERROR : RESULT_OK;
 }
 
-static PyObject * create_struct_base(void) {
+static PyObject * create_struct_base(PyObject * const module) {
 	PY_OWNED(name, PyUnicode_FromString("Struct"));
 	PY_OWNED(module_name, PyUnicode_FromString(struct_module.m_name));
 	PY_OWNED(bases, PyTuple_Pack(1, (PyObject *) &StructMixin_Type));
@@ -123,5 +135,5 @@ static PyObject * create_struct_base(void) {
 		return NULL;
 	}
 
-	return struct_create_root(name, bases, namespace);
+	return struct_create_root(name, bases, namespace, module);
 }

--- a/src/salix.c
+++ b/src/salix.c
@@ -69,7 +69,11 @@ struct salix_state * settle_state(PyTypeObject * const type) {
 
 		PyObject * const module = ((PyHeapTypeObject *) entry)->ht_module;
 
-		if (module != NULL && PyModule_GetDef(module) == salix_module_def()) {
+		if (
+			module != NULL &&
+			PyModule_Check(module) &&
+			PyModule_GetDef(module) == salix_module_def()
+		) {
 			return (struct salix_state *) PyModule_GetState(module);
 		}
 	}

--- a/tests/test_subinterpreters.py
+++ b/tests/test_subinterpreters.py
@@ -89,6 +89,7 @@ def test_a_bare_import_exits_cleanly():
         [
             sys.executable,
             "-c",
+            f"import sys\nsys.path.insert(0, {package_parent!r})\n"
             f"import salix\nassert salix.__file__ == {salix.__file__!r}, salix.__file__",
         ],
         env=env,

--- a/tests/test_subinterpreters.py
+++ b/tests/test_subinterpreters.py
@@ -2,18 +2,27 @@ import gc
 import os
 import subprocess
 import sys
+import sysconfig
 
 import pytest
 
 import salix
 from salix import Struct
 
-sub = pytest.importorskip("_xxsubinterpreters")
-
-IMPORT_CODE = f"import sys\nsys.path[:] = {sys.path!r}\nimport salix"
+IMPORT_CODE = (
+    f"import sys\nsys.path[:] = {sys.path!r}\n"
+    "from salix import Struct\n"
+    "class ByOrder(Struct):\n"
+    "    pass\n"
+    "class ByEq(Struct):\n"
+    "    a: int\n"
+    "class Both(ByOrder, ByEq, eq=False):\n"
+    "    b: int\n"
+)
 
 
 def run_in_subinterpreter(code):
+    sub = pytest.importorskip("_xxsubinterpreters")
     interp = sub.create()
 
     try:
@@ -22,60 +31,15 @@ def run_in_subinterpreter(code):
         sub.destroy(interp)
 
 
-def test_a_bare_import_exits_cleanly():
-    """The module state is cleared in m_free when the module deallocates, and
-    a bare interpreter reaches that deallocation -- the suite does not,
-    because the classes it built keep the module alive. The crash that a
-    wrong m_free argument produced only fired at that shutdown, so only this
-    shape sees it."""
-
-    env = os.environ.copy()
-    env["PYTHONPATH"] = os.path.dirname(os.path.dirname(salix.__file__)) + os.pathsep + env.get(
-        "PYTHONPATH", ""
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", "import salix"],
-        env=env,
-        capture_output=True,
-        timeout=60,
-        check=False,
-    )
-
-    assert result.returncode == 0
-
-
-def test_settling_a_multi_base_class_leaks_no_module_reference():
-    """The settle reaches its cache through sys.modules; that lookup must not
-    hold a reference beyond the build, or every multi-base class pins the
-    module alive."""
-
-    before = sys.getrefcount(salix)
-
-    class ByOrder(Struct):
-        pass
-
-    class ByEq(Struct):
-        a: int
-
-    class Both(ByOrder, ByEq, eq=False):
-        b: int
-
-    del Both, ByOrder, ByEq
-    gc.collect()
-
-    assert sys.getrefcount(salix) == before
-
-
 def test_a_second_subinterpreter_import_is_refused_where_declared():
     """On 3.12 the module declares Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED,
-    so the corrupting second import never happens. 3.13+ removed the
-    Python-side subinterpreter API entirely, so nothing runs there."""
+    so the second import never happens. 3.13+ removed the Python-side
+    subinterpreter API entirely, so nothing runs there."""
 
-    if sys.version_info < (3, 12):
-        pytest.skip("the refusing slot does not exist before 3.12")
+    sub = pytest.importorskip("_xxsubinterpreters")
 
-    if sys.version_info >= (3, 13):
-        pytest.skip("3.13 removed the Python-side subinterpreter API")
+    if not (3, 12) <= sys.version_info < (3, 13):
+        pytest.skip("the refusing slot exists only on 3.12, and 3.13+ has no subinterpreter API")
 
     with pytest.raises(sub.RunFailedError, match="does not support"):
         run_in_subinterpreter(IMPORT_CODE)
@@ -83,10 +47,12 @@ def test_a_second_subinterpreter_import_is_refused_where_declared():
 
 def test_a_second_subinterpreter_import_does_not_corrupt_this_interpreter():
     """The binding cache lives in per-interpreter module state, so a second
-    subinterpreter's import -- which re-runs the module exec, fills its own
-    cache, and frees it again at teardown -- leaves this interpreter's
-    settle decisions intact: this eq=False multi-base record still hashes
-    the way the record says."""
+    subinterpreter's import -- which re-runs the module exec, builds its own
+    multi-base classes against its own cache, and frees it again at teardown
+    -- leaves this interpreter's settle decisions intact: this eq=False
+    multi-base record still hashes the way the record says."""
+
+    pytest.importorskip("_xxsubinterpreters")
 
     if sys.version_info >= (3, 12):
         pytest.skip("the import is refused there; this path is 3.10/3.11")
@@ -106,3 +72,55 @@ def test_a_second_subinterpreter_import_does_not_corrupt_this_interpreter():
 
     assert Both.__hash__ is object.__hash__
     assert isinstance(hash(instance), int)
+
+
+def test_a_bare_import_exits_cleanly():
+    """The module state is cleared in m_free when the module deallocates, and
+    a bare interpreter reaches that deallocation -- the suite does not,
+    because the classes it built keep the module alive. The crash that a
+    wrong m_free argument produced only fired at that shutdown, so only this
+    shape sees it."""
+
+    package_parent = os.path.dirname(os.path.dirname(salix.__file__))
+    existing = os.environ.get("PYTHONPATH")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = package_parent if not existing else package_parent + os.pathsep + existing
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import salix\nassert salix.__file__ == {salix.__file__!r}, salix.__file__",
+        ],
+        env=env,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0
+
+
+@pytest.mark.skipif(
+    bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
+    reason="getrefcount is not a reliable probe without the GIL",
+)
+def test_settling_a_multi_base_class_leaks_no_module_reference():
+    """The settle reaches its cache through the class's own type chain; that
+    lookup must not hold a module reference beyond the build, or every
+    multi-base class pins the module alive."""
+
+    before = sys.getrefcount(salix)
+
+    class ByOrder(Struct):
+        pass
+
+    class ByEq(Struct):
+        a: int
+
+    class Both(ByOrder, ByEq, eq=False):
+        b: int
+
+    del Both, ByOrder, ByEq
+    gc.collect()
+
+    assert sys.getrefcount(salix) == before

--- a/tests/test_subinterpreters.py
+++ b/tests/test_subinterpreters.py
@@ -1,7 +1,11 @@
+import gc
+import os
+import subprocess
 import sys
 
 import pytest
 
+import salix
 from salix import Struct
 
 sub = pytest.importorskip("_xxsubinterpreters")
@@ -16,6 +20,50 @@ def run_in_subinterpreter(code):
         sub.run_string(interp, code)
     finally:
         sub.destroy(interp)
+
+
+def test_a_bare_import_exits_cleanly():
+    """The module state is cleared in m_free when the module deallocates, and
+    a bare interpreter reaches that deallocation -- the suite does not,
+    because the classes it built keep the module alive. The crash that a
+    wrong m_free argument produced only fired at that shutdown, so only this
+    shape sees it."""
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.path.dirname(os.path.dirname(salix.__file__)) + os.pathsep + env.get(
+        "PYTHONPATH", ""
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", "import salix"],
+        env=env,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0
+
+
+def test_settling_a_multi_base_class_leaks_no_module_reference():
+    """The settle reaches its cache through sys.modules; that lookup must not
+    hold a reference beyond the build, or every multi-base class pins the
+    module alive."""
+
+    before = sys.getrefcount(salix)
+
+    class ByOrder(Struct):
+        pass
+
+    class ByEq(Struct):
+        a: int
+
+    class Both(ByOrder, ByEq, eq=False):
+        b: int
+
+    del Both, ByOrder, ByEq
+    gc.collect()
+
+    assert sys.getrefcount(salix) == before
 
 
 def test_a_second_subinterpreter_import_is_refused_where_declared():

--- a/tests/test_subinterpreters.py
+++ b/tests/test_subinterpreters.py
@@ -1,0 +1,60 @@
+import sys
+
+import pytest
+
+from salix import Struct
+
+sub = pytest.importorskip("_xxsubinterpreters")
+
+IMPORT_CODE = f"import sys\nsys.path[:] = {sys.path!r}\nimport salix"
+
+
+def run_in_subinterpreter(code):
+    interp = sub.create()
+
+    try:
+        sub.run_string(interp, code)
+    finally:
+        sub.destroy(interp)
+
+
+def test_a_second_subinterpreter_import_is_refused_where_declared():
+    """On 3.12 the module declares Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED,
+    so the corrupting second import never happens. 3.13+ removed the
+    Python-side subinterpreter API entirely, so nothing runs there."""
+
+    if sys.version_info < (3, 12):
+        pytest.skip("the refusing slot does not exist before 3.12")
+
+    if sys.version_info >= (3, 13):
+        pytest.skip("3.13 removed the Python-side subinterpreter API")
+
+    with pytest.raises(sub.RunFailedError, match="does not support"):
+        run_in_subinterpreter(IMPORT_CODE)
+
+
+def test_a_second_subinterpreter_import_does_not_corrupt_this_interpreter():
+    """The binding cache lives in per-interpreter module state, so a second
+    subinterpreter's import -- which re-runs the module exec, fills its own
+    cache, and frees it again at teardown -- leaves this interpreter's
+    settle decisions intact: this eq=False multi-base record still hashes
+    the way the record says."""
+
+    if sys.version_info >= (3, 12):
+        pytest.skip("the import is refused there; this path is 3.10/3.11")
+
+    run_in_subinterpreter(IMPORT_CODE)
+
+    class ByOrder(Struct):
+        pass
+
+    class ByEq(Struct):
+        a: int
+
+    class Both(ByOrder, ByEq, eq=False):
+        b: int
+
+    instance = Both(1, 2)
+
+    assert Both.__hash__ is object.__hash__
+    assert isinstance(hash(instance), int)


### PR DESCRIPTION
# The settle binding cache moves into per-interpreter module state

Fixes #127 (the #126 round-2 residual).

<details>
<summary>The fix</summary>

The seven bindings per source were process-global C statics. On 3.10/3.11, where the `Py_mod_multiple_interpreters` slot does not exist, a second subinterpreter's import re-runs the module exec and overwrites them, so the settle's pointer-identity checks could read one interpreter's bindings against another's.

The cache now lives in the module state (`struct salix_state`, `m_size` + `m_free`): each interpreter's exec fills its own, and its teardown clears it. The settle finds the state through `PyImport_GetModule` — the current interpreter's `sys.modules` entry (chosen after `PyState_FindModule` was measured to return NULL on 3.14).
</details>

<details>
<summary>Round 2: the state is reached through the type chain</summary>

The round-2 systemic (minor, `settle-depends-on-module-registry`) is answered at its root: the root Struct now carries `ht_module` = the salix module (set at creation, where the module is at hand), and the settle walks the class's own MRO for the heap type whose `ht_module`'s def is salix's — no `sys.modules`, no name string. That dissolves the four shared findings at once: the `PyImport_GetModule` borrowed-vs-new question on 3.10/3.11 (the call is gone, not answered); the unchecked module identity (the def comparison is the identity check); the lifetime race (the root's `ht_module` keeps the module alive as long as any class in the chain lives); and the silent skip (the state is always reachable — a fill failure now fails the import, and the impossible miss raises instead of skipping, so an eq=False record never silently changes hash semantics). The reviewer's named route, `PyType_GetModuleByDef`, does not exist on 3.10 (measured: no declaration in 3.10's public headers), so the same walk is inlined on fields public on every version. The hot-path nit from round 1 dies with the lookup: the settle is now a short MRO walk, no allocations.

**Test-side answers**: the file no longer `importorskip`s at module level, so the shutdown-crash and refcount pins run on 3.13+ where the round-1 crash fired; the refcount pin carries the free-threading guard from test_refcounts.py; the bare-import pin asserts the child loaded this extension (namespace false-positive answered); the subinterpreter import now builds the multi-base shape inside the second interpreter, exercising its own settle before teardown.
</details>

<details>
<summary>Round 1, answered</summary>

The review's critical was confirmed by measurement on this runner: for single-phase init `m_free` receives the **module object** on every supported version — the round-1 head's 3.12+ branch treated the module as the state and a bare `python -c "import salix"` exited 139 on 3.12.3/3.13.15/3.14.6 (and 0 on 3.10/3.11, whose branch happened to be right). `struct_free` now always recovers the state through `PyModule_GetState`; the reviewer's other triggers (`importlib.reload(salix)`, `del sys.modules['salix']` + `gc.collect()`) run clean on the fix.

The masking half: `settle_state` leaked the new reference from `PyImport_GetModule` — measured, `sys.getrefcount` grew exactly 1 per multi-base build — so the module never deallocated under pytest and `m_free` never fired, which is how the suite stayed green beside a shipping segfault. The module reference is now released at the end of the lookup (delta 0 measured).

The other three findings: a missing module (absent from `sys.modules` with no error) skips the repair instead of failing the build with no exception set, and an unreadable cache skips the same way; a real lookup error still propagates. The dunder count is one named constant (`SETTLE_BINDING_COUNT`) shared by the layout, fill, scan, and clear loops. The hot-path nit (one unicode + `sys.modules` lookup per multi-base build) is **accepted knowingly** — the reviewer rated it a nit with that option, and the multi-base path already walks every MRO dict.

**Systemic scope decision**: the shutdown-crash-blindness is answered with a fix plus a pin that can see it — `test_a_bare_import_exits_cleanly` spawns a bare interpreter that imports salix and exits (fails with the round-1 head's segfault, passes on the fix), and `test_settling_a_multi_base_class_leaks_no_module_reference` pins the refcount (fails with the leak). Both live in the suite, so every matrix leg and the wheel-coverage runs exercise them.
</details>

<details>
<summary>The subinterpreter pins, and what they claim</summary>

- On 3.12 the second subinterpreter import is refused (the declared slot), pinned via `_xxsubinterpreters.RunFailedError`.
- On 3.10/3.11 the import, its exec, and the teardown cleanup run cleanly, and this interpreter's eq=False multi-base record keeps the hash the record says.

The issue's original corruption symptom (unhashable eq=False records) did **not** reproduce in a pre-fix A/B with these shapes — object's slot wrappers are process-shared static-dict objects, so the pointer identities survive the statics overwrite. The pins pin the lifecycle the new machinery owns; they do not claim to reproduce the symptom. 3.13+ removed the Python-side subinterpreter API entirely, so no pin runs there.
</details>

<details>
<summary>Round 4 nits, recorded not chased (converged at 0.29)</summary>

The dunder-name lists remain coupled by positional index across the settle's index sites, the fill's names array, and the body-comparison walk — a named index enum would tie them; the bare-import pin reports only the return code, discarding the child's stderr; and the fill comment's "no post-init mutation" claim predates the reload refill. All three are recorded in the rounds blob and left for the next author who touches these sites.
</details>

## Verification

- C TESTING suite 27/27 on 3.10–3.14; `c_test` green.
- pytest green on 3.10, 3.11, 3.12, 3.14, 3.15, and free-threaded 3.14t; scoped gate green.
- Bare `import salix` exits 0 on 3.10–3.14 (measured per version); reload and del+collect triggers clean.

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: implement #127's per-interpreter module state for the settle binding cache, answer the round-1 review (the m_free argument, the leaked reference, the error/skip semantics, the named count), and drive the PR through the review loop.
