### PR TITLE
fix: one walk, one force for the base-derived options (#115)

### DIFF
--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -205,22 +205,37 @@ static bool carries_fielded_frozen(PyTypeObject const * const base) {
 	return struct_base->struct_field_count > 0 && struct_base->struct_options.frozen;
 }
 
+struct base_facts base_facts_of(PyObject * const bases) {
+	struct base_facts facts = {.fielded_frozen = false, .weakref_carried = false};
+
+	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
+		PyObject * const base = PyTuple_GET_ITEM(bases, i);
+
+		if (!PyType_Check(base)) {
+			continue;
+		}
+
+		facts.fielded_frozen |= carries_fielded_frozen((PyTypeObject *) base);
+		facts.weakref_carried |= carries_weakref_slot((PyTypeObject *) base);
+	}
+
+	return facts;
+}
+
 struct options inherited_options(
 	PyObject * const bases,
 	StructType const * const behaviour,
-	bool * const promised_frozen
+	struct base_facts const facts
 ) {
 	struct options const from_behaviour = base_options(behaviour);
 
-	*promised_frozen = any_base_satisfies(bases, carries_fielded_frozen);
-
 	return (struct options){
-		.frozen = from_behaviour.frozen || *promised_frozen,
+		.frozen = from_behaviour.frozen || facts.fielded_frozen,
 		.eq = from_behaviour.eq,
 		.order = from_behaviour.order,
 		.repr = from_behaviour.repr,
 		.match_args = from_behaviour.match_args,
-		.weakref = from_behaviour.weakref,
+		.weakref = from_behaviour.weakref || facts.weakref_carried,
 	};
 }
 
