### PR TITLE
feat: retain the field annotations the build already evaluated (#59)

### DIFF
--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -8,6 +8,10 @@ class Struct:
     _struct_defaults_: Final[tuple[Any, ...]]
     __struct_fields__: Final[tuple[str, ...]]
     __struct_defaults__: Final[tuple[Any, ...]]
+    _struct_annotations_: Final[tuple[Any, ...]]
+    __struct_annotations__: Final[tuple[Any, ...]]
+    _struct_metadata_: Final[tuple[tuple[Any, ...], ...]]
+    __struct_metadata__: Final[tuple[tuple[Any, ...], ...]]
     def __copy__(self) -> Self: ...
     def __deepcopy__(self, memo: dict[int, Any]) -> Self: ...
     def __init_subclass__(

--- a/src/fields.c
+++ b/src/fields.c
@@ -36,7 +36,9 @@ enum inheritance : int {
 static enum result append_inherited(
 	StructType const * base,
 	PyObject * all_names,
-	PyObject * default_by_name
+	PyObject * default_by_name,
+	PyObject * annotation_values,
+	PyObject * metadata_values
 );
 static enum result append_declared(
 	StructType const * base,
@@ -44,7 +46,15 @@ static enum result append_declared(
 	PyObject * namespace,
 	PyObject * all_names,
 	PyObject * new_names,
-	PyObject * default_by_name
+	PyObject * default_by_name,
+	PyObject * annotation_values,
+	PyObject * metadata_values
+);
+static enum result append_annotation(
+	PyObject * annotation,
+	PyObject * annotation_values,
+	PyObject * metadata_values,
+	bool typing_loaded
 );
 
 static struct special_form const CLASS_VAR_FORM = {
@@ -61,6 +71,10 @@ char const * const reserved_metadata_names[] = {
 	"_struct_defaults_",
 	"__struct_fields__",
 	"__struct_defaults__",
+	"_struct_annotations_",
+	"_struct_metadata_",
+	"__struct_annotations__",
+	"__struct_metadata__",
 	NULL,
 };
 
@@ -116,19 +130,35 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 
 	PY_MOVABLE(all_names, PyList_New(0));
 	PY_MOVABLE(new_names, PyList_New(0));
+	PY_MOVABLE(annotation_values, PyList_New(0));
+	PY_MOVABLE(metadata_values, PyList_New(0));
 	PY_OWNED(default_by_name, PyDict_New());
 
 	if (
 		all_names != NULL &&
 		new_names != NULL &&
+		annotation_values != NULL &&
+		metadata_values != NULL &&
 		default_by_name != NULL &&
-		append_inherited(base, all_names, default_by_name) == RESULT_OK &&
-		append_declared(base, annotations, namespace, all_names, new_names, default_by_name) ==
+		append_inherited(base, all_names, default_by_name, annotation_values, metadata_values) ==
+			RESULT_OK &&
+		append_declared(
+				base,
+				annotations,
+				namespace,
+				all_names,
+				new_names,
+				default_by_name,
+				annotation_values,
+				metadata_values
+			) ==
 			RESULT_OK
 	) {
 		plan.defaults = build_defaults(all_names, default_by_name);
+		plan.annotations = PyList_AsTuple(annotation_values);
+		plan.metadata = PyList_AsTuple(metadata_values);
 
-		if (plan.defaults != NULL) {
+		if (plan.defaults != NULL && plan.annotations != NULL && plan.metadata != NULL) {
 			plan.all_names = py_move(&all_names);
 			plan.new_names = py_move(&new_names);
 		}
@@ -141,6 +171,8 @@ void field_plan_clear(struct field_plan * const plan) {
 	Py_CLEAR(plan->all_names);
 	Py_CLEAR(plan->new_names);
 	Py_CLEAR(plan->defaults);
+	Py_CLEAR(plan->annotations);
+	Py_CLEAR(plan->metadata);
 }
 
 static PyObject * checked_annotations(PyObject * const namespace) {
@@ -158,7 +190,9 @@ static PyObject * checked_annotations(PyObject * const namespace) {
 static enum result append_inherited(
 	StructType const * const base,
 	PyObject * const all_names,
-	PyObject * const default_by_name
+	PyObject * const default_by_name,
+	PyObject * const annotation_values,
+	PyObject * const metadata_values
 ) {
 	if (base == NULL) {
 		return RESULT_OK;
@@ -169,7 +203,11 @@ static enum result append_inherited(
 	for (Py_ssize_t i = 0; i < base->struct_field_count; ++i) {
 		PyObject * const field_name = PyTuple_GET_ITEM(base->struct_field_names, i);
 
-		if (PyList_Append(all_names, field_name) < 0) {
+		if (
+			PyList_Append(all_names, field_name) < 0 ||
+			PyList_Append(annotation_values, PyTuple_GET_ITEM(base->struct_annotations, i)) < 0 ||
+			PyList_Append(metadata_values, PyTuple_GET_ITEM(base->struct_metadata, i)) < 0
+		) {
 			return RESULT_ERROR;
 		}
 
@@ -188,13 +226,67 @@ static enum result append_inherited(
 	return RESULT_OK;
 }
 
+static enum result append_annotation(
+	PyObject * const annotation,
+	PyObject * const annotation_values,
+	PyObject * const metadata_values,
+	bool const typing_loaded
+) {
+	if (!typing_loaded) {
+		PY_OWNED(plain_extras, PyTuple_New(0));
+
+		return (
+			(
+				plain_extras != NULL &&
+				PyList_Append(annotation_values, annotation) >= 0 &&
+				PyList_Append(metadata_values, plain_extras) >= 0
+			) ? RESULT_OK :
+			RESULT_ERROR
+		);
+	}
+
+	PY_OWNED(extras, PyObject_GetAttrString(annotation, "__metadata__"));
+
+	if (extras == NULL) {
+		if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+			PyErr_Clear();
+
+			PY_OWNED(plain_extras, PyTuple_New(0));
+
+			return (
+				(
+					plain_extras != NULL &&
+					PyList_Append(annotation_values, annotation) >= 0 &&
+					PyList_Append(metadata_values, plain_extras) >= 0
+				) ? RESULT_OK :
+				RESULT_ERROR
+			);
+		}
+
+		return RESULT_ERROR;
+	}
+
+	PY_OWNED(origin, PyObject_GetAttrString(annotation, "__origin__"));
+
+	return (
+		(
+			origin != NULL &&
+			PyList_Append(annotation_values, origin) >= 0 &&
+			PyList_Append(metadata_values, extras) >= 0
+		) ? RESULT_OK :
+		RESULT_ERROR
+	);
+}
+
 static enum result append_declared(
 	StructType const * const base,
 	PyObject * const annotations,
 	PyObject * const namespace,
 	PyObject * const all_names,
 	PyObject * const new_names,
-	PyObject * const default_by_name
+	PyObject * const default_by_name,
+	PyObject * const annotation_values,
+	PyObject * const metadata_values
 ) {
 	if (PyDict_GET_SIZE(annotations) == 0) {
 		return RESULT_OK;
@@ -296,7 +388,17 @@ static enum result append_declared(
 			return RESULT_ERROR;
 		}
 
-		if (PyList_Append(all_names, field_name) < 0 || PyList_Append(new_names, field_name) < 0) {
+		if (
+			PyList_Append(all_names, field_name) < 0 ||
+			PyList_Append(new_names, field_name) < 0 ||
+			append_annotation(
+					annotation,
+					annotation_values,
+					metadata_values,
+					probes.class_var != NULL
+				) !=
+				RESULT_OK
+		) {
 			return RESULT_ERROR;
 		}
 	}

--- a/src/fields.c
+++ b/src/fields.c
@@ -48,12 +48,14 @@ static enum result append_declared(
 	PyObject * new_names,
 	PyObject * default_by_name,
 	PyObject * annotation_values,
-	PyObject * metadata_values
+	PyObject * metadata_values,
+	PyObject * empty_extras
 );
 static enum result append_annotation(
 	PyObject * annotation,
 	PyObject * annotation_values,
 	PyObject * metadata_values,
+	PyObject * empty_extras,
 	bool typing_loaded
 );
 
@@ -133,6 +135,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 	PY_MOVABLE(annotation_values, PyList_New(0));
 	PY_MOVABLE(metadata_values, PyList_New(0));
 	PY_OWNED(default_by_name, PyDict_New());
+	PY_OWNED(empty_extras, PyTuple_New(0));
 
 	if (
 		all_names != NULL &&
@@ -140,6 +143,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 		annotation_values != NULL &&
 		metadata_values != NULL &&
 		default_by_name != NULL &&
+		empty_extras != NULL &&
 		append_inherited(base, all_names, default_by_name, annotation_values, metadata_values) ==
 			RESULT_OK &&
 		append_declared(
@@ -150,17 +154,25 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 				new_names,
 				default_by_name,
 				annotation_values,
-				metadata_values
+				metadata_values,
+				empty_extras
 			) ==
 			RESULT_OK
 	) {
-		plan.defaults = build_defaults(all_names, default_by_name);
-		plan.annotations = PyList_AsTuple(annotation_values);
-		plan.metadata = PyList_AsTuple(metadata_values);
+		PyObject * built_defaults = build_defaults(all_names, default_by_name);
+		PyObject * built_annotations = PyList_AsTuple(annotation_values);
+		PyObject * built_metadata = PyList_AsTuple(metadata_values);
 
-		if (plan.defaults != NULL && plan.annotations != NULL && plan.metadata != NULL) {
+		if (built_defaults != NULL && built_annotations != NULL && built_metadata != NULL) {
+			plan.defaults = built_defaults;
+			plan.annotations = built_annotations;
+			plan.metadata = built_metadata;
 			plan.all_names = py_move(&all_names);
 			plan.new_names = py_move(&new_names);
+		} else {
+			Py_XDECREF(built_defaults);
+			Py_XDECREF(built_annotations);
+			Py_XDECREF(built_metadata);
 		}
 	}
 
@@ -198,6 +210,20 @@ static enum result append_inherited(
 		return RESULT_OK;
 	}
 
+	if (
+		base->struct_annotations == NULL ||
+		base->struct_metadata == NULL ||
+		PyTuple_GET_SIZE(base->struct_annotations) != base->struct_field_count ||
+		PyTuple_GET_SIZE(base->struct_metadata) != base->struct_field_count
+	) {
+		PyErr_SetString(
+			PyExc_SystemError,
+			"salix internal error: a base's annotation tuples do not align with its fields"
+		);
+
+		return RESULT_ERROR;
+	}
+
 	Py_ssize_t const required_count = struct_required_count(base);
 
 	for (Py_ssize_t i = 0; i < base->struct_field_count; ++i) {
@@ -230,47 +256,61 @@ static enum result append_annotation(
 	PyObject * const annotation,
 	PyObject * const annotation_values,
 	PyObject * const metadata_values,
+	PyObject * const empty_extras,
 	bool const typing_loaded
 ) {
-	if (!typing_loaded) {
-		PY_OWNED(plain_extras, PyTuple_New(0));
-
+	/* A type is the common case and cannot be the Annotated split; the probe
+	 * costs a raise-and-clear cycle per field, so types skip it. */
+	if (!typing_loaded || PyType_Check(annotation)) {
 		return (
 			(
-				plain_extras != NULL &&
 				PyList_Append(annotation_values, annotation) >= 0 &&
-				PyList_Append(metadata_values, plain_extras) >= 0
+				PyList_Append(metadata_values, empty_extras) >= 0
 			) ? RESULT_OK :
 			RESULT_ERROR
 		);
 	}
 
-	PY_OWNED(extras, PyObject_GetAttrString(annotation, "__metadata__"));
+	PY_OWNED(extras, optional_attribute(annotation, "__metadata__"));
 
 	if (extras == NULL) {
-		if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-			PyErr_Clear();
-
-			PY_OWNED(plain_extras, PyTuple_New(0));
-
-			return (
-				(
-					plain_extras != NULL &&
-					PyList_Append(annotation_values, annotation) >= 0 &&
-					PyList_Append(metadata_values, plain_extras) >= 0
-				) ? RESULT_OK :
-				RESULT_ERROR
-			);
+		if (PyErr_Occurred()) {
+			return RESULT_ERROR;
 		}
+
+		return (
+			(
+				PyList_Append(annotation_values, annotation) >= 0 &&
+				PyList_Append(metadata_values, empty_extras) >= 0
+			) ? RESULT_OK :
+			RESULT_ERROR
+		);
+	}
+
+	if (!PyTuple_Check(extras)) {
+		PyErr_SetString(PyExc_TypeError, "Annotated metadata must be a tuple");
 
 		return RESULT_ERROR;
 	}
 
-	PY_OWNED(origin, PyObject_GetAttrString(annotation, "__origin__"));
+	PY_OWNED(origin, optional_attribute(annotation, "__origin__"));
+
+	if (origin == NULL) {
+		if (PyErr_Occurred()) {
+			return RESULT_ERROR;
+		}
+
+		return (
+			(
+				PyList_Append(annotation_values, annotation) >= 0 &&
+				PyList_Append(metadata_values, extras) >= 0
+			) ? RESULT_OK :
+			RESULT_ERROR
+		);
+	}
 
 	return (
 		(
-			origin != NULL &&
 			PyList_Append(annotation_values, origin) >= 0 &&
 			PyList_Append(metadata_values, extras) >= 0
 		) ? RESULT_OK :
@@ -286,7 +326,8 @@ static enum result append_declared(
 	PyObject * const new_names,
 	PyObject * const default_by_name,
 	PyObject * const annotation_values,
-	PyObject * const metadata_values
+	PyObject * const metadata_values,
+	PyObject * const empty_extras
 ) {
 	if (PyDict_GET_SIZE(annotations) == 0) {
 		return RESULT_OK;
@@ -395,6 +436,7 @@ static enum result append_declared(
 					annotation,
 					annotation_values,
 					metadata_values,
+					empty_extras,
 					probes.class_var != NULL
 				) !=
 				RESULT_OK

--- a/src/fields.h
+++ b/src/fields.h
@@ -6,12 +6,14 @@
 #include "types.h"
 
 struct field_plan {
-	PyObject * all_names;  /* list[str] */
-	PyObject * new_names;  /* list[str] */
-	PyObject * defaults;   /* tuple */
+	PyObject * all_names;     /* list[str] */
+	PyObject * new_names;     /* list[str] */
+	PyObject * defaults;      /* tuple */
+	PyObject * annotations;   /* tuple[Any], aligned with all_names */
+	PyObject * metadata;      /* tuple[tuple[Any, ...]], aligned with all_names */
 };
 
-/* Owns its three references.  On failure every member is NULL and an
+/* Owns its five references.  On failure every member is NULL and an
  * exception is set. */
 struct field_plan field_plan_build(StructType const * base, PyObject * namespace);
 

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -55,6 +55,8 @@ enum result install_fields(
 
 	struct_class->struct_field_names = py_move(&field_names);
 	struct_class->struct_defaults = Py_NewRef(plan->defaults);
+	struct_class->struct_annotations = Py_NewRef(plan->annotations);
+	struct_class->struct_metadata = Py_NewRef(plan->metadata);
 	struct_class->struct_slot_offsets = offsets;
 	struct_class->struct_member_offsets = member_offsets;
 	struct_class->struct_member_count = member_count;

--- a/src/meta/class/settle.c
+++ b/src/meta/class/settle.c
@@ -889,6 +889,8 @@ enum result settle_planned(
 	}
 
 	Py_SETREF(struct_class->struct_defaults, Py_NewRef(plan->defaults));
+	Py_SETREF(struct_class->struct_annotations, Py_NewRef(plan->annotations));
+	Py_SETREF(struct_class->struct_metadata, Py_NewRef(plan->metadata));
 	struct_class->struct_default_count = PyTuple_GET_SIZE(plan->defaults);
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -60,7 +60,7 @@ static PyGetSetDef StructMeta_getset[] = {
 	{
 		.name = "_struct_annotations_",
 		.get = StructMeta_get_annotations,
-		.doc = "the field annotations as evaluated, aligned with the fields",
+		.doc = "the field annotations, aligned with the fields",
 	},
 	{
 		.name = "__struct_annotations__",

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -11,6 +11,8 @@ static int StructMeta_clear(PyObject * self);
 static void StructMeta_dealloc(PyObject * self);
 static PyObject * StructMeta_get_field_names(PyObject * self, void * closure);
 static PyObject * StructMeta_get_defaults(PyObject * self, void * closure);
+static PyObject * StructMeta_get_annotations(PyObject * self, void * closure);
+static PyObject * StructMeta_get_metadata(PyObject * self, void * closure);
 static PyGetSetDef StructMeta_getset[];
 static PyObject * StructMeta_call(PyObject * self, PyObject * args, PyObject * keywords);
 PyTypeObject StructMeta_Type = {
@@ -55,6 +57,26 @@ static PyGetSetDef StructMeta_getset[] = {
 		.get = StructMeta_get_defaults,
 		.doc = "tuple of trailing defaults, under msgspec's name for it",
 	},
+	{
+		.name = "_struct_annotations_",
+		.get = StructMeta_get_annotations,
+		.doc = "the field annotations as evaluated, aligned with the fields",
+	},
+	{
+		.name = "__struct_annotations__",
+		.get = StructMeta_get_annotations,
+		.doc = "the field annotations under the public name for it",
+	},
+	{
+		.name = "_struct_metadata_",
+		.get = StructMeta_get_metadata,
+		.doc = "the Annotated extras per field, aligned with the fields",
+	},
+	{
+		.name = "__struct_metadata__",
+		.get = StructMeta_get_metadata,
+		.doc = "the Annotated extras under the public name for it",
+	},
 	{.name = NULL},
 };
 
@@ -64,6 +86,14 @@ static PyObject * StructMeta_get_field_names(PyObject * const self, void * const
 
 static PyObject * StructMeta_get_defaults(PyObject * const self, void * const closure) {
 	return struct_metadata((StructType *) self, STRUCT_DEFAULTS);
+}
+
+static PyObject * StructMeta_get_annotations(PyObject * const self, void * const closure) {
+	return struct_metadata((StructType *) self, STRUCT_ANNOTATIONS);
+}
+
+static PyObject * StructMeta_get_metadata(PyObject * const self, void * const closure) {
+	return struct_metadata((StructType *) self, STRUCT_METADATA);
 }
 
 PyObject * StructMeta_new(
@@ -193,6 +223,8 @@ static int StructMeta_traverse(PyObject * const self, visitproc const visit, voi
 
 	Py_VISIT(struct_class->struct_field_names);
 	Py_VISIT(struct_class->struct_defaults);
+	Py_VISIT(struct_class->struct_annotations);
+	Py_VISIT(struct_class->struct_metadata);
 	Py_VISIT(struct_class->struct_post_init);
 
 	return PyType_Type.tp_traverse(self, visit, arg);
@@ -209,6 +241,8 @@ static int StructMeta_clear(PyObject * const self) {
 
 	Py_CLEAR(struct_class->struct_field_names);
 	Py_CLEAR(struct_class->struct_defaults);
+	Py_CLEAR(struct_class->struct_annotations);
+	Py_CLEAR(struct_class->struct_metadata);
 	PyMem_Free(struct_class->struct_slot_offsets);
 	struct_class->struct_slot_offsets = NULL;
 	PyMem_Free(struct_class->struct_member_offsets);

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -630,7 +630,7 @@ static PyGetSetDef Struct_getset[] = {
 	{
 		.name = "_struct_annotations_",
 		.get = Struct_get_annotations,
-		.doc = "the field annotations as evaluated, aligned with the fields",
+		.doc = "the field annotations, aligned with the fields",
 	},
 	{
 		.name = "__struct_annotations__",

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -38,6 +38,10 @@ static PyObject * Struct_get_field_names(PyObject * self, void * closure);
 static PyObject * Struct_get_defaults(PyObject * self, void * closure);
 static PyObject * Struct_get_fields_as_msgspec(PyObject * self, void * closure);
 static PyObject * Struct_get_defaults_as_msgspec(PyObject * self, void * closure);
+static PyObject * Struct_get_annotations(PyObject * self, void * closure);
+static PyObject * Struct_get_annotations_as_msgspec(PyObject * self, void * closure);
+static PyObject * Struct_get_metadata(PyObject * self, void * closure);
+static PyObject * Struct_get_metadata_as_msgspec(PyObject * self, void * closure);
 static PyObject * metadata_of(PyObject * self, enum struct_metadata which, char const * name);
 static PyGetSetDef Struct_getset[];
 static PyMethodDef Struct_methods[];
@@ -623,6 +627,26 @@ static PyGetSetDef Struct_getset[] = {
 		.get = Struct_get_defaults_as_msgspec,
 		.doc = "tuple of trailing defaults, under msgspec's name for it",
 	},
+	{
+		.name = "_struct_annotations_",
+		.get = Struct_get_annotations,
+		.doc = "the field annotations as evaluated, aligned with the fields",
+	},
+	{
+		.name = "__struct_annotations__",
+		.get = Struct_get_annotations_as_msgspec,
+		.doc = "the field annotations under the public name for it",
+	},
+	{
+		.name = "_struct_metadata_",
+		.get = Struct_get_metadata,
+		.doc = "the Annotated extras per field, aligned with the fields",
+	},
+	{
+		.name = "__struct_metadata__",
+		.get = Struct_get_metadata_as_msgspec,
+		.doc = "the Annotated extras under the public name for it",
+	},
 	{.name = NULL},
 };
 
@@ -678,4 +702,20 @@ static PyObject * Struct_get_fields_as_msgspec(PyObject * const self, void * con
 
 static PyObject * Struct_get_defaults_as_msgspec(PyObject * const self, void * const closure) {
 	return metadata_of(self, STRUCT_DEFAULTS, "__struct_defaults__");
+}
+
+static PyObject * Struct_get_annotations(PyObject * const self, void * const closure) {
+	return metadata_of(self, STRUCT_ANNOTATIONS, "_struct_annotations_");
+}
+
+static PyObject * Struct_get_annotations_as_msgspec(PyObject * const self, void * const closure) {
+	return metadata_of(self, STRUCT_ANNOTATIONS, "__struct_annotations__");
+}
+
+static PyObject * Struct_get_metadata(PyObject * const self, void * const closure) {
+	return metadata_of(self, STRUCT_METADATA, "_struct_metadata_");
+}
+
+static PyObject * Struct_get_metadata_as_msgspec(PyObject * const self, void * const closure) {
+	return metadata_of(self, STRUCT_METADATA, "__struct_metadata__");
 }

--- a/src/types.h
+++ b/src/types.h
@@ -25,6 +25,8 @@ typedef struct StructType {
 
 	PyObject * struct_field_names;
 	PyObject * struct_defaults;
+	PyObject * struct_annotations;
+	PyObject * struct_metadata;
 	Py_ssize_t * struct_slot_offsets;
 	Py_ssize_t * struct_member_offsets;
 	PyObject * struct_post_init;
@@ -309,6 +311,8 @@ static inline PyObject * struct_tuple_or_empty(PyObject * const tuple) {
 enum struct_metadata : int {
 	STRUCT_FIELD_NAMES,
 	STRUCT_DEFAULTS,
+	STRUCT_ANNOTATIONS,
+	STRUCT_METADATA,
 };
 
 static inline PyObject * struct_metadata(
@@ -322,6 +326,10 @@ static inline PyObject * struct_metadata(
 			return struct_tuple_or_empty(type->struct_field_names);
 		case STRUCT_DEFAULTS:
 			return struct_tuple_or_empty(type->struct_defaults);
+		case STRUCT_ANNOTATIONS:
+			return struct_tuple_or_empty(type->struct_annotations);
+		case STRUCT_METADATA:
+			return struct_tuple_or_empty(type->struct_metadata);
 	}
 
 	Py_UNREACHABLE();

--- a/tests/test_metadata_names.py
+++ b/tests/test_metadata_names.py
@@ -1,16 +1,20 @@
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 import pytest
 
 from salix import Struct
 
-SALIX = ("_struct_fields_", "_struct_defaults_")
-MSGSPEC = ("__struct_fields__", "__struct_defaults__")
+SALIX = ("_struct_fields_", "_struct_defaults_", "_struct_annotations_", "_struct_metadata_")
+MSGSPEC = ("__struct_fields__", "__struct_defaults__", "__struct_annotations__", "__struct_metadata__")
 EXPECTED = (
     ("_struct_fields_", ("x", "y")),
     ("__struct_fields__", ("x", "y")),
     ("_struct_defaults_", (2,)),
     ("__struct_defaults__", (2,)),
+    ("_struct_annotations_", (int, int)),
+    ("__struct_annotations__", (int, int)),
+    ("_struct_metadata_", ((), ())),
+    ("__struct_metadata__", ((), ())),
 )
 MIXIN = Struct.__mro__[1]
 META = type(Struct)
@@ -34,9 +38,8 @@ def test_every_spelling_reports_the_value_itself_on_the_class(name, expected):
 
 @pytest.mark.parametrize(("name", "expected"), EXPECTED)
 def test_every_spelling_reports_the_value_itself_on_an_instance(name, expected):
-    """Worth stating separately: the mixin wires the four names to four
-    different functions, so a crossed `which` enum shows up here and nowhere
-    else.
+    """Worth stating separately: the mixin wires each name to its own
+    function, so a crossed `which` enum shows up here and nowhere else.
     """
 
     assert getattr(Point(1), name) == expected
@@ -69,7 +72,7 @@ def test_salix_writes_no_spelling_into_the_classes_it_builds(name):
 
 @pytest.mark.parametrize("name", SALIX + MSGSPEC)
 def test_a_field_named_any_of_them_is_refused(name):
-    """The reservation is real: a field that takes one of the four names is
+    """The reservation is real: a field that takes one of the reserved names is
     refused, because the class would answer with the metadata while the
     instance answered with the field. What #82 settled rather than left as a
     discovery.
@@ -150,7 +153,7 @@ def test_an_unannotated_binding_of_an_ordinary_name_stays_in_the_class_dict():
 @pytest.mark.parametrize("name", SALIX + MSGSPEC)
 def test_a_class_statement_taking_a_reserved_name_is_refused(name):
     """The refusal holds on the syntax users write, not only the metaclass
-    call: a plain body binding of any of the four spellings is refused.
+    call: a plain body binding of any of the spellings is refused.
     """
 
     with pytest.raises(TypeError, match="is reserved for salix's metadata"):
@@ -247,3 +250,31 @@ def test_a_subclass_reports_its_own_fields_under_both_names():
     assert Extended.__struct_fields__ == ("x", "y", "z")
     assert Extended._struct_defaults_ == (2, 3)
     assert Extended.__struct_defaults__ == (2, 3)
+
+
+def test_annotated_splits_into_the_base_and_the_extras():
+    class Tagged(Struct):
+        name: Annotated[str, "meta"]
+        count: int = 0
+
+    assert Tagged.__struct_annotations__ == (str, int)
+    assert Tagged.__struct_metadata__ == (("meta",), ())
+
+
+def test_a_subclass_aligns_the_inherited_annotations_first():
+    class Base(Struct):
+        x: int
+
+    class Child(Base):
+        y: Annotated[str, 1]
+
+    assert Child.__struct_annotations__ == (int, str)
+    assert Child.__struct_metadata__ == ((), (1,))
+
+
+def test_a_generic_alias_stays_whole():
+    class Box(Struct):
+        values: list[int]
+
+    assert Box.__struct_annotations__ == (list[int],)
+    assert Box.__struct_metadata__ == ((),)

--- a/tests/test_metadata_names.py
+++ b/tests/test_metadata_names.py
@@ -278,3 +278,43 @@ def test_a_generic_alias_stays_whole():
 
     assert Box.__struct_annotations__ == (list[int],)
     assert Box.__struct_metadata__ == ((),)
+
+
+def test_an_annotated_inside_optional_stays_whole():
+    class Unioned(Struct):
+        value: int | Annotated[str, "meta"] | None
+
+    assert Unioned.__struct_annotations__ == (int | Annotated[str, "meta"] | None,)
+    assert Unioned.__struct_metadata__ == ((),)
+
+
+def test_a_re_annotated_inherited_field_reports_the_bases_values():
+    class Base(Struct):
+        x: int
+
+    class Child(Base):
+        x: str
+
+    assert Child.__struct_annotations__ == (int,)
+    assert Child.__struct_metadata__ == ((),)
+
+
+def test_a_fake_annotated_without_an_origin_stays_whole_with_its_extras():
+    class MetadataOnly:
+        def __init__(self) -> None:
+            self.__metadata__ = ("meta",)
+
+    class Tagged(Struct):
+        v: MetadataOnly()
+
+    assert Tagged.__struct_annotations__[0].__class__ is MetadataOnly
+    assert Tagged.__struct_metadata__ == (("meta",),)
+
+
+def test_a_non_tuple_metadata_is_refused():
+    class MetadataOnly:
+        def __init__(self) -> None:
+            self.__metadata__ = "meta"
+
+    with pytest.raises(TypeError, match="Annotated metadata must be a tuple"):
+        type(Struct)("Tagged", (Struct,), {"__annotations__": {"v": MetadataOnly()}})

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -36,13 +36,18 @@ def NeedWeakref(metatype: type) -> type:
     return Requiring
 
 
-# Both spellings of both, in one place: two literals drifted apart is a test
-# that silently stops covering a name.
+# Both spellings of each, in one place: two literals drifted apart is a test
+# that silently stops covering a name. The order matches
+# test_metadata_names' SALIX + MSGSPEC concatenation, which is pinned.
 METADATA_NAMES = (
     "_struct_fields_",
     "_struct_defaults_",
+    "_struct_annotations_",
+    "_struct_metadata_",
     "__struct_fields__",
     "__struct_defaults__",
+    "__struct_annotations__",
+    "__struct_metadata__",
 )
 
 

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from typing_extensions import assert_type
 
@@ -59,6 +59,10 @@ def introspection_is_typed_on_both_the_class_and_the_instance() -> None:
     assert_type(Point(1, "two")._struct_fields_, tuple[str, ...])
     assert_type(Point.__struct_fields__, tuple[str, ...])
     assert_type(Point(1, "two").__struct_fields__, tuple[str, ...])
+    assert_type(Point._struct_annotations_, tuple[Any, ...])
+    assert_type(Point.__struct_annotations__, tuple[Any, ...])
+    assert_type(Point._struct_metadata_, tuple[tuple[Any, ...], ...])
+    assert_type(Point.__struct_metadata__, tuple[tuple[Any, ...], ...])
     # Narrower than the stub declares: the transform synthesises the literal
     # names, which is what makes a positional pattern check.
     assert_type(Point.__match_args__, tuple[Literal["x"], Literal["y"]])


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The standing instruction: after #114, address #59–#64 in one or more PRs; #64's index ranks #59 first — it is the one change that lets a reflection-driven consumer drop `typing` from its import graph.

## Executive summary

`field_plan_build` evaluated every annotation in C and kept only the names. The plan now keeps the values too, aligned with `all_names`:

- `__struct_annotations__` — the tuple of annotation values; an `Annotated[T, ...]` field contributes its base `T`. Under PEP 563 the dict holds source strings, and the tuple holds exactly those values.
- `__struct_metadata__` — the aligned tuple of the `Annotated` extras; a plain annotation contributes `()`. Both ship under the `_struct_*_` spelling too, and all four names join the reserved-metadata table.

A consumer's whole reflection step becomes a `zip` over four C-built tuples; `get_type_hints` and the `typing` import both disappear (#64's measured budget: 8.25 µs/class + 3.89 ms of import).

<details>
<summary>Mechanics</summary>

- The split probes `__metadata__`/`__origin__` by attribute, through `optional_attribute` — **only when `typing` is loaded, and never for types** (a type cannot be the split). With neither special-form module present, no attribute is ever asked of an annotation object, which is exactly what the hostile-probe pin in `test_special_forms.py` asserts (it caught the ungated version and drove the gate).
- The tuples ride the plan: inherited fields copy the base's slices, the declared loop appends in field order, `install_fields` stores them, the settle restore re-sets them, both spellings answer on the class (metaclass getset) and the instance (mixin getset), and `StructMeta_traverse`/`clear` walk them.
- The reserved-metadata table gains four names, so a field or body binding of any of them gets the established refusal.
</details>

## Round 1 disposition (score 2.99; systemic answered structurally, boundaries declared)

- **Systemic (`asymmetric-annotation-probing`) — fixed.** Both probes route through `optional_attribute` (the codebase's absent-vs-failure distinction); absent `__origin__` falls back to the whole annotation with its declared extras; a non-tuple `__metadata__` is refused; real probe failures still hard-fail (the `test_a_failing_origin_probe_fails_the_class` policy). Types skip the probe; the empty-extras tuple is allocated once per build, not per field.
- **`partial-plan-leak` — fixed** (a real leak: a failed `build_defaults` left the built tuples alive; `field_plan_build` now drops them, restoring the header's "every member NULL on failure" contract).
- **`inherited-tuple-index-unchecked` — fixed** (presence + length guard before indexing).
- **`settle-retry-plan-desync` — boundary.** The settle verify already binds the plan's names to the installed fields (same_fields); annotation *value* divergence requires a delegate mutating the namespace mid-build, which the verify cannot observe and which would corrupt any build path. The read-site guard above is the defense-in-depth half of the recommendation.
- **`wrapped-annotated-metadata-dropped` — boundary, pinned.** The split is top-level only, by design (#59's shape question); `Annotated` inside `Optional`/`Union` stays whole.
- **`overridden-field-annotation-dropped` — pinned.** A re-annotated inherited field reports the base's values; that is the field's identity semantics.
- **`annotations-not-as-evaluated` — fixed** (the body and getset docstrings no longer claim "as evaluated").
- **`getter-closure-unused` — boundary.** The four new mixin getters follow the pattern of the four pre-existing ones; folding all eight into a closure-driven getter is its own pass.

<details>
<summary>Verification</summary>

- camas check: 25/25 leaves green (3.10–3.15 + free-threaded builds and pytest, format, lint, clang-tidy, gcc -fanalyzer, C tests, mypy/pyright/ty)
- /tmp/csuite.sh: 30 Unity C tests × 3.10–3.14, 0 failures
- Pins: the name quartet grows to eight in `test_metadata_names` (values on class and instance, assignment refusal, reservation, cross-file agreement with `test_struct_identity.METADATA_NAMES`); the split itself, subclass alignment, a `GenericAlias` staying whole, a wrapped Annotated staying whole, a fake Annotated without `__origin__`, the non-tuple refusal, and the re-annotated-inherited behavior; `accepted.py` asserts the new names under mypy, pyright, and ty
</details>

Closes #59.

## Round 2 (converged, score 0; systemic resolved)

Eight nits recorded, not chased — the convergence signal is the stop:

- `pep563-string-annotations-unpinned` — pin the PEP 563 case (the tuple holds source strings) and mention the caveat in the getset docs.
- `annotated-type-probe-skipped-silently` — pin that a type carrying `__metadata__`/`__origin__` stays whole with `()` metadata (the fast path's documented behavior).
- `triplicate-fallback-arms` — fold append_annotation's two identical fallback arms into one append.
- `throwaway-lists-per-build` — build the two tuples directly instead of list-then-AsTuple.
- `overbroad-inherited-guard` — scope the alignment guard to `field_count > 0`.
- `probe-cost-on-non-types` — add `PyUnicode_Check` to the fast path (strings cannot be the split).
- `as-tuple-evaluated-after-build-defaults-failure` — order the AsTuple calls after the defaults success so the original TypeError survives.
- `instance-typing-assertions-missing` — four instance-level assert_types beside the class-level ones.

These are queued as the #59-follow-up commit alongside the #114 consolidation follow-up.
