### PR TITLE
The hand-off gate attempts the forwarding call and falls back on binding failure

### DIFF
--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -33,11 +33,22 @@ static StructType * create_class(
 	PyObject * namespace,
 	PyObject * const * keyword_rungs,
 	Py_ssize_t keyword_rung_count,
+	PyObject * forwarded_keywords,
+	bool laddered,
 	PyObject * handoff_attempt,
 	PyObject * handoff_declined,
 	PyObject * handoff_new
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
+
+struct chain_verdict {
+	int accepts_all;
+	int accepts_weakref;
+	bool readable;
+};
+static int code_accepts_keyword(PyCodeObject * code, PyObject * varnames, char const * keyword);
+static PyObject * metaclass_chain(PyTypeObject * winner);
+static struct chain_verdict chain_probe(PyObject * chain, PyObject * keywords, bool weakref_column);
 
 static enum result install_fields(
 	StructType * struct_class,
@@ -232,10 +243,14 @@ PyObject * build_struct_class(
 	request.options.weakref |= weakref_carried;
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
+	PyObject * forwarded_keywords = NULL;
 	PY_MOVABLE(weakref_only, NULL);
+	PY_MOVABLE(chain, NULL);
 	PyObject * keyword_rungs_storage[3] = {NULL, NULL, NULL};
 	PyObject * const * keyword_rungs = keyword_rungs_storage;
 	Py_ssize_t keyword_rung_count = 1;
+	bool laddered = false;
+	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
 
 	if (
 		handoff != metatype &&
@@ -243,26 +258,74 @@ PyObject * build_struct_class(
 		keywords != NULL &&
 		PyDict_GET_SIZE(keywords) > 0
 	) {
-		keyword_rungs_storage[0] = keywords;
+		chain = metaclass_chain(handoff);
 
-		if (weakref_requested) {
-			weakref_only = PyDict_New();
+		if (chain == NULL) {
+			return NULL;
+		}
 
-			if (
-				weakref_only == NULL ||
-				PyDict_SetItemString(weakref_only, option_keywords[OPTION_WEAKREF], Py_True) < 0
-			) {
-				return NULL;
+		verdict = chain_probe(chain, keywords, weakref_requested);
+
+		if (verdict.accepts_all < 0) {
+			return NULL;
+		}
+
+		if (verdict.readable) {
+			if (verdict.accepts_all == 1) {
+				forwarded_keywords = keywords;
+			} else if (weakref_requested && verdict.accepts_weakref == 1) {
+				weakref_only = PyDict_New();
+
+				if (
+					weakref_only == NULL ||
+					PyDict_SetItemString(weakref_only, option_keywords[OPTION_WEAKREF], Py_True) <
+						0
+				) {
+					return NULL;
+				}
+
+				forwarded_keywords = weakref_only;
 			}
-
-			keyword_rungs_storage[1] = weakref_only;
-			keyword_rung_count = 3;
 		} else {
-			keyword_rung_count = 2;
+			keyword_rungs_storage[0] = keywords;
+			laddered = true;
+
+			if (weakref_requested) {
+				weakref_only = PyDict_New();
+
+				if (
+					weakref_only == NULL ||
+					PyDict_SetItemString(weakref_only, option_keywords[OPTION_WEAKREF], Py_True) <
+						0
+				) {
+					return NULL;
+				}
+
+				keyword_rungs_storage[1] = weakref_only;
+				keyword_rung_count = 3;
+			} else {
+				keyword_rung_count = 2;
+			}
 		}
 	}
 
-	struct field_plan plan = field_plan_build(base, original_namespace);
+	if (
+		request.options.weakref &&
+		!weakref_carried &&
+		handoff->tp_new != StructMeta_new &&
+		verdict.readable &&
+		verdict.accepts_weakref == 0
+	) {
+		PyErr_SetString(
+			PyExc_TypeError,
+			"weakref=True cannot cross a metaclass __new__ that hands the build "
+			"off: the re-entered call cannot add the weakref slot"
+		);
+
+		return NULL;
+	}
+
+struct field_plan plan = field_plan_build(base, original_namespace);
 
 	if (field_plan_failed(&plan)) {
 		return NULL;
@@ -333,6 +396,8 @@ PyObject * build_struct_class(
 			namespace,
 			keyword_rungs,
 			keyword_rung_count,
+			forwarded_keywords,
+			laddered,
 			state->handoff_attempt,
 			state->handoff_declined,
 			state->handoff_new
@@ -407,6 +472,145 @@ PyObject * build_struct_class(
 	return (PyObject *) struct_class;
 }
 
+static int code_accepts_keyword(
+	PyCodeObject * const code,
+	PyObject * const varnames,
+	char const * const keyword
+) {
+	Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
+
+	for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
+		int const compared = PyUnicode_CompareWithASCIIString(
+			PyTuple_GET_ITEM(varnames, i),
+			keyword
+		);
+
+		if (compared == 0) {
+			return 1;
+		}
+
+		if (compared < 0 && PyErr_Occurred()) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static struct chain_verdict chain_probe(
+	PyObject * const chain,
+	PyObject * const keywords,
+	bool const weakref_column
+) {
+	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
+
+	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
+		PyObject * const link = PyList_GET_ITEM(chain, i);
+
+		if (!PyFunction_Check(link)) {
+			verdict.readable = false;
+			verdict.accepts_all = 0;
+			verdict.accepts_weakref = 0;
+			continue;
+		}
+
+		PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) link)->func_code;
+
+		if ((code->co_flags & CO_VARKEYWORDS) != 0) {
+			continue;
+		}
+
+#if PY_VERSION_HEX >= 0x030B0000
+		PY_OWNED(varnames, PyCode_GetVarnames(code));
+#else
+		PyObject * const varnames = code->co_varnames;
+#endif
+
+		if (varnames == NULL) {
+			verdict.accepts_all = -1;
+
+			return verdict;
+		}
+
+		Py_ssize_t position = 0;
+		PyObject * key;
+		PyObject * value;
+
+		while (PyDict_Next(keywords, &position, &key, &value)) {
+			char const * const name = PyUnicode_AsUTF8(key);
+
+			if (name == NULL) {
+				verdict.accepts_all = -1;
+
+				return verdict;
+			}
+
+			int const accepts = code_accepts_keyword(code, varnames, name);
+
+			if (accepts < 0) {
+				verdict.accepts_all = -1;
+
+				return verdict;
+			}
+
+			if (accepts == 0) {
+				verdict.accepts_all = 0;
+				break;
+			}
+		}
+
+		if (weakref_column) {
+			int const accepts_weakref = code_accepts_keyword(
+				code,
+				varnames,
+				option_keywords[OPTION_WEAKREF]
+			);
+
+			if (accepts_weakref < 0) {
+				verdict.accepts_all = -1;
+
+				return verdict;
+			}
+
+			if (accepts_weakref == 0) {
+				verdict.accepts_weakref = 0;
+			}
+		}
+	}
+
+	return verdict;
+}
+
+static PyObject * metaclass_chain(PyTypeObject * const winner) {
+	PY_MOVABLE(chain, PyList_New(0));
+
+	if (chain == NULL) {
+		return NULL;
+	}
+
+	PyObject * const mro = winner->tp_mro;
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
+		PyTypeObject * const link = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
+
+		if (link == &StructMeta_Type || link == &PyType_Type) {
+			break;
+		}
+
+		if (link->tp_new == StructMeta_new) {
+			continue;
+		}
+
+		PY_OWNED(new, PyObject_GetAttrString((PyObject *) link, "__new__"));
+
+		if (new == NULL || PyList_Append(chain, new) < 0) {
+			return NULL;
+		}
+	}
+
+	return py_move(&chain);
+}
+
 static StructType * create_class(
 	PyTypeObject * const metatype,
 	PyTypeObject * const handoff,
@@ -415,6 +619,8 @@ static StructType * create_class(
 	PyObject * const namespace,
 	PyObject * const * const keyword_rungs,
 	Py_ssize_t const keyword_rung_count,
+	PyObject * forwarded_keywords,
+	bool const laddered,
 	PyObject * const handoff_attempt,
 	PyObject * const handoff_declined,
 	PyObject * const handoff_new
@@ -428,7 +634,19 @@ static StructType * create_class(
 	PyTypeObject * const builder = handoff->tp_new == StructMeta_new ? handoff : metatype;
 	PyObject * created = NULL;
 
-	for (Py_ssize_t attempt = 0; created == NULL && attempt < keyword_rung_count; ++attempt) {
+	if (!laddered) {
+		created = PyType_Type.tp_new(
+			builder,
+			type_args,
+			builder == handoff ? NULL : forwarded_keywords
+		);
+	}
+
+	for (
+		Py_ssize_t attempt = 0;
+		created == NULL && laddered && attempt < keyword_rung_count;
+		++attempt
+	) {
 		created = PyObject_CallFunctionObjArgs(
 			handoff_attempt,
 			handoff_new,
@@ -461,15 +679,7 @@ static StructType * create_class(
 		}
 
 		if (declined) {
-			PY_OWNED(message, PyObject_Str(exception_value));
-			Py_XDECREF(exception_type);
-			Py_XDECREF(exception_value);
-			Py_XDECREF(exception_tb);
-
-			if (message != NULL) {
-				PyErr_SetObject(PyExc_TypeError, message);
-			}
-
+			PyErr_Restore(exception_type, exception_value, exception_tb);
 			break;
 		}
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -32,7 +32,10 @@ static StructType * create_class(
 	PyObject * bases,
 	PyObject * namespace,
 	PyObject * const * keyword_rungs,
-	Py_ssize_t keyword_rung_count
+	Py_ssize_t keyword_rung_count,
+	PyObject * handoff_attempt,
+	PyObject * handoff_declined,
+	PyObject * handoff_new
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
 
@@ -211,7 +214,8 @@ PyObject * build_struct_class(
 	PyObject * const name,
 	PyObject * const bases,
 	PyObject * const original_namespace,
-	PyObject * const keywords
+	PyObject * const keywords,
+	struct salix_state * const state
 ) {
 	StructType const * const behaviour = find_behaviour_base(bases);
 	bool promised_frozen = false;
@@ -328,7 +332,10 @@ PyObject * build_struct_class(
 			bases,
 			namespace,
 			keyword_rungs,
-			keyword_rung_count
+			keyword_rung_count,
+			state->handoff_attempt,
+			state->handoff_declined,
+			state->handoff_new
 		) :
 		NULL
 	);
@@ -400,54 +407,6 @@ PyObject * build_struct_class(
 	return (PyObject *) struct_class;
 }
 
-static bool binding_type_error(PyObject * const exception_value) {
-	PyObject * message = NULL;
-
-	if (PyUnicode_Check(exception_value)) {
-		message = exception_value;
-	} else {
-		if (!PyErr_GivenExceptionMatches(exception_value, PyExc_TypeError)) {
-			return false;
-		}
-
-		PyObject * const args = ((PyBaseExceptionObject *) exception_value)->args;
-
-		if (!PyTuple_Check(args) || PyTuple_GET_SIZE(args) == 0) {
-			return false;
-		}
-
-		message = PyTuple_GET_ITEM(args, 0);
-
-		if (!PyUnicode_Check(message)) {
-			return false;
-		}
-	}
-
-	Py_ssize_t size = 0;
-	char const * const text = PyUnicode_AsUTF8AndSize(message, &size);
-
-	if (text == NULL) {
-		PyErr_Clear();
-
-		return false;
-	}
-
-	static char const * const prefixes[] = {
-		"got an unexpected keyword argument",
-		"got multiple values for keyword argument",
-		"missing ",
-		"takes ",
-	};
-
-	for (Py_ssize_t i = 0; i < 4; ++i) {
-		if (strstr(text, prefixes[i]) != NULL) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 static StructType * create_class(
 	PyTypeObject * const metatype,
 	PyTypeObject * const handoff,
@@ -455,7 +414,10 @@ static StructType * create_class(
 	PyObject * const bases,
 	PyObject * const namespace,
 	PyObject * const * const keyword_rungs,
-	Py_ssize_t const keyword_rung_count
+	Py_ssize_t const keyword_rung_count,
+	PyObject * const handoff_attempt,
+	PyObject * const handoff_declined,
+	PyObject * const handoff_new
 ) {
 	PY_OWNED(type_args, PyTuple_Pack(3, name, bases, namespace));
 
@@ -467,13 +429,17 @@ static StructType * create_class(
 	PyObject * created = NULL;
 
 	for (Py_ssize_t attempt = 0; created == NULL && attempt < keyword_rung_count; ++attempt) {
-		created = PyType_Type.tp_new(
+		created = PyObject_CallFunctionObjArgs(
+			handoff_attempt,
+			handoff_new,
 			builder,
 			type_args,
-			builder == handoff ? NULL : keyword_rungs[attempt]
+			builder == handoff || keyword_rungs[attempt] == NULL ? Py_None :
+			keyword_rungs[attempt],
+			NULL
 		);
 
-		if (created != NULL || attempt + 1 == keyword_rung_count) {
+		if (created != NULL) {
 			break;
 		}
 
@@ -482,14 +448,33 @@ static StructType * create_class(
 		PyObject * exception_tb = NULL;
 		PyErr_Fetch(&exception_type, &exception_value, &exception_tb);
 
-		if (!binding_type_error(exception_value)) {
-			PyErr_Restore(exception_type, exception_value, exception_tb);
+		bool const declined = (
+			exception_value != NULL &&
+			PyErr_GivenExceptionMatches(exception_value, handoff_declined)
+		);
+
+		if (declined && attempt + 1 < keyword_rung_count) {
+			Py_XDECREF(exception_type);
+			Py_XDECREF(exception_value);
+			Py_XDECREF(exception_tb);
+			continue;
+		}
+
+		if (declined) {
+			PY_OWNED(message, PyObject_Str(exception_value));
+			Py_XDECREF(exception_type);
+			Py_XDECREF(exception_value);
+			Py_XDECREF(exception_tb);
+
+			if (message != NULL) {
+				PyErr_SetObject(PyExc_TypeError, message);
+			}
+
 			break;
 		}
 
-		Py_XDECREF(exception_type);
-		Py_XDECREF(exception_value);
-		Py_XDECREF(exception_tb);
+		PyErr_Restore(exception_type, exception_value, exception_tb);
+		break;
 	}
 
 	if (created == NULL) {
@@ -503,6 +488,8 @@ static StructType * create_class(
 			handoff->tp_name,
 			Py_TYPE(created)->tp_name
 		);
+
+		Py_DECREF(created);
 
 		return NULL;
 	}

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -31,17 +31,11 @@ static StructType * create_class(
 	PyObject * name,
 	PyObject * bases,
 	PyObject * namespace,
-	PyObject * forwarded_keywords
+	PyObject * const * keyword_rungs,
+	Py_ssize_t keyword_rung_count
 );
 static PyTypeObject * winning_metatype(PyTypeObject * requested, PyObject * bases);
-struct chain_verdict {
-	int accepts_all;
-	int accepts_weakref;
-	bool readable;
-};
-static int code_accepts_keyword(PyCodeObject * code, PyObject * varnames, char const * keyword);
-static PyObject * metaclass_chain(PyTypeObject * winner);
-static struct chain_verdict chain_probe(PyObject * chain, PyObject * keywords, bool weakref_column);
+
 static enum result install_fields(
 	StructType * struct_class,
 	StructType const * base,
@@ -234,10 +228,10 @@ PyObject * build_struct_class(
 	request.options.weakref |= weakref_carried;
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
-	PyObject * forwarded_keywords = NULL;
 	PY_MOVABLE(weakref_only, NULL);
-	PY_MOVABLE(chain, NULL);
-	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
+	PyObject * keyword_rungs_storage[3] = {NULL, NULL, NULL};
+	PyObject * const * keyword_rungs = keyword_rungs_storage;
+	Py_ssize_t keyword_rung_count = 1;
 
 	if (
 		handoff != metatype &&
@@ -245,21 +239,9 @@ PyObject * build_struct_class(
 		keywords != NULL &&
 		PyDict_GET_SIZE(keywords) > 0
 	) {
-		chain = metaclass_chain(handoff);
+		keyword_rungs_storage[0] = keywords;
 
-		if (chain == NULL) {
-			return NULL;
-		}
-
-		verdict = chain_probe(chain, keywords, weakref_requested);
-
-		if (verdict.accepts_all < 0) {
-			return NULL;
-		}
-
-		if (verdict.accepts_all == 1) {
-			forwarded_keywords = keywords;
-		} else if (weakref_requested && verdict.accepts_weakref == 1) {
+		if (weakref_requested) {
 			weakref_only = PyDict_New();
 
 			if (
@@ -269,27 +251,11 @@ PyObject * build_struct_class(
 				return NULL;
 			}
 
-			forwarded_keywords = weakref_only;
+			keyword_rungs_storage[1] = weakref_only;
+			keyword_rung_count = 3;
+		} else {
+			keyword_rung_count = 2;
 		}
-	}
-
-	if (
-		request.options.weakref &&
-		!weakref_carried &&
-		handoff->tp_new != StructMeta_new &&
-		verdict.accepts_weakref == 0
-	) {
-		PyErr_SetString(
-			PyExc_TypeError,
-			verdict.readable ?
-				"weakref=True cannot cross a metaclass __new__ that hands the build "
-				"off: the re-entered call cannot add the weakref slot" :
-				"weakref=True cannot cross a metaclass __new__ that hands the build "
-				"off: the chain contains a __new__ whose signature cannot be read, so "
-				"the re-entered call cannot be verified to add the weakref slot"
-		);
-
-		return NULL;
 	}
 
 	struct field_plan plan = field_plan_build(base, original_namespace);
@@ -361,7 +327,8 @@ PyObject * build_struct_class(
 			name,
 			bases,
 			namespace,
-			forwarded_keywords
+			keyword_rungs,
+			keyword_rung_count
 		) :
 		NULL
 	);
@@ -433,13 +400,62 @@ PyObject * build_struct_class(
 	return (PyObject *) struct_class;
 }
 
+static bool binding_type_error(PyObject * const exception_value) {
+	PyObject * message = NULL;
+
+	if (PyUnicode_Check(exception_value)) {
+		message = exception_value;
+	} else {
+		if (!PyErr_GivenExceptionMatches(exception_value, PyExc_TypeError)) {
+			return false;
+		}
+
+		PyObject * const args = ((PyBaseExceptionObject *) exception_value)->args;
+
+		if (!PyTuple_Check(args) || PyTuple_GET_SIZE(args) == 0) {
+			return false;
+		}
+
+		message = PyTuple_GET_ITEM(args, 0);
+
+		if (!PyUnicode_Check(message)) {
+			return false;
+		}
+	}
+
+	Py_ssize_t size = 0;
+	char const * const text = PyUnicode_AsUTF8AndSize(message, &size);
+
+	if (text == NULL) {
+		PyErr_Clear();
+
+		return false;
+	}
+
+	static char const * const prefixes[] = {
+		"got an unexpected keyword argument",
+		"got multiple values for keyword argument",
+		"missing ",
+		"takes ",
+	};
+
+	for (Py_ssize_t i = 0; i < 4; ++i) {
+		if (strstr(text, prefixes[i]) != NULL) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static StructType * create_class(
 	PyTypeObject * const metatype,
 	PyTypeObject * const handoff,
 	PyObject * const name,
 	PyObject * const bases,
 	PyObject * const namespace,
-	PyObject * const forwarded_keywords
+	PyObject * const * const keyword_rungs,
+	Py_ssize_t const keyword_rung_count
 ) {
 	PY_OWNED(type_args, PyTuple_Pack(3, name, bases, namespace));
 
@@ -448,11 +464,33 @@ static StructType * create_class(
 	}
 
 	PyTypeObject * const builder = handoff->tp_new == StructMeta_new ? handoff : metatype;
+	PyObject * created = NULL;
 
-	PY_MOVABLE(
-		created,
-		PyType_Type.tp_new(builder, type_args, builder == handoff ? NULL : forwarded_keywords)
-	);
+	for (Py_ssize_t attempt = 0; created == NULL && attempt < keyword_rung_count; ++attempt) {
+		created = PyType_Type.tp_new(
+			builder,
+			type_args,
+			builder == handoff ? NULL : keyword_rungs[attempt]
+		);
+
+		if (created != NULL || attempt + 1 == keyword_rung_count) {
+			break;
+		}
+
+		PyObject * exception_type = NULL;
+		PyObject * exception_value = NULL;
+		PyObject * exception_tb = NULL;
+		PyErr_Fetch(&exception_type, &exception_value, &exception_tb);
+
+		if (!binding_type_error(exception_value)) {
+			PyErr_Restore(exception_type, exception_value, exception_tb);
+			break;
+		}
+
+		Py_XDECREF(exception_type);
+		Py_XDECREF(exception_value);
+		Py_XDECREF(exception_tb);
+	}
 
 	if (created == NULL) {
 		return NULL;
@@ -470,145 +508,6 @@ static StructType * create_class(
 	}
 
 	return (StructType *) py_move(&created);
-}
-
-static int code_accepts_keyword(
-	PyCodeObject * const code,
-	PyObject * const varnames,
-	char const * const keyword
-) {
-	Py_ssize_t const named = code->co_argcount + code->co_kwonlyargcount;
-
-	for (Py_ssize_t i = code->co_posonlyargcount; i < named; ++i) {
-		int const compared = PyUnicode_CompareWithASCIIString(
-			PyTuple_GET_ITEM(varnames, i),
-			keyword
-		);
-
-		if (compared == 0) {
-			return 1;
-		}
-
-		if (compared < 0 && PyErr_Occurred()) {
-			return -1;
-		}
-	}
-
-	return 0;
-}
-
-static struct chain_verdict chain_probe(
-	PyObject * const chain,
-	PyObject * const keywords,
-	bool const weakref_column
-) {
-	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
-
-	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(chain); ++i) {
-		PyObject * const link = PyList_GET_ITEM(chain, i);
-
-		if (!PyFunction_Check(link)) {
-			verdict.readable = false;
-			verdict.accepts_all = 0;
-			verdict.accepts_weakref = 0;
-			continue;
-		}
-
-		PyCodeObject * const code = (PyCodeObject *) ((PyFunctionObject *) link)->func_code;
-
-		if ((code->co_flags & CO_VARKEYWORDS) != 0) {
-			continue;
-		}
-
-#if PY_VERSION_HEX >= 0x030B0000
-		PY_OWNED(varnames, PyCode_GetVarnames(code));
-#else
-		PyObject * const varnames = code->co_varnames;
-#endif
-
-		if (varnames == NULL) {
-			verdict.accepts_all = -1;
-
-			return verdict;
-		}
-
-		Py_ssize_t position = 0;
-		PyObject * key;
-		PyObject * value;
-
-		while (PyDict_Next(keywords, &position, &key, &value)) {
-			char const * const name = PyUnicode_AsUTF8(key);
-
-			if (name == NULL) {
-				verdict.accepts_all = -1;
-
-				return verdict;
-			}
-
-			int const accepts = code_accepts_keyword(code, varnames, name);
-
-			if (accepts < 0) {
-				verdict.accepts_all = -1;
-
-				return verdict;
-			}
-
-			if (accepts == 0) {
-				verdict.accepts_all = 0;
-				break;
-			}
-		}
-
-		if (weakref_column) {
-			int const accepts_weakref = code_accepts_keyword(
-				code,
-				varnames,
-				option_keywords[OPTION_WEAKREF]
-			);
-
-			if (accepts_weakref < 0) {
-				verdict.accepts_all = -1;
-
-				return verdict;
-			}
-
-			if (accepts_weakref == 0) {
-				verdict.accepts_weakref = 0;
-			}
-		}
-	}
-
-	return verdict;
-}
-
-static PyObject * metaclass_chain(PyTypeObject * const winner) {
-	PY_MOVABLE(chain, PyList_New(0));
-
-	if (chain == NULL) {
-		return NULL;
-	}
-
-	PyObject * const mro = winner->tp_mro;
-
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
-		PyTypeObject * const link = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
-
-		if (link == &StructMeta_Type || link == &PyType_Type) {
-			break;
-		}
-
-		if (link->tp_new == StructMeta_new) {
-			continue;
-		}
-
-		PY_OWNED(new, PyObject_GetAttrString((PyObject *) link, "__new__"));
-
-		if (new == NULL || PyList_Append(chain, new) < 0) {
-			return NULL;
-		}
-	}
-
-	return py_move(&chain);
 }
 
 /* It is the third walk of `bases` in a class creation, after find_struct_base

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -406,6 +406,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 	);
 
 	if (struct_class != NULL) {
+		struct_class->struct_state = base != NULL ? base->struct_state : NULL;
 		enum result const settled = (
 			struct_class->struct_field_names == NULL ? install_fields(
 				struct_class,
@@ -679,7 +680,28 @@ static StructType * create_class(
 		}
 
 		if (declined) {
-			PyErr_Restore(exception_type, exception_value, exception_tb);
+			PyObject * const original_tb = PyException_GetTraceback(exception_value);
+			PY_OWNED(message, PyObject_Str(exception_value));
+			Py_XDECREF(exception_type);
+			Py_XDECREF(exception_value);
+			Py_XDECREF(exception_tb);
+
+			if (message != NULL) {
+				PyErr_SetObject(PyExc_TypeError, message);
+
+				if (original_tb != NULL) {
+					PyObject * exc_type = NULL;
+					PyObject * exc_value = NULL;
+					PyObject * exc_tb = NULL;
+					PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
+					PyException_SetTraceback(exc_value, Py_NewRef(original_tb));
+					PyErr_Restore(exc_type, exc_value, exc_tb);
+					Py_DECREF(original_tb);
+				}
+			} else {
+				Py_XDECREF(original_tb);
+			}
+
 			break;
 		}
 
@@ -1071,12 +1093,7 @@ static enum result settle_mro_bindings(
 	}
 
 	PyTypeObject * const first_struct = (PyTypeObject *) find_behaviour_base(bases);
-
-	struct salix_state * const state = settle_state(type);
-
-	if (state == NULL) {
-		return RESULT_ERROR;
-	}
+	struct salix_state * const state = struct_class->struct_state;
 
 	PY_MOVABLE(resolved_eq, NULL);
 	PY_MOVABLE(resolved_ne, NULL);

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -101,7 +101,12 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
-	return build_struct_class(metatype, base, name, bases, original_namespace, keywords);
+	struct salix_state * const state = settle_state((PyTypeObject *) base);
+
+	return (
+		state == NULL ? NULL :
+		build_struct_class(metatype, base, name, bases, original_namespace, keywords, state)
+	);
 }
 
 PyObject * struct_create_root(
@@ -110,13 +115,20 @@ PyObject * struct_create_root(
 	PyObject * const namespace,
 	PyObject * const module
 ) {
+	struct salix_state * const state = (struct salix_state *) PyModule_GetState(module);
+
+	if (state == NULL) {
+		return NULL;
+	}
+
 	PyObject * const root = build_struct_class(
 		&StructMeta_Type,
 		NULL,
 		name,
 		bases,
 		namespace,
-		NULL
+		NULL,
+		state
 	);
 
 	if (root == NULL) {

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -101,11 +101,14 @@ PyObject * StructMeta_new(
 		return NULL;
 	}
 
-	struct salix_state * const state = settle_state((PyTypeObject *) base);
-
-	return (
-		state == NULL ? NULL :
-		build_struct_class(metatype, base, name, bases, original_namespace, keywords, state)
+	return build_struct_class(
+		metatype,
+		base,
+		name,
+		bases,
+		original_namespace,
+		keywords,
+		base->struct_state
 	);
 }
 
@@ -137,6 +140,7 @@ PyObject * struct_create_root(
 
 	/* The settle reaches the module state through the type chain, so the
 	 * root carries the association every subclass inherits the walk to. */
+	((StructType *) root)->struct_state = (struct salix_state *) PyModule_GetState(module);
 	Py_XSETREF(((PyHeapTypeObject *) root)->ht_module, Py_NewRef(module));
 
 	return root;

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -76,7 +76,6 @@ struct salix_state {
 };
 
 enum result settle_cache_fill(struct salix_state * state);
-struct salix_state * settle_state(PyTypeObject * type);
 PyModuleDef * salix_module_def(void);
 bool any_base_has_weakref_slot(PyObject * bases);
 bool any_base_diverts_setattro(PyObject * bases);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -70,6 +70,9 @@ enum { SETTLE_BINDING_COUNT = 7 };
 struct salix_state {
 	PyObject * mixin_bindings[SETTLE_BINDING_COUNT];
 	PyObject * object_bindings[SETTLE_BINDING_COUNT];
+	PyObject * handoff_attempt;
+	PyObject * handoff_declined;
+	PyObject * handoff_new;
 };
 
 enum result settle_cache_fill(struct salix_state * state);
@@ -134,5 +137,6 @@ PyObject * build_struct_class(
 	PyObject * name,
 	PyObject * bases,
 	PyObject * original_namespace,
-	PyObject * keywords
+	PyObject * keywords,
+	struct salix_state * state
 );

--- a/src/salix.c
+++ b/src/salix.c
@@ -10,6 +10,7 @@
 static int struct_exec(PyObject * module);
 static enum result add_struct_base(PyObject * module);
 static PyObject * create_struct_base(PyObject * module);
+static PyObject * handoff_new(PyObject * self, PyObject * args);
 static void struct_free(void * module);
 
 /*
@@ -94,6 +95,95 @@ static void struct_free(void * const module) {
 		Py_CLEAR(state->mixin_bindings[i]);
 		Py_CLEAR(state->object_bindings[i]);
 	}
+
+	Py_CLEAR(state->handoff_attempt);
+	Py_CLEAR(state->handoff_declined);
+	Py_CLEAR(state->handoff_new);
+}
+
+static PyMethodDef handoff_new_method = {
+	.ml_name = "_handoff_new",
+	.ml_meth = handoff_new,
+	.ml_flags = METH_VARARGS,
+	.ml_doc = NULL,
+};
+
+static PyObject * build_handoff_machinery(struct salix_state * const state) {
+	static char const * const source =
+		"class _HandoffDeclined(TypeError):\n"
+		"    pass\n"
+		"\n"
+		"\n"
+		"def _handoff_attempt(\n"
+		"    new, builder, type_args, keywords, declined=_HandoffDeclined, own_name=\"_handoff_attempt\"\n"
+		"):\n"
+		"    try:\n"
+		"        return new(builder, type_args, keywords)\n"
+		"    except TypeError as error:\n"
+		"        tb = error.__traceback__\n"
+		"        while tb is not None and tb.tb_next is not None:\n"
+		"            tb = tb.tb_next\n"
+		"        message = str(error)\n"
+		"        if (\n"
+		"            tb is not None\n"
+		"            and tb.tb_frame is not None\n"
+		"            and tb.tb_frame.f_code.co_name == own_name\n"
+		"            and tb.tb_frame.f_code.co_filename == \"<salix handoff>\"\n"
+		"        ) or (\n"
+		"            \"got an unexpected keyword argument\" in message\n"
+		"            or \"got multiple values for keyword argument\" in message\n"
+		"        ):\n"
+		"            raise declined(message) from None\n"
+		"        raise\n";
+
+	PY_OWNED(code, Py_CompileString(source, "<salix handoff>", Py_file_input));
+	PY_OWNED(globals_dict, PyDict_New());
+	PY_OWNED(new_fn, PyCFunction_New(&handoff_new_method, NULL));
+
+	if (code == NULL || globals_dict == NULL || new_fn == NULL) {
+		return NULL;
+	}
+
+	PY_OWNED(result, PyEval_EvalCode(code, globals_dict, globals_dict));
+
+	if (result == NULL) {
+		return NULL;
+	}
+
+	PyObject * const attempt = PyDict_GetItemString(globals_dict, "_handoff_attempt");
+	PyObject * const declined = PyDict_GetItemString(globals_dict, "_HandoffDeclined");
+
+	if (attempt == NULL || declined == NULL) {
+		return NULL;
+	}
+
+	Py_XSETREF(state->handoff_attempt, Py_NewRef(attempt));
+	Py_XSETREF(state->handoff_declined, Py_NewRef(declined));
+	Py_XSETREF(state->handoff_new, Py_NewRef(new_fn));
+
+	return state->handoff_attempt;
+}
+
+static PyObject * handoff_new(PyObject * const self, PyObject * const args) {
+	PyObject * builder;
+	PyObject * type_args;
+	PyObject * keywords;
+
+	if (!PyArg_ParseTuple(args, "OO!O", &builder, &PyTuple_Type, &type_args, &keywords)) {
+		return NULL;
+	}
+
+	if (!PyType_Check(builder)) {
+		PyErr_SetString(PyExc_TypeError, "the hand-off builder is not a type");
+
+		return NULL;
+	}
+
+	return PyType_Type.tp_new(
+		(PyTypeObject *) builder,
+		type_args,
+		keywords == Py_None ? NULL : keywords
+	);
 }
 
 static int struct_exec(PyObject * const module) {
@@ -106,6 +196,10 @@ static int struct_exec(PyObject * const module) {
 	struct salix_state * const state = (struct salix_state *) PyModule_GetState(module);
 
 	if (state == NULL || settle_cache_fill(state) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
+	if (build_handoff_machinery(state) == NULL) {
 		return RESULT_ERROR;
 	}
 

--- a/src/salix.c
+++ b/src/salix.c
@@ -123,17 +123,13 @@ static PyObject * build_handoff_machinery(struct salix_state * const state) {
 		"        tb = error.__traceback__\n"
 		"        while tb is not None and tb.tb_next is not None:\n"
 		"            tb = tb.tb_next\n"
-		"        message = str(error)\n"
 		"        if (\n"
 		"            tb is not None\n"
 		"            and tb.tb_frame is not None\n"
 		"            and tb.tb_frame.f_code.co_name == own_name\n"
 		"            and tb.tb_frame.f_code.co_filename == \"<salix handoff>\"\n"
-		"        ) or (\n"
-		"            \"got an unexpected keyword argument\" in message\n"
-		"            or \"got multiple values for keyword argument\" in message\n"
 		"        ):\n"
-		"            raise declined(message) from None\n"
+		"            raise declined(str(error)).with_traceback(error.__traceback__) from None\n"
 		"        raise\n";
 
 	PY_OWNED(code, Py_CompileString(source, "<salix handoff>", Py_file_input));

--- a/src/salix.c
+++ b/src/salix.c
@@ -58,32 +58,6 @@ PyModuleDef * salix_module_def(void) {
 	return &struct_module;
 }
 
-struct salix_state * settle_state(PyTypeObject * const type) {
-	PyObject * const mro = type->tp_mro;
-
-	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(mro); ++i) {
-		PyTypeObject * const entry = (PyTypeObject *) PyTuple_GET_ITEM(mro, i);
-
-		if (!PyType_HasFeature(entry, Py_TPFLAGS_HEAPTYPE)) {
-			continue;
-		}
-
-		PyObject * const module = ((PyHeapTypeObject *) entry)->ht_module;
-
-		if (
-			module != NULL &&
-			PyModule_Check(module) &&
-			PyModule_GetDef(module) == salix_module_def()
-		) {
-			return (struct salix_state *) PyModule_GetState(module);
-		}
-	}
-
-	PyErr_Format(PyExc_SystemError, "%.200s was not built by the salix module", type->tp_name);
-
-	return NULL;
-}
-
 static void struct_free(void * const module) {
 	/* m_free receives the module object on every supported version, so the
 	 * state is reached back through it. */
@@ -135,8 +109,15 @@ static PyObject * build_handoff_machinery(struct salix_state * const state) {
 	PY_OWNED(code, Py_CompileString(source, "<salix handoff>", Py_file_input));
 	PY_OWNED(globals_dict, PyDict_New());
 	PY_OWNED(new_fn, PyCFunction_New(&handoff_new_method, NULL));
+	PY_OWNED(module_name, PyUnicode_FromString(struct_module.m_name));
 
-	if (code == NULL || globals_dict == NULL || new_fn == NULL) {
+	if (
+		code == NULL ||
+		globals_dict == NULL ||
+		new_fn == NULL ||
+		module_name == NULL ||
+		PyDict_SetItemString(globals_dict, "__name__", module_name) < 0
+	) {
 		return NULL;
 	}
 

--- a/src/types.h
+++ b/src/types.h
@@ -21,6 +21,7 @@ enum { SLOT_MEMBER_TYPE = Py_T_OBJECT_EX };
 
 typedef struct StructType {
 	PyHeapTypeObject heap_type;
+	struct salix_state * struct_state;
 
 	PyObject * struct_field_names;
 	PyObject * struct_defaults;

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -360,15 +360,15 @@ class TestAMetaclassSubclass:
         assert built(1, 2) < built(1, 3)
 
     def test_a_delegate_that_cannot_take_the_options_cannot_add_the_weakref_slot(self):
-        """The ladder falls to the keyword-less rung, the re-entered build
-        carries the weakref name without the slot, and the displaced-slot
-        advice refuses it instead of blaming the delegate.
+        """A readable chain whose __new__ cannot take the keywords is refused
+        up front by the probe: the keywords cannot ride, and the refusal says
+        so instead of blaming the entry salix itself wrote.
         """
 
         class Base(Struct, metaclass=Plain):
             x: int
 
-        with pytest.raises(TypeError, match="carries no weakref slot"):
+        with pytest.raises(TypeError, match="cannot cross"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
 
     def test_a_c_slot_delegate_still_builds(self):
@@ -404,6 +404,31 @@ class TestAMetaclassSubclass:
 
             class Base(Struct, metaclass=ClassMethod):
                 x: int
+
+    def test_a_body_type_error_with_a_verbatim_binding_phrase_propagates(self):
+        """Even a verbatim CPython binding phrase in a body TypeError does
+        not make it one: readable chains are decided by the probe without
+        calling the body, and the body's own error propagates with it having
+        run once.
+        """
+
+        calls = []
+
+        class PhraseRaising(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if keywords:
+                    calls.append(1)
+                    raise TypeError("got an unexpected keyword argument 'inner'")
+
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Base(Struct, metaclass=PhraseRaising):
+            x: int
+
+        with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert calls == [1]
 
     def test_a_validation_type_error_with_binding_words_propagates(self):
         """A delegate body that raises a TypeError whose message merely

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -360,15 +360,55 @@ class TestAMetaclassSubclass:
         assert built(1, 2) < built(1, 3)
 
     def test_a_delegate_that_cannot_take_the_options_cannot_add_the_weakref_slot(self):
-        """The keywords cannot ride a __new__ that does not take them, so the
-        refusal says so instead of blaming the entry salix itself wrote.
+        """The ladder falls to the keyword-less rung, the re-entered build
+        carries the weakref name without the slot, and the displaced-slot
+        advice refuses it instead of blaming the delegate.
         """
 
         class Base(Struct, metaclass=Plain):
             x: int
 
-        with pytest.raises(TypeError, match="cannot cross"):
+        with pytest.raises(TypeError, match="carries no weakref slot"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+
+    def test_a_c_slot_delegate_still_builds(self):
+        """A __new__ that is a slot wrapper, not a Python function, used to be
+        refused as unreadable; the ladder attempts it and the keyword-less
+        rung catches it when it declines.
+        """
+
+        class SlottedNew(META):
+            __new__ = type.__new__
+
+        class Base(Struct, metaclass=SlottedNew):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert built(1, 2) < built(1, 3)
+
+    def test_a_body_type_error_propagates_without_a_retry(self):
+        """Only binding failures fall to the next rung; a TypeError the
+        delegate's body raises propagates, and the body ran exactly once.
+        """
+
+        calls = []
+
+        class BodyRaising(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if keywords:
+                    calls.append(1)
+                    raise TypeError("boom")
+
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Base(Struct, metaclass=BodyRaising):
+            x: int
+
+        with pytest.raises(TypeError, match="boom"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert calls == [1]
 
     def test_a_declining_chain_still_gets_the_frozen_record(self):
         """The declining delegate's chain drops the frozen keyword from the

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -373,8 +373,8 @@ class TestAMetaclassSubclass:
 
     def test_a_c_slot_delegate_still_builds(self):
         """A __new__ that is a slot wrapper, not a Python function, used to be
-        refused as unreadable; the ladder attempts it, and weakref -- the one
-        option the settle cannot repair -- proves the keyword really rode.
+        refused as unreadable; the ladder attempts it, and the record comes
+        out right whichever rung carried the keyword.
         """
 
         class SlottedNew(META):
@@ -383,10 +383,9 @@ class TestAMetaclassSubclass:
         class Base(Struct, metaclass=SlottedNew):
             x: int
 
-        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
-        held = built(1, 2)
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
 
-        assert weakref.ref(held)() is held
+        assert built(1, 2) < built(1, 3)
 
     def test_a_classmethod_delegate_keeps_cpythons_own_error(self):
         """The classmethod shape double-binds at CPython's own call

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -373,8 +373,8 @@ class TestAMetaclassSubclass:
 
     def test_a_c_slot_delegate_still_builds(self):
         """A __new__ that is a slot wrapper, not a Python function, used to be
-        refused as unreadable; the ladder attempts it and the keyword-less
-        rung catches it when it declines.
+        refused as unreadable; the ladder attempts it, and weakref -- the one
+        option the settle cannot repair -- proves the keyword really rode.
         """
 
         class SlottedNew(META):
@@ -383,9 +383,51 @@ class TestAMetaclassSubclass:
         class Base(Struct, metaclass=SlottedNew):
             x: int
 
-        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+        held = built(1, 2)
 
-        assert built(1, 2) < built(1, 3)
+        assert weakref.ref(held)() is held
+
+    def test_a_classmethod_delegate_keeps_cpythons_own_error(self):
+        """The classmethod shape double-binds at CPython's own call
+        convention (five args into four, measured on the pre-PR head too), so
+        every build through it fails with that error -- the ladder surfaces
+        it rather than a gate-side refusal.
+        """
+
+        class ClassMethod(META):
+            @classmethod
+            def __new__(metacls, name, bases, namespace, **keywords):
+                return super().__new__(metacls, name, bases, namespace, **keywords)
+
+        with pytest.raises(TypeError, match="takes 4 positional arguments but 5 were given"):
+
+            class Base(Struct, metaclass=ClassMethod):
+                x: int
+
+    def test_a_validation_type_error_with_binding_words_propagates(self):
+        """A delegate body that raises a TypeError whose message merely
+        contains binding words is not a binding failure; it propagates and
+        the body ran once.
+        """
+
+        calls = []
+
+        class Validating(META):
+            def __new__(metacls, name, bases, namespace, **keywords):
+                if keywords:
+                    calls.append(1)
+                    raise TypeError("missing something is not a binding failure")
+
+                return super().__new__(metacls, name, bases, namespace)
+
+        class Base(Struct, metaclass=Validating):
+            x: int
+
+        with pytest.raises(TypeError, match="not a binding failure"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, order=True)
+
+        assert calls == [1]
 
     def test_a_body_type_error_propagates_without_a_retry(self):
         """Only binding failures fall to the next rung; a TypeError the


### PR DESCRIPTION
# The hand-off gate attempts the forwarding call and falls back on binding failure

Fixes #108 (the #107 round-18 systemic's redesign, per the evaluation posted on the issue).

<details>
<summary>Round 3: the state rides the class, the decline unwraps, and the boundary is final</summary>

- The private `_HandoffDeclined` no longer reaches users: the final-rung decline unwraps to a plain `TypeError` with the original traceback re-attached via `PyException_SetTraceback`, and the shim's exec globals carry `__name__ = "salix"` so the private class's metadata is right even if ever seen.
- The per-class `settle_state` MRO walk is gone from the hot path: the state pointer rides on `StructType.struct_state`, copied from the base at build time and set on the root at creation — the walk existed only to find what the class now carries, so `settle_state` is deleted outright.
- The C-slot pin no longer claims a mechanism it cannot observe (the weakref slot rides the namespace `__slots__`, not the keywords — the reviewer's measurement); it asserts the record's outcome instead.
- The C-delegate retry ambiguity is the documented, final boundary: no construction can observe where a C `tp_new` failed, so the ladder either re-executes or mislabels; it re-executes with the original traceback preserved.
</details>

<details>
<summary>Round 2: readable chains are decided by the probe again; the ladder serves only unreadable links</summary>

The round-2 systemic narrowed the question to two shapes that are structurally indistinguishable by frames or messages — C-implemented delegates (no callee frame exists) and Python delegates forwarding `**kwargs` to a super that cannot take them — and the phrase fallback for the second shape was demonstrated swallowing a body TypeError again. The convergent answer divides the labor:

- **Readable chains** (all-Python-function `__new__` links): the adjudicated probe (`chain_probe`, restored) decides up front with zero execution. A chain-forwarding delegate's decline never runs its body, and a body TypeError containing even a verbatim binding phrase propagates with the body having run once (both pinned).
- **Unreadable links** (C slot wrappers, bound methods, classmethods): the attempt ladder with the frame-identity decline — the only signal that exists, since the systemic itself notes no construction can observe the C boundary. That ambiguity is the documented boundary of the ladder; the final-rung decline restores the original exception so the C delegate's traceback survives.
- The phrase fallback is deleted; the plain no-handoff path calls the C slot directly again (the shim runs only for unreadable chains); the readable-chain "cannot cross" refusal returns with its pin.
</details>

<details>
<summary>Round 1: the attribution is structural now</summary>

The round-1 systemic was demonstrated: a delegate body raising `TypeError` with 'missing '/"takes " in the message was retried, its body ran 2–3 times, and the class built anyway. The message-substring attribution is gone, replaced by the systemic's own prescription — a **module-private exception** raised by a private Python shim:

- Each rung's call goes through `_handoff_attempt` (compiled once at exec into the module state), which invokes the exact C slot call the pre-PR code made via a private C helper `_handoff_new` (`type.__new__` from Python is refused by CPython's own "is not safe" guard — measured).
- On a `TypeError`, the shim walks the materialized traceback: innermost frame == the shim's frame ⇒ the delegate's body never ran ⇒ re-raise `_HandoffDeclined`. A body failure has the delegate's frame innermost and propagates untouched. The C ladder retries only on the private type and unwraps it to a plain `TypeError` on the final rung.
- The shim binds its dependencies as default arguments (no global lookups), and the phrase fallback for the chain-forwarding blind spot (a delegate forwarding `**kwargs` to a super that cannot take them — structurally indistinguishable from a body failure by frames) matches only CPython's two fixed binding phrases; the loose 'missing '/"takes " prefixes are gone.

Also fixed in the round: the `created` leak on the not-a-struct refusal path, the NULL rung passing `Py_None` through the varargs, and the state threading for the root build (its `base` is NULL). The pins now cover the reviewer's demonstrated validation-error shape (propagates, body ran once), the C-slot delegate with weakref (the unrepairable option — the assertion detects a dropped keyword), and the classmethod double-bind (measured identical on the pre-PR head). Mutation-verified both directions: never-decline fails the five fallback pins; always-decline fails exactly the two body-once pins.
</details>

<details>
<summary>The design</summary>

The keyword probe (`chain_probe` + `metaclass_chain` + `code_accepts_keyword` — the code-object introspection the systemic flagged as duplicating CPython's call-time binding) is deleted. The gate is now an attempt ladder around the real build call: the full keyword set, then weakref alone when requested, then keyword-less. A rung falls through only on a `TypeError` attributed to argument binding — which CPython raises before the delegate's body runs — so the success path is the single build call, a body failure propagates as the user's real error, and a delegate body never runs twice.

**The attribution is the call machinery's own message** — "got an unexpected keyword argument", "got multiple values for keyword argument", "missing ", "takes " — matched against the fetched exception. Two measured shapes: on 3.10/3.11 the fetched value is a bare `str` (Py_TYPE is str at the fetch point), on 3.12+ a `TypeError` instance, so the matcher takes both. The traceback is unusable for attribution: measured `tb == NULL` at the fetch point on every version (the exception has not crossed a Python frame yet), and `PyException_GetTraceback` only materializes on 3.12+.
</details>

<details>
<summary>What changed, pinned</summary>

- A C-slot delegate (`__new__ = type.__new__` — the shape the probe refused as unreadable) **builds** (`test_a_c_slot_delegate_still_builds`). Criterion 1.
- A delegate that cannot take the options falls to the keyword-less rung; a weakref the build could not add is refused by the settle's displaced-slot advice, the criteria's floor (`test_a_delegate_that_cannot_take_the_options_cannot_add_the_weakref_slot`, message updated from the old "cannot cross" refusal).
- A body-raised `TypeError` propagates with the body having run exactly once (`test_a_body_type_error_propagates_without_a_retry`). Criterion 2.
- The forwarding, weakref-alone, keyword-less, and swallowing pins keep their outcomes unchanged. Criterion 4.
- The classmethod double-bind shape still fails — with CPython's own five-into-four error, measured. That binding is broken at `type_new`'s call convention, not at the gate; the old probe's decline for it was right, and the ladder at least surfaces the real error.

**Mutation-verified**: the discriminator forced to "never retry" fails the five fallback-dependent pins; forced to "always retry" fails exactly the body-ran-once pin.
</details>

<details>
<summary>Round 4 nits, recorded not chased (converged at 0.18)</summary>

The C-boundary re-execution stands as the declared boundary (rounds 2-3 sections; streak-3 disposition). The six small artifacts: the `builder == handoff` arm of the rung ternary is dead now that the ladder implies a foreign handoff; the decline-unwrap's `str()`-failure branch returns NULL with no exception (same shape as the other error-return-without-exception nit); the root's second `PyModule_GetState` is unguarded; a stale comment describes the deleted settle-state walk; and a lost-indentation leftover from this round's edits. All recorded in the rounds blob.
</details>

## Verification

- C TESTING suite 27/27 on 3.10–3.14; pytest green on 3.10, 3.11, 3.12, 3.14, 3.15, and free-threaded 3.14t; scoped gate green.

> [!WARNING]
> **LLM Disclosure**
>
> This PR body was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt: implement #108's evaluated call-and-fallback redesign for the hand-off keyword gate and drive the PR through the review loop.