@@ -271,14 +286,6 @@ static bool carries_diverting_setattro(PyTypeObject const * const base) {
 
 bool any_base_diverts_setattro(PyObject * const bases) {
 	return any_base_satisfies(bases, carries_diverting_setattro);
-}
-
-bool any_base_has_weakref_slot(PyObject * const bases) {
-	return any_base_satisfies(bases, carries_weakref_slot);
-}
-
-bool weakref_expected(struct options const options, PyObject * const bases) {
-	return options.weakref || any_base_satisfies(bases, carries_weakref_slot);
 }
 
 bool any_base_has_instance_dict(PyObject * const bases) {

--- a/src/meta/bases.c
+++ b/src/meta/bases.c
@@ -205,8 +205,28 @@ static bool carries_fielded_frozen(PyTypeObject const * const base) {
 	return struct_base->struct_field_count > 0 && struct_base->struct_options.frozen;
 }
 
-struct base_facts base_facts_of(PyObject * const bases) {
-	struct base_facts facts = {.fielded_frozen = false, .weakref_carried = false};
+static bool carries_instance_dict(PyTypeObject const * const base) {
+	if (base->tp_dictoffset != 0) {
+		return true;
+	}
+
+#if PY_VERSION_HEX >= 0x030C0000
+	return (base->tp_flags & Py_TPFLAGS_HEAPTYPE) != 0 &&
+		(base->tp_flags & Py_TPFLAGS_MANAGED_DICT) != 0;
+#else
+	return false;
+#endif
+}
+
+struct base_survey survey_bases(PyObject * const bases) {
+	struct base_survey survey = {
+		.behaviour = NULL,
+		.facts = {
+			.fielded_frozen = false,
+			.weakref_carried = false,
+			.instance_dict_carried = false,
+		},
+	};
 
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
@@ -215,15 +235,28 @@ struct base_facts base_facts_of(PyObject * const bases) {
 			continue;
 		}
 
-		facts.fielded_frozen |= carries_fielded_frozen((PyTypeObject *) base);
-		facts.weakref_carried |= carries_weakref_slot((PyTypeObject *) base);
+		if (survey.behaviour == NULL && is_struct_class(base)) {
+			survey.behaviour = (StructType *) base;
+		}
+
+		survey.facts.fielded_frozen |= carries_fielded_frozen((PyTypeObject *) base);
+		survey.facts.weakref_carried |= carries_weakref_slot((PyTypeObject *) base);
+		survey.facts.instance_dict_carried |= carries_instance_dict((PyTypeObject *) base);
+
+		if (
+			survey.behaviour != NULL &&
+			survey.facts.fielded_frozen &&
+			survey.facts.weakref_carried &&
+			survey.facts.instance_dict_carried
+		) {
+			break;
+		}
 	}
 
-	return facts;
+	return survey;
 }
 
 struct options inherited_options(
-	PyObject * const bases,
 	StructType const * const behaviour,
 	struct base_facts const facts
 ) {
@@ -252,19 +285,6 @@ bool carries_weakref_slot(PyTypeObject const * const base) {
 #endif
 }
 
-static bool carries_instance_dict(PyTypeObject const * const base) {
-	if (base->tp_dictoffset != 0) {
-		return true;
-	}
-
-#if PY_VERSION_HEX >= 0x030C0000
-	return (base->tp_flags & Py_TPFLAGS_HEAPTYPE) != 0 &&
-		(base->tp_flags & Py_TPFLAGS_MANAGED_DICT) != 0;
-#else
-	return false;
-#endif
-}
-
 static bool any_base_satisfies(PyObject * const bases, bool (*carries)(PyTypeObject const *)) {
 	for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(bases); ++i) {
 		PyObject * const base = PyTuple_GET_ITEM(bases, i);
@@ -286,8 +306,4 @@ static bool carries_diverting_setattro(PyTypeObject const * const base) {
 
 bool any_base_diverts_setattro(PyObject * const bases) {
 	return any_base_satisfies(bases, carries_diverting_setattro);
-}
-
-bool any_base_has_instance_dict(PyObject * const bases) {
-	return any_base_satisfies(bases, carries_instance_dict);
 }

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -229,18 +229,15 @@ PyObject * build_struct_class(
 	struct salix_state * const state
 ) {
 	StructType const * const behaviour = find_behaviour_base(bases);
-	bool promised_frozen = false;
-	bool const weakref_carried = any_base_has_weakref_slot(bases);
-	struct options const inherited = inherited_options(bases, behaviour, &promised_frozen);
-	struct options_request request =
-		options_read(keywords, inherited, promised_frozen, weakref_carried);
+	struct base_facts const facts = base_facts_of(bases);
+	struct options const inherited = inherited_options(bases, behaviour, facts);
+	struct options_request request = options_read(keywords, inherited, facts);
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;
 	}
 
-	bool const weakref_requested = request.options.weakref;
-	request.options.weakref |= weakref_carried;
+	bool const weakref_requested = request.options.weakref && !facts.weakref_carried;
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;
@@ -310,8 +307,7 @@ PyObject * build_struct_class(
 	}
 
 	if (
-		request.options.weakref &&
-		!weakref_carried &&
+		weakref_requested &&
 		handoff->tp_new != StructMeta_new &&
 		verdict.readable &&
 		verdict.accepts_weakref == 0
@@ -378,7 +374,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 			plan.new_names,
 			request.options,
 			base,
-			bases,
+			facts.weakref_carried,
 			inherited,
 			frozen_across_bases,
 			bases_divert_setattro,
@@ -1343,7 +1339,7 @@ static enum result settle_planned(
 
 	bool const carries_slot = carries_weakref_slot((PyTypeObject *) struct_class);
 
-	if (carries_slot != weakref_expected(options, bases)) {
+	if (carries_slot != options.weakref) {
 		return refuse_unplanned(struct_class);
 	}
 

--- a/src/meta/class.c
+++ b/src/meta/class.c
@@ -228,16 +228,19 @@ PyObject * build_struct_class(
 	PyObject * const keywords,
 	struct salix_state * const state
 ) {
-	StructType const * const behaviour = find_behaviour_base(bases);
-	struct base_facts const facts = base_facts_of(bases);
-	struct options const inherited = inherited_options(bases, behaviour, facts);
-	struct options_request request = options_read(keywords, inherited, facts);
+	struct base_survey const survey = survey_bases(bases);
+	struct options const inherited = inherited_options(survey.behaviour, survey.facts);
+	struct options_request request = options_read(keywords, inherited, survey.facts);
 
 	if (request.tag == OPTIONS_REJECTED) {
 		return NULL;
 	}
 
-	bool const weakref_requested = request.options.weakref && !facts.weakref_carried;
+	bool const adds_weakref_slot = request.options.weakref && !survey.facts.weakref_carried;
+	bool const weakref_keyword_rides = (
+		(request.weakref_written && request.options.weakref) ||
+		(survey.behaviour != NULL && survey.behaviour->struct_options.weakref)
+	);
 
 	PyTypeObject * const handoff = winning_metatype(metatype, bases);
 	PyObject * forwarded_keywords = NULL;
@@ -261,7 +264,7 @@ PyObject * build_struct_class(
 			return NULL;
 		}
 
-		verdict = chain_probe(chain, keywords, weakref_requested);
+		verdict = chain_probe(chain, keywords, weakref_keyword_rides);
 
 		if (verdict.accepts_all < 0) {
 			return NULL;
@@ -270,7 +273,7 @@ PyObject * build_struct_class(
 		if (verdict.readable) {
 			if (verdict.accepts_all == 1) {
 				forwarded_keywords = keywords;
-			} else if (weakref_requested && verdict.accepts_weakref == 1) {
+			} else if (weakref_keyword_rides && verdict.accepts_weakref == 1) {
 				weakref_only = PyDict_New();
 
 				if (
@@ -287,7 +290,7 @@ PyObject * build_struct_class(
 			keyword_rungs_storage[0] = keywords;
 			laddered = true;
 
-			if (weakref_requested) {
+			if (weakref_keyword_rides) {
 				weakref_only = PyDict_New();
 
 				if (
@@ -307,7 +310,8 @@ PyObject * build_struct_class(
 	}
 
 	if (
-		weakref_requested &&
+		weakref_keyword_rides &&
+		!survey.facts.weakref_carried &&
 		handoff->tp_new != StructMeta_new &&
 		verdict.readable &&
 		verdict.accepts_weakref == 0
@@ -333,7 +337,12 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
 		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||
 		refuse_slot_name_fields(plan.new_names) != RESULT_OK ||
-		refuse_displaced_slots(original_namespace, plan.all_names, bases, request.options) !=
+		refuse_displaced_slots(
+				original_namespace,
+				plan.all_names,
+				request.options,
+				survey.facts.instance_dict_carried
+			) !=
 			RESULT_OK
 	) {
 		field_plan_clear(&plan);
@@ -374,7 +383,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 			plan.new_names,
 			request.options,
 			base,
-			facts.weakref_carried,
+			adds_weakref_slot,
 			inherited,
 			frozen_across_bases,
 			bases_divert_setattro,
@@ -725,12 +734,11 @@ static StructType * create_class(
 	return (StructType *) py_move(&created);
 }
 
-/* It is the third walk of `bases` in a class creation, after find_struct_base
- * and _PyType_CalculateMetaclass. Measured, and smaller than the measurement:
- * replacing the body with `return requested` leaves class creation at 9.77-9.87
- * us for a 16-field class either way, so the walk is bounded by the width of
- * that band rather than shown to be free. It is one Py_TYPE and one
- * PyType_IsSubtype per base, and a class has one. */
+/* Measured, and smaller than the measurement: replacing the body with
+ * `return requested` leaves class creation at 9.77-9.87 us for a 16-field
+ * class either way, so the walk is bounded by the width of that band rather
+ * than shown to be free. It is one Py_TYPE and one PyType_IsSubtype per base,
+ * and a class has one. */
 static PyTypeObject * winning_metatype(PyTypeObject * const requested, PyObject * const bases) {
 	PyTypeObject * winner = requested;
 

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -59,10 +59,11 @@ struct equality_source {
 StructType * find_struct_base(PyObject * bases);
 StructType * find_behaviour_base(PyObject * bases);
 struct equality_source resolves_body_equality(PyObject * bases);
+struct base_facts base_facts_of(PyObject * bases);
 struct options inherited_options(
 	PyObject * bases,
 	StructType const * behaviour,
-	bool * promised_frozen
+	struct base_facts facts
 );
 bool any_struct_base_is_mutable(PyObject * bases);
 enum { SETTLE_BINDING_COUNT = 7 };
@@ -77,10 +78,8 @@ struct salix_state {
 
 enum result settle_cache_fill(struct salix_state * state);
 PyModuleDef * salix_module_def(void);
-bool any_base_has_weakref_slot(PyObject * bases);
 bool any_base_diverts_setattro(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);
-bool weakref_expected(struct options options, PyObject * bases);
 bool any_base_has_instance_dict(PyObject * bases);
 
 struct binding_plan binding_plan(
@@ -107,7 +106,7 @@ PyObject * build_class_namespace(
 	PyObject * new_names,
 	struct options options,
 	StructType const * base,
-	PyObject * bases,
+	bool weakref_carried,
 	struct options inherited,
 	bool frozen_across_bases,
 	bool bases_divert_setattro,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -56,15 +56,22 @@ struct equality_source {
 	bool needs_derived_not_equal;
 };
 
+struct base_facts {
+	bool fielded_frozen;
+	bool weakref_carried;
+	bool instance_dict_carried;
+};
+
+struct base_survey {
+	StructType * behaviour;
+	struct base_facts facts;
+};
+
 StructType * find_struct_base(PyObject * bases);
 StructType * find_behaviour_base(PyObject * bases);
 struct equality_source resolves_body_equality(PyObject * bases);
-struct base_facts base_facts_of(PyObject * bases);
-struct options inherited_options(
-	PyObject * bases,
-	StructType const * behaviour,
-	struct base_facts facts
-);
+struct base_survey survey_bases(PyObject * bases);
+struct options inherited_options(StructType const * behaviour, struct base_facts facts);
 bool any_struct_base_is_mutable(PyObject * bases);
 enum { SETTLE_BINDING_COUNT = 7 };
 
@@ -80,7 +87,6 @@ enum result settle_cache_fill(struct salix_state * state);
 PyModuleDef * salix_module_def(void);
 bool any_base_diverts_setattro(PyObject * bases);
 bool carries_weakref_slot(PyTypeObject const * type);
-bool any_base_has_instance_dict(PyObject * bases);
 
 struct binding_plan binding_plan(
 	struct options options,
@@ -106,7 +112,7 @@ PyObject * build_class_namespace(
 	PyObject * new_names,
 	struct options options,
 	StructType const * base,
-	bool weakref_carried,
+	bool adds_weakref_slot,
 	struct options inherited,
 	bool frozen_across_bases,
 	bool bases_divert_setattro,
@@ -117,8 +123,8 @@ PyObject * build_class_namespace(
 enum result refuse_displaced_slots(
 	PyObject * original_namespace,
 	PyObject * all_names,
-	PyObject * bases,
-	struct options options
+	struct options options,
+	bool instance_dict_carried
 );
 enum result refuse_colliding_methods(
 	PyObject * original_namespace,

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -32,7 +32,7 @@ static enum slot_name_owner slot_name_owner_of(PyObject * const name) {
 	return SLOT_NAME_NONE;
 }
 
-static PyObject * build_slots(PyObject * new_names, bool weakref, bool weakref_carried);
+static PyObject * build_slots(PyObject * new_names, bool adds_weakref_slot);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
 	PyObject * namespace,
@@ -67,7 +67,7 @@ PyObject * build_class_namespace(
 	PyObject * const new_names,
 	struct options const options,
 	StructType const * const base,
-	bool const weakref_carried,
+	bool const adds_weakref_slot,
 	struct options const inherited,
 	bool const frozen_across_bases,
 	bool const bases_divert_setattro,
@@ -75,7 +75,7 @@ PyObject * build_class_namespace(
 	bool const inherits_body_eq,
 	bool const derive_not_equal
 ) {
-	PY_OWNED(slots, build_slots(new_names, options.weakref, weakref_carried));
+	PY_OWNED(slots, build_slots(new_names, adds_weakref_slot));
 	PY_MOVABLE(namespace, PyDict_Copy(original_namespace));
 
 	if (
@@ -105,8 +105,8 @@ PyObject * build_class_namespace(
 enum result refuse_displaced_slots(
 	PyObject * const original_namespace,
 	PyObject * const all_names,
-	PyObject * const bases,
-	struct options const options
+	struct options const options,
+	bool const instance_dict_carried
 ) {
 	PyObject * const declared = dict_get_string(original_namespace, "__slots__");
 
@@ -115,7 +115,6 @@ enum result refuse_displaced_slots(
 	}
 
 	bool const carries_a_weakref_slot = options.weakref;
-	bool const carries_an_instance_dict = any_base_has_instance_dict(bases);
 
 	PY_OWNED(
 		entries,
@@ -157,7 +156,7 @@ enum result refuse_displaced_slots(
 		}
 
 		if (owner == SLOT_NAME_INSTANCE_DICT) {
-			if (carries_an_instance_dict) {
+			if (instance_dict_carried) {
 				continue;
 			}
 
@@ -274,18 +273,14 @@ enum result refuse_reserved_metadata_names(
 	return RESULT_OK;
 }
 
-static PyObject * build_slots(
-	PyObject * const new_names,
-	bool const weakref,
-	bool const weakref_carried
-) {
+static PyObject * build_slots(PyObject * const new_names, bool const adds_weakref_slot) {
 	PY_OWNED(names, PySequence_List(new_names));
 
 	if (names == NULL) {
 		return NULL;
 	}
 
-	if (weakref && !weakref_carried) {
+	if (adds_weakref_slot) {
 		PY_OWNED(weakref_name, PyUnicode_FromString(weakref_slot_name()));
 
 		if (weakref_name == NULL || PyList_Append(names, weakref_name) < 0) {

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -32,7 +32,7 @@ static enum slot_name_owner slot_name_owner_of(PyObject * const name) {
 	return SLOT_NAME_NONE;
 }
 
-static PyObject * build_slots(PyObject * new_names, bool weakref, PyObject * bases);
+static PyObject * build_slots(PyObject * new_names, bool weakref, bool weakref_carried);
 static enum result set_match_args(PyObject * namespace, PyObject * all_names, bool wanted);
 static enum result apply_options(
 	PyObject * namespace,
@@ -67,7 +67,7 @@ PyObject * build_class_namespace(
 	PyObject * const new_names,
 	struct options const options,
 	StructType const * const base,
-	PyObject * const bases,
+	bool const weakref_carried,
 	struct options const inherited,
 	bool const frozen_across_bases,
 	bool const bases_divert_setattro,
@@ -75,7 +75,7 @@ PyObject * build_class_namespace(
 	bool const inherits_body_eq,
 	bool const derive_not_equal
 ) {
-	PY_OWNED(slots, build_slots(new_names, options.weakref, bases));
+	PY_OWNED(slots, build_slots(new_names, options.weakref, weakref_carried));
 	PY_MOVABLE(namespace, PyDict_Copy(original_namespace));
 
 	if (
@@ -114,7 +114,7 @@ enum result refuse_displaced_slots(
 		return PyErr_Occurred() ? RESULT_ERROR : RESULT_OK;
 	}
 
-	bool const carries_a_weakref_slot = weakref_expected(options, bases);
+	bool const carries_a_weakref_slot = options.weakref;
 	bool const carries_an_instance_dict = any_base_has_instance_dict(bases);
 
 	PY_OWNED(
@@ -277,7 +277,7 @@ enum result refuse_reserved_metadata_names(
 static PyObject * build_slots(
 	PyObject * const new_names,
 	bool const weakref,
-	PyObject * const bases
+	bool const weakref_carried
 ) {
 	PY_OWNED(names, PySequence_List(new_names));
 
@@ -285,7 +285,7 @@ static PyObject * build_slots(
 		return NULL;
 	}
 
-	if (weakref && !any_base_has_weakref_slot(bases)) {
+	if (weakref && !weakref_carried) {
 		PY_OWNED(weakref_name, PyUnicode_FromString(weakref_slot_name()));
 
 		if (weakref_name == NULL || PyList_Append(names, weakref_name) < 0) {

--- a/src/options.c
+++ b/src/options.c
@@ -24,22 +24,20 @@ char const * const option_keywords[OPTION_COUNT] = {
 
 static struct option_lookup find_option(PyObject * keyword);
 static struct options with_option(struct options options, enum option which, bool value);
-static struct options_request checked(struct options requested, bool fielded_base_is_frozen);
+static struct options_request checked(struct options requested, struct base_facts facts);
 static struct options_request reject_unknown(PyObject * keyword);
 static PyObject * accepted_keywords(void);
 
 struct options_request options_read(
 	PyObject * const keywords,
 	struct options const inherited,
-	bool const fielded_base_is_frozen,
-	bool const weakref_slot_carried
+	struct base_facts const facts
 ) {
 	if (keywords == NULL) {
 		return (struct options_request){.tag = OPTIONS_RESOLVED, .options = inherited};
 	}
 
 	struct options requested = inherited;
-	bool weakref_written = false;
 	PyObject * keyword;
 	PyObject * value;
 	Py_ssize_t position = 0;
@@ -60,23 +58,10 @@ struct options_request options_read(
 			return (struct options_request){.tag = OPTIONS_REJECTED};
 		}
 
-		weakref_written |= found.option == OPTION_WEAKREF;
 		requested = with_option(requested, found.option, truth != 0);
 	}
 
-	struct options_request const checked_request = checked(requested, fielded_base_is_frozen);
-
-	if (checked_request.tag == OPTIONS_REJECTED) {
-		return checked_request;
-	}
-
-	if (weakref_written && !requested.weakref && weakref_slot_carried) {
-		PyErr_SetString(PyExc_TypeError, "weakref=False cannot drop a weakref slot a base carries");
-
-		return (struct options_request){.tag = OPTIONS_REJECTED};
-	}
-
-	return checked_request;
+	return checked(requested, facts);
 }
 
 static struct option_lookup find_option(PyObject * const keyword) {
@@ -122,9 +107,9 @@ static struct options with_option(
 
 static struct options_request checked(
 	struct options const requested,
-	bool const fielded_base_is_frozen
+	struct base_facts const facts
 ) {
-	if (!requested.frozen && fielded_base_is_frozen) {
+	if (!requested.frozen && facts.fielded_frozen) {
 		PyErr_SetString(PyExc_TypeError, "mutable struct cannot inherit from a frozen one");
 
 		return (struct options_request){.tag = OPTIONS_REJECTED};
@@ -132,6 +117,12 @@ static struct options_request checked(
 
 	if (requested.order && !requested.eq) {
 		PyErr_SetString(PyExc_TypeError, "order=True needs eq=True");
+
+		return (struct options_request){.tag = OPTIONS_REJECTED};
+	}
+
+	if (!requested.weakref && facts.weakref_carried) {
+		PyErr_SetString(PyExc_TypeError, "weakref=False cannot drop a weakref slot a base carries");
 
 		return (struct options_request){.tag = OPTIONS_REJECTED};
 	}
@@ -191,7 +182,12 @@ static void test_no_keywords_inherit_the_base(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
-	struct options_request const request = options_read(NULL, inherited, false, false);
+	struct options_request const request =
+		options_read(
+			NULL,
+			inherited,
+			(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+		);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.eq);
@@ -200,7 +196,11 @@ static void test_no_keywords_inherit_the_base(void) {
 
 static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 	PyObject * const keywords = keywords_of("order", true);
-	struct options_request const request = options_read(keywords, options_initial(), false, false);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.order);
@@ -212,7 +212,11 @@ static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 
 static void test_an_unknown_keyword_is_rejected(void) {
 	PyObject * const keywords = keywords_of("frozn", true);
-	struct options_request const request = options_read(keywords, options_initial(), false, false);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
 	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
@@ -226,7 +230,11 @@ static void test_ordering_without_equality_is_rejected(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
-	struct options_request const request = options_read(keywords, inherited, false, false);
+	struct options_request const request = options_read(
+		keywords,
+		inherited,
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
 	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
@@ -240,14 +248,17 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 	struct options_request const constrained = options_read(
 		keywords,
 		options_initial(),
-		true,
-		false
+		(struct base_facts){.fielded_frozen = true, .weakref_carried = false}
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, constrained.tag);
 	PyErr_Clear();
 
-	struct options_request const free = options_read(keywords, options_initial(), false, false);
+	struct options_request const free = options_read(
+		keywords,
+		options_initial(),
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, free.tag);
 	TEST_ASSERT_FALSE(free.options.frozen);
@@ -257,7 +268,11 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 
 static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 	PyObject * const keywords = keywords_of("weakref", false);
-	struct options_request const refused = options_read(keywords, options_initial(), false, true);
+	struct options_request const refused = options_read(
+		keywords,
+		options_initial(),
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = true}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, refused.tag);
 	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
@@ -268,7 +283,11 @@ static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 
 static void test_weakref_false_without_a_carried_slot_still_resolves(void) {
 	PyObject * const keywords = keywords_of("weakref", false);
-	struct options_request const request = options_read(keywords, options_initial(), false, false);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.weakref);
@@ -278,10 +297,31 @@ static void test_weakref_false_without_a_carried_slot_still_resolves(void) {
 
 static void test_frozen_true_resolves_over_the_fielded_promise(void) {
 	PyObject * const keywords = keywords_of("frozen", true);
-	struct options_request const request = options_read(keywords, options_initial(), true, false);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		(struct base_facts){.fielded_frozen = true, .weakref_carried = false}
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.frozen);
+
+	Py_DECREF(keywords);
+}
+
+static void test_an_unwritten_weakref_over_a_carried_slot_resolves_forced(void) {
+	PyObject * const keywords = keywords_of("frozen", true);
+	struct options inherited = options_initial();
+	inherited.weakref = true;
+
+	struct options_request const request = options_read(
+		keywords,
+		inherited,
+		(struct base_facts){.fielded_frozen = false, .weakref_carried = true}
+	);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_TRUE(request.options.weakref);
 
 	Py_DECREF(keywords);
 }
@@ -298,6 +338,7 @@ void options_tests(void) {
 	RUN_TEST(test_a_carried_weakref_slot_refuses_the_explicit_drop);
 	RUN_TEST(test_weakref_false_without_a_carried_slot_still_resolves);
 	RUN_TEST(test_frozen_true_resolves_over_the_fielded_promise);
+	RUN_TEST(test_an_unwritten_weakref_over_a_carried_slot_resolves_forced);
 }
 
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -1,6 +1,7 @@
 #include <Python.h>
 #include <stdbool.h>
 
+#include "meta.h"
 #include "options.h"
 #include "owned.h"
 
@@ -24,7 +25,11 @@ char const * const option_keywords[OPTION_COUNT] = {
 
 static struct option_lookup find_option(PyObject * keyword);
 static struct options with_option(struct options options, enum option which, bool value);
-static struct options_request checked(struct options requested, struct base_facts facts);
+static struct options_request checked(
+	struct options requested,
+	struct base_facts facts,
+	bool weakref_written
+);
 static struct options_request reject_unknown(PyObject * keyword);
 static PyObject * accepted_keywords(void);
 
@@ -33,11 +38,32 @@ struct options_request options_read(
 	struct options const inherited,
 	struct base_facts const facts
 ) {
+	/* The record a reader hands in must already carry the base-derived facts;
+	 * inherited_options is the only producer and forces both columns. A caller
+	 * that skips the force would otherwise get a refusal for a keyword nobody
+	 * wrote, or a record that contradicts the settle verify downstream. */
+	if (
+		(!inherited.frozen && facts.fielded_frozen) ||
+		(!inherited.weakref && facts.weakref_carried)
+	) {
+		PyErr_SetString(
+			PyExc_SystemError,
+			"salix internal error: the inherited options contradict the base facts"
+		);
+
+		return (struct options_request){.tag = OPTIONS_REJECTED};
+	}
+
 	if (keywords == NULL) {
-		return (struct options_request){.tag = OPTIONS_RESOLVED, .options = inherited};
+		return (struct options_request){
+			.tag = OPTIONS_RESOLVED,
+			.options = inherited,
+			.weakref_written = false,
+		};
 	}
 
 	struct options requested = inherited;
+	bool weakref_written = false;
 	PyObject * keyword;
 	PyObject * value;
 	Py_ssize_t position = 0;
@@ -58,10 +84,11 @@ struct options_request options_read(
 			return (struct options_request){.tag = OPTIONS_REJECTED};
 		}
 
+		weakref_written |= found.option == OPTION_WEAKREF;
 		requested = with_option(requested, found.option, truth != 0);
 	}
 
-	return checked(requested, facts);
+	return checked(requested, facts, weakref_written);
 }
 
 static struct option_lookup find_option(PyObject * const keyword) {
@@ -107,7 +134,8 @@ static struct options with_option(
 
 static struct options_request checked(
 	struct options const requested,
-	struct base_facts const facts
+	struct base_facts const facts,
+	bool const weakref_written
 ) {
 	if (!requested.frozen && facts.fielded_frozen) {
 		PyErr_SetString(PyExc_TypeError, "mutable struct cannot inherit from a frozen one");
@@ -127,7 +155,11 @@ static struct options_request checked(
 		return (struct options_request){.tag = OPTIONS_REJECTED};
 	}
 
-	return (struct options_request){.tag = OPTIONS_RESOLVED, .options = requested};
+	return (struct options_request){
+		.tag = OPTIONS_RESOLVED,
+		.options = requested,
+		.weakref_written = weakref_written,
+	};
 }
 
 static struct options_request reject_unknown(PyObject * const keyword) {
@@ -178,16 +210,27 @@ static PyObject * keywords_of(char const * const name, bool const value) {
 	return keywords;
 }
 
+static struct base_facts facts_of(
+	bool const fielded_frozen,
+	bool const weakref_carried,
+	bool const instance_dict_carried
+) {
+	return (struct base_facts){
+		.fielded_frozen = fielded_frozen,
+		.weakref_carried = weakref_carried,
+		.instance_dict_carried = instance_dict_carried,
+	};
+}
+
 static void test_no_keywords_inherit_the_base(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
-	struct options_request const request =
-		options_read(
-			NULL,
-			inherited,
-			(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
-		);
+	struct options_request const request = options_read(
+		NULL,
+		inherited,
+		facts_of(false, false, false)
+	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.eq);
@@ -199,7 +242,7 @@ static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+		facts_of(false, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
@@ -215,7 +258,7 @@ static void test_an_unknown_keyword_is_rejected(void) {
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+		facts_of(false, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
@@ -233,7 +276,7 @@ static void test_ordering_without_equality_is_rejected(void) {
 	struct options_request const request = options_read(
 		keywords,
 		inherited,
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+		facts_of(false, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
@@ -248,7 +291,7 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 	struct options_request const constrained = options_read(
 		keywords,
 		options_initial(),
-		(struct base_facts){.fielded_frozen = true, .weakref_carried = false}
+		facts_of(true, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, constrained.tag);
@@ -257,7 +300,7 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 	struct options_request const free = options_read(
 		keywords,
 		options_initial(),
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+		facts_of(false, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, free.tag);
@@ -268,10 +311,13 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 
 static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 	PyObject * const keywords = keywords_of("weakref", false);
+	struct options inherited = options_initial();
+	inherited.weakref = true;
+
 	struct options_request const refused = options_read(
 		keywords,
-		options_initial(),
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = true}
+		inherited,
+		facts_of(false, true, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, refused.tag);
@@ -286,7 +332,7 @@ static void test_weakref_false_without_a_carried_slot_still_resolves(void) {
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = false}
+		facts_of(false, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
@@ -300,7 +346,7 @@ static void test_frozen_true_resolves_over_the_fielded_promise(void) {
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		(struct base_facts){.fielded_frozen = true, .weakref_carried = false}
+		facts_of(true, false, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
@@ -309,7 +355,7 @@ static void test_frozen_true_resolves_over_the_fielded_promise(void) {
 	Py_DECREF(keywords);
 }
 
-static void test_an_unwritten_weakref_over_a_carried_slot_resolves_forced(void) {
+static void test_an_unwritten_weakref_over_a_carried_slot_resolves_without_a_refusal(void) {
 	PyObject * const keywords = keywords_of("frozen", true);
 	struct options inherited = options_initial();
 	inherited.weakref = true;
@@ -317,13 +363,54 @@ static void test_an_unwritten_weakref_over_a_carried_slot_resolves_forced(void) 
 	struct options_request const request = options_read(
 		keywords,
 		inherited,
-		(struct base_facts){.fielded_frozen = false, .weakref_carried = true}
+		facts_of(false, true, false)
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.weakref);
+	TEST_ASSERT_FALSE(request.weakref_written);
 
 	Py_DECREF(keywords);
+}
+
+static void test_the_request_reports_that_weakref_was_written(void) {
+	PyObject * const keywords = keywords_of("weakref", true);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		facts_of(false, false, false)
+	);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_TRUE(request.options.weakref);
+	TEST_ASSERT_TRUE(request.weakref_written);
+
+	Py_DECREF(keywords);
+}
+
+static void test_an_unforced_inherited_record_over_carried_facts_is_an_internal_error(void) {
+	struct options_request const weakref = options_read(
+		NULL,
+		options_initial(),
+		facts_of(false, true, false)
+	);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, weakref.tag);
+	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_SystemError));
+	PyErr_Clear();
+
+	struct options inherited = options_initial();
+	inherited.frozen = false;
+
+	struct options_request const frozen = options_read(
+		NULL,
+		inherited,
+		facts_of(true, false, false)
+	);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, frozen.tag);
+	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_SystemError));
+	PyErr_Clear();
 }
 
 void options_tests(void) {
@@ -338,7 +425,9 @@ void options_tests(void) {
 	RUN_TEST(test_a_carried_weakref_slot_refuses_the_explicit_drop);
 	RUN_TEST(test_weakref_false_without_a_carried_slot_still_resolves);
 	RUN_TEST(test_frozen_true_resolves_over_the_fielded_promise);
-	RUN_TEST(test_an_unwritten_weakref_over_a_carried_slot_resolves_forced);
+	RUN_TEST(test_an_unwritten_weakref_over_a_carried_slot_resolves_without_a_refusal);
+	RUN_TEST(test_the_request_reports_that_weakref_was_written);
+	RUN_TEST(test_an_unforced_inherited_record_over_carried_facts_is_an_internal_error);
 }
 
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -15,12 +15,10 @@ struct options {
 struct options_request {
 	enum { OPTIONS_RESOLVED, OPTIONS_REJECTED } tag;
 	struct options options;
+	bool weakref_written;
 };
 
-struct base_facts {
-	bool fielded_frozen;
-	bool weakref_carried;
-};
+struct base_facts;
 
 enum option {
 	OPTION_FROZEN,

--- a/src/options.h
+++ b/src/options.h
@@ -17,6 +17,11 @@ struct options_request {
 	struct options options;
 };
 
+struct base_facts {
+	bool fielded_frozen;
+	bool weakref_carried;
+};
+
 enum option {
 	OPTION_FROZEN,
 	OPTION_EQ,
@@ -42,6 +47,5 @@ static inline struct options options_initial(void) {
 struct options_request options_read(
 	PyObject * keywords,
 	struct options inherited,
-	bool fielded_base_is_frozen,
-	bool weakref_slot_carried
+	struct base_facts facts
 );

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -28,6 +28,14 @@ def WeakrefDefaulting(metatype: type) -> type:
     return Defaulting
 
 
+def NeedWeakref(metatype: type) -> type:
+    class Requiring(metatype):
+        def __new__(metacls, name, bases, namespace, *, weakref):
+            return super().__new__(metacls, name, bases, namespace, weakref=weakref)
+
+    return Requiring
+
+
 # Both spellings of both, in one place: two literals drifted apart is a test
 # that silently stops covering a name.
 METADATA_NAMES = (
@@ -345,6 +353,38 @@ class TestAMetaclassSubclass:
 
         assert weakref.ref(held)() is held
         assert built(1, 2) != built(1, 2)
+
+    def test_an_explicit_weakref_still_rides_a_delegate_over_a_carrying_base(self):
+        """weakref=True over a carried slot is not needed for the slot, but it
+        is what keeps the re-invoked delegate's own weakref=False default from
+        riding instead and refusing the build.
+        """
+
+        class Base(Struct, metaclass=WeakrefDefaulting(META), weakref=True):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True, eq=False)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
+
+    def test_a_behaviour_records_weakref_rides_when_the_rest_cannot(self):
+        class Base(Struct, metaclass=WeakrefDefaulting(META), weakref=True):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, eq=False)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
+
+    def test_a_delegate_requiring_weakref_gets_it_over_a_carrying_base(self):
+        class Base(Struct, metaclass=NeedWeakref(META), weakref=True):
+            x: int
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, eq=False)
+        held = built(1, 2)
+
+        assert weakref.ref(held)() is held
 
     def test_a_delegate_without_keywords_still_gets_none_handed_over(self):
         """A delegate whose __new__ takes no **keywords would be handed the


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The standing instruction: pull the residue issues simplest-first and drive each through the review loop to convergence; #115 is the round-1 systemic of #113, so this PR is its scope decision.

## Executive summary

One base-derived fact, three different seams becomes one walk, one force. `struct base_facts` (fielded-frozen promise, carried weakref slot, carried instance dict) is derived by a single pass over the bases and consumed by every seam that used to re-derive it.

## Round 1 → round 2 (what the review found, and how it was answered)

The reviewer demonstrated two real regressions, both **measured before fixing** (worktree at fbfeb16 against the round-1 head): a carried slot plus an explicit `weakref=True` — or the behaviour base's record saying weakref — no longer forwarded weakref through the hand-off, so a keyword-only delegate's own `weakref=False` default rode the re-entry and the build refused where the old code built it.

- **The gate's weakref column is restored to its pre-force reachability**: the written keyword (`options_read` now reports `weakref_written`) or the behaviour base's record. The "cannot cross" refusal keeps its `!carried` exclusion, so its reachable set is unchanged. Three new pins: explicit weakref=True over a carried slot, the behaviour-record case, and a delegate that *requires* the weakref keyword.
- **The systemic (forced-record-invariant) is answered structurally**: `options_read` enforces the precondition at the module boundary — an inherited record contradicting the base facts is an internal error (pinned by two new C tests) — and both refusals keep the same symmetric shape.
- **The one walk now surveys everything**: `survey_bases` returns the behaviour base plus fielded-frozen, weakref, and instance-dict facts in one pass (early termination restored); `refuse_displaced_slots` consumes the instance-dict fact; the adds-slot bit is derived once in build_struct_class and threaded to `build_slots`; the dead `bases` parameter and `any_base_has_instance_dict` are deleted.
- **The nits**: the facts struct is defined beside its producer in `meta.h` (`options.h` forward-declares it); the winning_metatype comment's walk ordinal is dropped (the measured band stays); the C pin that hand-set `inherited.weakref` is renamed to what it actually covers — the moved force itself is covered by the pre-existing integration pin `test_a_later_bases_slot_forces_the_record`.

<details>
<summary>Verification</summary>

- camas check: 25/25 leaves green (build+pytest on 3.10/3.11/3.12/3.13/3.14/3.15, free-threaded 3.14t, format, lint, clang-tidy, gcc -fanalyzer, C tests, mypy/pyright/ty/tooling)
- /tmp/csuite.sh: 30 Unity C tests × 3.10-3.14, 0 failures — including the new internal-error pins and the written-bit pins
- Old-vs-new equivalence measured on the scenario matrix: F1/G1/F2/F4/F6 build on both heads after round 2; F3/F5 (the pinned delegate-default refusals) refuse on both, unchanged
</details>

Closes #115.

## Round 2 (converged, score 0)

Two nits recorded, not chased — the convergence signal is the stop:

- `uninitialized-request-field` — rejected `options_request` returns leave `weakref_written` indeterminate; every rejection return should set `.weakref_written = false` (or rejected requests should carry no options at all).
- `settle-path-base-rewalks` — the one-walk consolidation stops at plan-build time; `settle_planned`/`settle_mro_bindings` re-walk the bases. Threading the survey into the settle path completes the consolidation this PR started.
