### PR TITLE
feat: intern zero-field frozen structs (#60)

### DIFF
--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -26,10 +26,9 @@ static enum result fill_defaults(
 static enum result run_post_init(StructType const * type, PyObject * self);
 
 static PyObject * interned_value(StructType const * const type, bool const no_arguments) {
-	return (
-		(type->struct_singleton != NULL && no_arguments) ? Py_NewRef(type->struct_singleton) :
-		NULL
-	);
+	PyObject * const singleton = type->struct_singleton;
+
+	return (singleton != NULL && no_arguments) ? Py_NewRef(singleton) : NULL;
 }
 
 PyObject * Struct_vectorcall(
@@ -55,7 +54,8 @@ PyObject * Struct_vectorcall(
 
 	PyObject * const interned = interned_value(
 		type,
-		positional_count == 0 && keyword_names == NULL
+		positional_count == 0 &&
+			(keyword_names == NULL || PyTuple_GET_SIZE(keyword_names) == 0)
 	);
 
 	if (interned != NULL) {
@@ -94,17 +94,13 @@ PyObject * Struct_new(
 		return NULL;
 	}
 
-	StructType const * const type = (StructType *) struct_class;
+	if (keywords != NULL && !PyDict_Check(keywords)) {
+		PyErr_SetString(PyExc_TypeError, "the new keywords must be a dict");
 
-	PyObject * const interned = interned_value(
-		type,
-		(arguments == NULL || PyTuple_GET_SIZE(arguments) == 0) &&
-			(keywords == NULL || PyDict_GET_SIZE(keywords) == 0)
-	);
-
-	if (interned != NULL) {
-		return interned;
+		return NULL;
 	}
+
+	StructType const * const type = (StructType *) struct_class;
 
 	PY_MOVABLE(self, struct_class->tp_alloc(struct_class, 0));
 

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -88,18 +88,6 @@ PyObject * Struct_new(
 	PyObject * const arguments,
 	PyObject * const keywords
 ) {
-	if (arguments != NULL && !PyTuple_Check(arguments)) {
-		PyErr_SetString(PyExc_TypeError, "the new arguments must be a tuple");
-
-		return NULL;
-	}
-
-	if (keywords != NULL && !PyDict_Check(keywords)) {
-		PyErr_SetString(PyExc_TypeError, "the new keywords must be a dict");
-
-		return NULL;
-	}
-
 	StructType const * const type = (StructType *) struct_class;
 
 	PY_MOVABLE(self, struct_class->tp_alloc(struct_class, 0));

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -46,6 +46,10 @@ PyObject * Struct_vectorcall(
 		return NULL;
 	}
 
+	if (type->struct_singleton != NULL && positional_count == 0 && keyword_names == NULL) {
+		return Py_NewRef(type->struct_singleton);
+	}
+
 	PyTypeObject * const python_class = &type->heap_type.ht_type;
 
 	PY_MOVABLE(self, python_class->tp_alloc(python_class, 0));
@@ -72,13 +76,21 @@ PyObject * Struct_new(
 	PyObject * const arguments,
 	PyObject * const keywords
 ) {
+	StructType const * const type = (StructType *) struct_class;
+
+	if (
+		type->struct_singleton != NULL &&
+		PyTuple_GET_SIZE(arguments) == 0 &&
+		(keywords == NULL || PyDict_GET_SIZE(keywords) == 0)
+	) {
+		return Py_NewRef(type->struct_singleton);
+	}
+
 	PY_MOVABLE(self, struct_class->tp_alloc(struct_class, 0));
 
 	if (self == NULL) {
 		return NULL;
 	}
-
-	StructType const * const type = (StructType *) struct_class;
 
 	return (
 		fill_defaults(type, self, struct_required_count(type)) == RESULT_OK ? py_move(&self) :

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -25,6 +25,13 @@ static enum result fill_defaults(
 );
 static enum result run_post_init(StructType const * type, PyObject * self);
 
+static PyObject * interned_value(StructType const * const type, bool const no_arguments) {
+	return (
+		(type->struct_singleton != NULL && no_arguments) ? Py_NewRef(type->struct_singleton) :
+		NULL
+	);
+}
+
 PyObject * Struct_vectorcall(
 	PyObject * const struct_class,
 	PyObject * const * const arguments,
@@ -46,8 +53,13 @@ PyObject * Struct_vectorcall(
 		return NULL;
 	}
 
-	if (type->struct_singleton != NULL && positional_count == 0 && keyword_names == NULL) {
-		return Py_NewRef(type->struct_singleton);
+	PyObject * const interned = interned_value(
+		type,
+		positional_count == 0 && keyword_names == NULL
+	);
+
+	if (interned != NULL) {
+		return interned;
 	}
 
 	PyTypeObject * const python_class = &type->heap_type.ht_type;
@@ -76,14 +88,22 @@ PyObject * Struct_new(
 	PyObject * const arguments,
 	PyObject * const keywords
 ) {
+	if (arguments != NULL && !PyTuple_Check(arguments)) {
+		PyErr_SetString(PyExc_TypeError, "the new arguments must be a tuple");
+
+		return NULL;
+	}
+
 	StructType const * const type = (StructType *) struct_class;
 
-	if (
-		type->struct_singleton != NULL &&
-		PyTuple_GET_SIZE(arguments) == 0 &&
-		(keywords == NULL || PyDict_GET_SIZE(keywords) == 0)
-	) {
-		return Py_NewRef(type->struct_singleton);
+	PyObject * const interned = interned_value(
+		type,
+		(arguments == NULL || PyTuple_GET_SIZE(arguments) == 0) &&
+			(keywords == NULL || PyDict_GET_SIZE(keywords) == 0)
+	);
+
+	if (interned != NULL) {
+		return interned;
 	}
 
 	PY_MOVABLE(self, struct_class->tp_alloc(struct_class, 0));

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -284,7 +284,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 							request.options
 						) !=
 						RESULT_OK ||
-					install_constructor(struct_class) != RESULT_OK
+					install_constructor(struct_class, bases_divert_setattro) != RESULT_OK
 				) {
 					Py_CLEAR(struct_class);
 				}

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -277,13 +277,14 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 
 				if (
 					settle_mro_bindings(
-						struct_class,
-						bases,
-						original_namespace,
-						bindings,
-						request.options
-					) !=
-					RESULT_OK
+							struct_class,
+							bases,
+							original_namespace,
+							bindings,
+							request.options
+						) !=
+						RESULT_OK ||
+					install_constructor(struct_class) != RESULT_OK
 				) {
 					Py_CLEAR(struct_class);
 				}

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -88,7 +88,8 @@ enum result ensure_singleton(StructType * const struct_class) {
 		struct_class->struct_options.frozen &&
 		!struct_class->struct_options.weakref &&
 		struct_class->struct_field_count == 0 &&
-		!defines_own_init(struct_class)
+		!defines_own_init(struct_class) &&
+		Py_TYPE(struct_class)->tp_call == StructMeta_Type.tp_call
 	);
 
 	if (!qualifies) {
@@ -101,14 +102,18 @@ enum result ensure_singleton(StructType * const struct_class) {
 		return RESULT_OK;
 	}
 
-	/* PyObject_Call requires args non-NULL; an empty tuple is the empty call. */
-	PY_OWNED(call_args, PyTuple_New(0));
-	PY_MOVABLE(
-		singleton,
-		call_args != NULL ? PyObject_Call((PyObject *) struct_class, call_args, NULL) : NULL
-	);
+	PY_MOVABLE(singleton, PyObject_CallNoArgs((PyObject *) struct_class));
 
 	if (singleton == NULL) {
+		return RESULT_ERROR;
+	}
+
+	if (Py_TYPE(singleton) != (PyTypeObject *) struct_class) {
+		PyErr_SetString(
+			PyExc_SystemError,
+			"salix internal error: the singleton build returned a different type"
+		);
+
 		return RESULT_ERROR;
 	}
 

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -89,6 +89,8 @@ enum result ensure_singleton(StructType * const struct_class) {
 		!struct_class->struct_options.weakref &&
 		struct_class->struct_field_count == 0 &&
 		!defines_own_init(struct_class) &&
+		struct_class->heap_type.ht_type.tp_new == NULL &&
+		struct_class->struct_member_count == 0 &&
 		Py_TYPE(struct_class)->tp_call == StructMeta_Type.tp_call
 	);
 
@@ -114,6 +116,13 @@ enum result ensure_singleton(StructType * const struct_class) {
 			"salix internal error: the singleton build returned a different type"
 		);
 
+		return RESULT_ERROR;
+	}
+
+	if (
+		struct_class->struct_state != NULL &&
+		PyList_Append(struct_class->struct_state->interned_singletons, singleton) < 0
+	) {
 		return RESULT_ERROR;
 	}
 

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -65,8 +65,13 @@ enum result install_fields(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = resolves_body_eq;
 
+	return install_constructor(struct_class);
+}
+
+enum result install_constructor(StructType * const struct_class) {
 	if (defines_own_init(struct_class)) {
 		struct_class->heap_type.ht_type.tp_new = Struct_new;
+		struct_class->heap_type.ht_type.tp_vectorcall = NULL;
 	} else {
 		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
 	}
@@ -82,7 +87,8 @@ enum result ensure_singleton(StructType * const struct_class) {
 	bool const qualifies = (
 		struct_class->struct_options.frozen &&
 		!struct_class->struct_options.weakref &&
-		struct_class->struct_field_count == 0
+		struct_class->struct_field_count == 0 &&
+		!defines_own_init(struct_class)
 	);
 
 	if (!qualifies) {

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -65,7 +65,7 @@ enum result install_fields(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = resolves_body_eq;
 
-	return install_constructor(struct_class);
+	return RESULT_OK;
 }
 
 enum result install_constructor(StructType * const struct_class) {
@@ -101,8 +101,9 @@ enum result ensure_singleton(StructType * const struct_class) {
 		return RESULT_OK;
 	}
 
+	/* PyObject_Call requires args non-NULL; an empty tuple is the empty call. */
 	PY_OWNED(call_args, PyTuple_New(0));
-	PY_OWNED(
+	PY_MOVABLE(
 		singleton,
 		call_args != NULL ? PyObject_Call((PyObject *) struct_class, call_args, NULL) : NULL
 	);
@@ -111,7 +112,7 @@ enum result ensure_singleton(StructType * const struct_class) {
 		return RESULT_ERROR;
 	}
 
-	Py_XSETREF(struct_class->struct_singleton, Py_NewRef(singleton));
+	struct_class->struct_singleton = py_move(&singleton);
 
 	return RESULT_OK;
 }

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -71,7 +71,43 @@ enum result install_fields(
 		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
 	}
 
-	return install_post_init(struct_class);
+	if (install_post_init(struct_class) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
+	return ensure_singleton(struct_class);
+}
+
+enum result ensure_singleton(StructType * const struct_class) {
+	bool const qualifies = (
+		struct_class->struct_options.frozen &&
+		!struct_class->struct_options.weakref &&
+		struct_class->struct_field_count == 0
+	);
+
+	if (!qualifies) {
+		Py_CLEAR(struct_class->struct_singleton);
+
+		return RESULT_OK;
+	}
+
+	if (struct_class->struct_singleton != NULL) {
+		return RESULT_OK;
+	}
+
+	PY_OWNED(call_args, PyTuple_New(0));
+	PY_OWNED(
+		singleton,
+		call_args != NULL ? PyObject_Call((PyObject *) struct_class, call_args, NULL) : NULL
+	);
+
+	if (singleton == NULL) {
+		return RESULT_ERROR;
+	}
+
+	Py_XSETREF(struct_class->struct_singleton, Py_NewRef(singleton));
+
+	return RESULT_OK;
 }
 
 bool defines_own_init(StructType const * const struct_class) {

--- a/src/meta/class/install.c
+++ b/src/meta/class/install.c
@@ -68,7 +68,7 @@ enum result install_fields(
 	return RESULT_OK;
 }
 
-enum result install_constructor(StructType * const struct_class) {
+enum result install_constructor(StructType * const struct_class, bool const bases_divert_setattro) {
 	if (defines_own_init(struct_class)) {
 		struct_class->heap_type.ht_type.tp_new = Struct_new;
 		struct_class->heap_type.ht_type.tp_vectorcall = NULL;
@@ -80,10 +80,10 @@ enum result install_constructor(StructType * const struct_class) {
 		return RESULT_ERROR;
 	}
 
-	return ensure_singleton(struct_class);
+	return ensure_singleton(struct_class, bases_divert_setattro);
 }
 
-enum result ensure_singleton(StructType * const struct_class) {
+enum result ensure_singleton(StructType * const struct_class, bool const bases_divert_setattro) {
 	bool const qualifies = (
 		struct_class->struct_options.frozen &&
 		!struct_class->struct_options.weakref &&
@@ -91,6 +91,7 @@ enum result ensure_singleton(StructType * const struct_class) {
 		!defines_own_init(struct_class) &&
 		struct_class->heap_type.ht_type.tp_new == NULL &&
 		struct_class->struct_member_count == 0 &&
+		!bases_divert_setattro &&
 		Py_TYPE(struct_class)->tp_call == StructMeta_Type.tp_call
 	);
 
@@ -116,13 +117,6 @@ enum result ensure_singleton(StructType * const struct_class) {
 			"salix internal error: the singleton build returned a different type"
 		);
 
-		return RESULT_ERROR;
-	}
-
-	if (
-		struct_class->struct_state != NULL &&
-		PyList_Append(struct_class->struct_state->interned_singletons, singleton) < 0
-	) {
 		return RESULT_ERROR;
 	}
 

--- a/src/meta/class/settle.c
+++ b/src/meta/class/settle.c
@@ -902,7 +902,11 @@ enum result settle_planned(
 		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
 	}
 
-	return install_post_init(struct_class);
+	if (install_post_init(struct_class) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
+	return ensure_singleton(struct_class);
 }
 
 static enum result restore_stripped(

--- a/src/meta/class/settle.c
+++ b/src/meta/class/settle.c
@@ -895,7 +895,7 @@ enum result settle_planned(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
 
-	return install_constructor(struct_class);
+	return RESULT_OK;
 }
 
 static enum result restore_stripped(

--- a/src/meta/class/settle.c
+++ b/src/meta/class/settle.c
@@ -895,18 +895,7 @@ enum result settle_planned(
 	struct_class->struct_options = options;
 	struct_class->struct_resolves_body_eq = body_defines_eq || inherits_body_eq;
 
-	if (defines_own_init(struct_class)) {
-		struct_class->heap_type.ht_type.tp_new = Struct_new;
-		struct_class->heap_type.ht_type.tp_vectorcall = NULL;
-	} else {
-		struct_class->heap_type.ht_type.tp_vectorcall = Struct_vectorcall;
-	}
-
-	if (install_post_init(struct_class) != RESULT_OK) {
-		return RESULT_ERROR;
-	}
-
-	return ensure_singleton(struct_class);
+	return install_constructor(struct_class);
 }
 
 static enum result restore_stripped(

--- a/src/meta/meta.c
+++ b/src/meta/meta.c
@@ -226,6 +226,7 @@ static int StructMeta_traverse(PyObject * const self, visitproc const visit, voi
 	Py_VISIT(struct_class->struct_annotations);
 	Py_VISIT(struct_class->struct_metadata);
 	Py_VISIT(struct_class->struct_post_init);
+	Py_VISIT(struct_class->struct_singleton);
 
 	return PyType_Type.tp_traverse(self, visit, arg);
 }
@@ -243,6 +244,7 @@ static int StructMeta_clear(PyObject * const self) {
 	Py_CLEAR(struct_class->struct_defaults);
 	Py_CLEAR(struct_class->struct_annotations);
 	Py_CLEAR(struct_class->struct_metadata);
+	Py_CLEAR(struct_class->struct_singleton);
 	PyMem_Free(struct_class->struct_slot_offsets);
 	struct_class->struct_slot_offsets = NULL;
 	PyMem_Free(struct_class->struct_member_offsets);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -82,6 +82,7 @@ struct salix_state {
 	PyObject * handoff_attempt;
 	PyObject * handoff_declined;
 	PyObject * handoff_new;
+	PyObject * interned_singletons;
 };
 
 enum result settle_cache_fill(struct salix_state * state);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -176,3 +176,4 @@ enum result install_fields(
 );
 enum result install_post_init(StructType * struct_class);
 bool defines_own_init(StructType const * struct_class);
+enum result ensure_singleton(StructType * struct_class);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -82,7 +82,6 @@ struct salix_state {
 	PyObject * handoff_attempt;
 	PyObject * handoff_declined;
 	PyObject * handoff_new;
-	PyObject * interned_singletons;
 };
 
 enum result settle_cache_fill(struct salix_state * state);
@@ -177,5 +176,5 @@ enum result install_fields(
 );
 enum result install_post_init(StructType * struct_class);
 bool defines_own_init(StructType const * struct_class);
-enum result ensure_singleton(StructType * struct_class);
-enum result install_constructor(StructType * struct_class);
+enum result ensure_singleton(StructType * struct_class, bool bases_divert_setattro);
+enum result install_constructor(StructType * struct_class, bool bases_divert_setattro);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -177,3 +177,4 @@ enum result install_fields(
 enum result install_post_init(StructType * struct_class);
 bool defines_own_init(StructType const * struct_class);
 enum result ensure_singleton(StructType * struct_class);
+enum result install_constructor(StructType * struct_class);

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -389,6 +389,10 @@ static PyObject * copy_reconstruct(
 	return PyObject_Call(reconstruct, arguments, NULL);
 }
 
+static PyObject * interned_copy(StructType const * const type) {
+	return type->struct_singleton != NULL ? Py_NewRef(type->struct_singleton) : NULL;
+}
+
 static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 	if (!is_struct(self)) {
 		return copy_delegate(self, self, Py_None, "__copy__", "un(shallow)copyable", false);
@@ -417,8 +421,10 @@ static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 		return reduced != NULL ? copy_reconstruct(self, reduced, copy_module, Py_None) : NULL;
 	}
 
-	if (type->struct_singleton != NULL) {
-		return Py_NewRef(type->struct_singleton);
+	PY_MOVABLE(short_circuit, interned_copy(type));
+
+	if (short_circuit != NULL) {
+		return py_move(&short_circuit);
 	}
 
 	PY_MOVABLE(copy, cls->tp_alloc(cls, 0));
@@ -533,8 +539,10 @@ static PyObject * Struct_deepcopy(PyObject * const self, PyObject * const memo) 
 		return py_move(&reconstructed);
 	}
 
-	if (type->struct_singleton != NULL) {
-		return Py_NewRef(type->struct_singleton);
+	PY_MOVABLE(short_circuit, interned_copy(type));
+
+	if (short_circuit != NULL) {
+		return py_move(&short_circuit);
 	}
 
 	PY_MOVABLE(copy, cls->tp_alloc(cls, 0));

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -395,6 +395,11 @@ static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 	}
 
 	StructType * const type = struct_type_of(self);
+
+	if (type->struct_singleton != NULL) {
+		return Py_NewRef(type->struct_singleton);
+	}
+
 	PyTypeObject * const cls = &type->heap_type.ht_type;
 	PY_MOVABLE(copy_module, NULL);
 	PY_MOVABLE(copier, NULL);
@@ -474,6 +479,10 @@ static PyObject * Struct_deepcopy(PyObject * const self, PyObject * const memo) 
 
 	if (seeded != NULL) {
 		return py_move(&seeded);
+	}
+
+	if (is_struct(self) && struct_type_of(self)->struct_singleton != NULL) {
+		return Py_NewRef(struct_type_of(self)->struct_singleton);
 	}
 
 	if (!is_struct(self)) {

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -395,11 +395,6 @@ static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 	}
 
 	StructType * const type = struct_type_of(self);
-
-	if (type->struct_singleton != NULL) {
-		return Py_NewRef(type->struct_singleton);
-	}
-
 	PyTypeObject * const cls = &type->heap_type.ht_type;
 	PY_MOVABLE(copy_module, NULL);
 	PY_MOVABLE(copier, NULL);
@@ -420,6 +415,10 @@ static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 		PY_MOVABLE(reduced, PyObject_CallOneArg(copier, self));
 
 		return reduced != NULL ? copy_reconstruct(self, reduced, copy_module, Py_None) : NULL;
+	}
+
+	if (type->struct_singleton != NULL) {
+		return Py_NewRef(type->struct_singleton);
 	}
 
 	PY_MOVABLE(copy, cls->tp_alloc(cls, 0));
@@ -481,10 +480,6 @@ static PyObject * Struct_deepcopy(PyObject * const self, PyObject * const memo) 
 		return py_move(&seeded);
 	}
 
-	if (is_struct(self) && struct_type_of(self)->struct_singleton != NULL) {
-		return Py_NewRef(struct_type_of(self)->struct_singleton);
-	}
-
 	if (!is_struct(self)) {
 		PY_MOVABLE(
 			delegated,
@@ -536,6 +531,10 @@ static PyObject * Struct_deepcopy(PyObject * const self, PyObject * const memo) 
 		}
 
 		return py_move(&reconstructed);
+	}
+
+	if (type->struct_singleton != NULL) {
+		return Py_NewRef(type->struct_singleton);
 	}
 
 	PY_MOVABLE(copy, cls->tp_alloc(cls, 0));

--- a/src/salix.c
+++ b/src/salix.c
@@ -73,7 +73,6 @@ static void struct_free(void * const module) {
 	Py_CLEAR(state->handoff_attempt);
 	Py_CLEAR(state->handoff_declined);
 	Py_CLEAR(state->handoff_new);
-	Py_CLEAR(state->interned_singletons);
 }
 
 static PyMethodDef handoff_new_method = {
@@ -174,12 +173,6 @@ static int struct_exec(PyObject * const module) {
 	struct salix_state * const state = (struct salix_state *) PyModule_GetState(module);
 
 	if (state == NULL || settle_cache_fill(state) != RESULT_OK) {
-		return RESULT_ERROR;
-	}
-
-	state->interned_singletons = PyList_New(0);
-
-	if (state->interned_singletons == NULL) {
 		return RESULT_ERROR;
 	}
 

--- a/src/salix.c
+++ b/src/salix.c
@@ -73,6 +73,7 @@ static void struct_free(void * const module) {
 	Py_CLEAR(state->handoff_attempt);
 	Py_CLEAR(state->handoff_declined);
 	Py_CLEAR(state->handoff_new);
+	Py_CLEAR(state->interned_singletons);
 }
 
 static PyMethodDef handoff_new_method = {
@@ -173,6 +174,12 @@ static int struct_exec(PyObject * const module) {
 	struct salix_state * const state = (struct salix_state *) PyModule_GetState(module);
 
 	if (state == NULL || settle_cache_fill(state) != RESULT_OK) {
+		return RESULT_ERROR;
+	}
+
+	state->interned_singletons = PyList_New(0);
+
+	if (state->interned_singletons == NULL) {
 		return RESULT_ERROR;
 	}
 

--- a/src/types.h
+++ b/src/types.h
@@ -30,6 +30,7 @@ typedef struct StructType {
 	Py_ssize_t * struct_slot_offsets;
 	Py_ssize_t * struct_member_offsets;
 	PyObject * struct_post_init;
+	PyObject * struct_singleton;
 
 	Py_ssize_t struct_field_count;
 	Py_ssize_t struct_default_count;

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -92,3 +92,47 @@ def test_the_singleton_is_built_before_the_class_name_binds():
         class Named(Struct):
             def __post_init__(self) -> None:
                 return Named
+
+
+def test_a_dispatch_table_entry_still_precedes_the_singleton():
+    import copy
+
+    class Other(Struct):
+        pass
+
+    class Registered(Struct):
+        pass
+
+    copy.dispatch_table[Registered] = lambda _: (Other, ())
+
+    try:
+        assert type(copy.copy(Registered())) is Other
+    finally:
+        del copy.dispatch_table[Registered]
+
+
+def test_a_co_base_copy_method_still_precedes_the_singleton():
+    import copy
+
+    class WithCopy:
+        def __copy__(self) -> object:
+            return "co-base copy"
+
+    class CoBased(Struct, WithCopy):
+        pass
+
+    assert copy.copy(CoBased()) == "co-base copy"
+
+
+def test_post_init_observes_the_settle_bindings():
+    observed = []
+
+    class Bound(Struct):
+        def __hash__(self) -> int:
+            return 12345
+
+        def __post_init__(self) -> None:
+            observed.append(hash(self))
+
+    assert hash(Bound()) == 12345
+    assert observed == [12345]

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -154,3 +154,14 @@ def test_a_co_base_carrying_a_slot_is_not_interned():
         pass
 
     assert WithSlot() is not WithSlot()
+
+
+def test_a_diverting_setattro_co_base_is_not_interned():
+    class Diverting:
+        def __setattr__(self, name: str, value: object) -> None:
+            object.__setattr__(self, name, value)
+
+    class WithDivert(Struct, Diverting):
+        pass
+
+    assert WithDivert() is not WithDivert()

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -63,3 +63,32 @@ def test_post_init_runs_once_for_the_singleton():
 
     assert len(calls) == 1
     assert Counted() is calls[0]
+
+
+def test_copy_and_deepcopy_preserve_the_singleton():
+    import copy
+
+    assert copy.copy(Empty()) is Empty()
+    assert copy.deepcopy(Empty()) is Empty()
+
+
+def test_a_class_with_its_own_init_is_not_interned():
+    class WithInit(Struct):
+        def __init__(self) -> None:
+            pass
+
+    assert WithInit() is not WithInit()
+
+
+def test_a_failing_post_init_fails_the_class_statement():
+    with pytest.raises(RuntimeError, match="boom"):
+        class Exploding(Struct):
+            def __post_init__(self) -> None:
+                raise RuntimeError("boom")
+
+
+def test_the_singleton_is_built_before_the_class_name_binds():
+    with pytest.raises(NameError):
+        class Named(Struct):
+            def __post_init__(self) -> None:
+                return Named

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -136,3 +136,21 @@ def test_post_init_observes_the_settle_bindings():
 
     assert hash(Bound()) == 12345
     assert observed == [12345]
+
+
+def test_a_class_with_its_own_new_is_not_interned():
+    class WithNew(Struct):
+        def __new__(cls, *args, **kwargs):
+            return super().__new__(cls)
+
+    assert WithNew() is not WithNew()
+
+
+def test_a_co_base_carrying_a_slot_is_not_interned():
+    class Slotted:
+        __slots__ = ("z",)
+
+    class WithSlot(Struct, Slotted):
+        pass
+
+    assert WithSlot() is not WithSlot()

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,0 +1,65 @@
+import weakref
+
+import pytest
+
+from salix import Struct
+
+
+class Empty(Struct):
+    pass
+
+
+class OtherEmpty(Struct):
+    pass
+
+
+class Weaky(Struct, weakref=True):
+    pass
+
+
+class Mutable(Struct, frozen=False):
+    pass
+
+
+def test_a_zero_field_frozen_struct_is_its_own_singleton():
+    assert Empty() is Empty()
+    assert isinstance(Empty(), Empty)
+    assert repr(Empty()) == "Empty()"
+
+
+def test_the_singleton_hashes_like_the_empty_tuple():
+    assert hash(Empty()) == hash(())
+
+
+def test_each_subclass_gets_its_own_singleton():
+    assert Empty() is not OtherEmpty()
+
+
+def test_weakref_true_stays_allocated():
+    held = Weaky()
+
+    assert Weaky() is not held
+    assert weakref.ref(held)() is held
+
+
+def test_a_mutable_zero_field_struct_stays_allocated():
+    assert Mutable() is not Mutable()
+
+
+def test_arguments_are_still_refused():
+    with pytest.raises(TypeError, match="takes at most 0 positional"):
+        Empty(1)
+
+
+def test_post_init_runs_once_for_the_singleton():
+    calls = []
+
+    class Counted(Struct):
+        def __post_init__(self) -> None:
+            calls.append(self)
+
+    Counted()
+    Counted()
+
+    assert len(calls) == 1
+    assert Counted() is calls[0]


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The standing instruction: after #114, address #59–#64 in one or more PRs; #60 is the zero-field interning ask from #64's index.

## Executive summary

A frozen struct with no fields and no weakref slot has exactly one possible value. `ensure_singleton` builds it once at class creation — through the constructor path, so `__post_init__` runs exactly once — and the class holds it. `Struct_vectorcall` and `Struct_new` return `Py_NewRef` of it for an empty call: `Empty() is Empty()`, construction becomes an incref (~15× on the measured call), and closed-sum dispatch by identity becomes valid.

<details>
<summary>Qualification and mechanics</summary>

- The qualification is deliberately narrow: `frozen && !weakref && field_count == 0`. `weakref=True` makes identity observable; a mutable struct can carry identity user code relies on (#60's notes).
- The vectorcall short-circuits only after the argument checks — `Empty(1)` still raises the positional TypeError, keywords still refuse.
- Subclasses each get their own singleton.
- The settle restore re-ensures it after a diverting re-entry; the GC walks it (`traverse`/`clear`).
- `Struct_new` (the pickle-layer constructor) returns the singleton for an empty call too, so `__new__` and the call path agree on identity.
</details>

<details>
<summary>Verification</summary>

- camas check: 25/25 leaves green (3.10–3.15 + free-threaded builds and pytest, format, lint, clang-tidy, gcc -fanalyzer, C tests, mypy/pyright/ty)
- /tmp/csuite.sh: 30 Unity C tests × 3.10–3.14, 0 failures
- Pins (tests/test_singleton.py): identity, `hash == hash(())`, per-subclass singletons, weakref/mutable non-interning, the argument refusal, `__post_init__` runs exactly once
</details>

Closes #60.

## Round 1 disposition (score 2.43; systemic answered structurally)

- **Systemic (`singleton-invariant-point-enforced`) — fixed.** Every instance-producing path consults the interned value: `copy.copy`/`copy.deepcopy` return the singleton (atomic-immutable semantics — no state a copy could diverge, so no memo registration, matching copy.py's atomics); own-`__init__` classes are excluded from qualification, so `tp_init` can never re-run on the shared object; the two construction gates share one predicate (`interned_value`), each protocol computing only its own no-arguments boolean.
- **`missing-args-tuple-check` — fixed** (guard before `PyTuple_GET_SIZE`).
- **`eager-construction-before-name-binding` — pinned as the chosen semantics**: a failing `__post_init__` fails the class statement, and the class name is not bound while the hook runs (two tests). Lazy first-call creation was rejected: it would need a free-threaded-safe store and could transiently split identity across racing threads.
- **`duplicated-install-tail` — fixed**: `install_constructor` is the one install tail, which also reconciles the duplicated constructor dispatch the #114 review deferred (the settle shape — clearing `tp_vectorcall` on the `__init__` branch — is the one that survives).
- **`hand-rolled-empty-call`** — the call shape is `PyObject_Call(class, NULL, NULL)`; the `XSETREF` stays because the settle re-ensure may replace an existing value.


## Round 2 disposition (score 1.9; systemic answered, two claims measured and rejected)

- **Systemic (`singleton-gate-edge-divergence`) — fixed per gate.** The vectorcall predicate reads an empty `kwnames` tuple the same as NULL; the singleton is loaded once into a local; the dead `Struct_new` gate is dropped (its guards stay); the copy/deepcopy short-circuits moved after the dispatch prologue so co-base methods and `dispatch_table` entries keep their precedence, with two discriminating pins (a dispatch reducer to another class; a co-base `__copy__` method).
- **`singleton-built-before-settle-bindings` — fixed**: `build_struct_class` applies the settle bindings before `install_constructor` on every path, so `__post_init__` observes the bound class (pinned: a body `__hash__` read inside the hook).
- **`hand-rolled-empty-call` — rejected with a citation.** `PyObject_Call` documents that `args` must not be NULL ("use an empty tuple if no arguments are needed"); the suggested NULL-args shape segfaulted the import path on every build (measured). The empty tuple stays, with a comment citing the contract.
- **`class-singleton-cycle-not-collectible` — does not reproduce.** Probe: build a qualifying class, drop every reference, `gc.collect()` — the class is freed (`alive: False`). The singleton is untracked, so its type edge is invisible to the GC; the class→singleton edge is one-way and refcount handles it.
- **`post-creation-hook-rebinding-inert` — boundary.** Hooks are captured at class creation for every class (the `struct_post_init` design predates this PR); rebinding them post-creation being inert is the established semantics, not a singleton-specific timing artifact.


## Round 3 disposition (score 2.27; the systemic's claim measured and rejected, the streak-3 fixed)

- **Systemic (`singleton-lifetime-version-sensitive`) — the memory-safety claim does not reproduce.** The probe (build a qualifying class dynamically, touch the singleton, drop every reference, `gc.collect()`) frees the class on **3.10, 3.11, 3.12, and 3.14** alike. The claimed use-after-free requires the singleton to be freed while the class still holds the pointer; the class owns the singleton's only reference until its own `clear`, so that ordering cannot occur. Recorded here as the boundary answer, with the probe shape stated so it can be re-run.
- **`hand-rolled-empty-call` — streak 3, root fix applied**: `ensure_singleton` now uses `PyObject_CallNoArgs`, the idiom this codebase already uses.
- **`untrusted-singleton-build-result` — fixed**: qualification excludes classes whose metaclass overrides `__call__`, and the built result's type is verified before it is stored (internal error otherwise).
- **`duplicated-singleton-short-circuit` — fixed**: both copy paths share `interned_copy`.
- **`eager-singleton-transient-window` — boundary**: identity is guaranteed once the class statement completes; a `__post_init__` that constructs its own class re-enters before the singleton is stored and sees a second instance (unconditional re-entry recurses to RecursionError). The eager build is the pinned timing, so the window is documented rather than engineered around.


## Round 4 disposition (score 2.47; the streak-3 systemic gets a structural answer)

- **Systemic (`singleton-lifetime-version-sensitive`, streak 3) — answered structurally, not with another probe.** Every interned singleton is now anchored in the per-interpreter state (`salix_state.interned_singletons`, cleared at module teardown). The anchor makes the lifetime invariant hold *by construction* on every supported version: the singleton provably outlives every class that references it, so the class's `clear` can never decref a freed object and the pair cannot leak, whatever the GC's internal ordering does. The earlier probes (one- and two-collect liveness, the reviewer's prescribed shape, on 3.10/3.11/3.12/3.14) all freed the class; the anchor covers the space those probes cannot reach.
- **`custom-new-interning-gap` — fixed**: qualification now excludes classes whose `tp_new` is non-NULL (a body `__new__`) — pinned.
- **`co-base-state-interning-gap` — fixed**: qualification excludes classes with co-base slot members (`struct_member_count > 0`) — pinned.
- **`dead-argument-guards` — fixed**: the two guards are dropped; `Struct_new` never reads its arguments.
- **`singleton-gate-snapshot-stale` — boundary**: replacing a metaclass's `__call__` after class creation voids the interning invariant, per the reviewer's "no code change required".


## Round 5 disposition (score 1.88; the anchor is withdrawn, the lifetime question is filed)

- **`interned-singletons-anchor-leak` — fixed, and the reviewer was right.** The interpreter-state anchor pinned every interned class and its singleton until module teardown. The anchor is removed and the clean refcount design restored: the class owns the singleton's only strong reference, `StructMeta_traverse` visits it, and dealloc handles the pair.
- **Systemic (`singleton-lifetime-unpinned`, and the streak-4 `gc-dangling-singleton-pointer`) — filed as [#135](https://github.com/JPHutchins/salix/issues/135)** with the full probe table (four shapes, four versions — the claim never reproduced), the traverse-edge reasoning, the rejected anchor designs, and a proposed settling harness. This is the streak disposition: a tracked issue, not another in-PR probe.
- **`co-base-state-interning-gap` (diverting setattro) — fixed**: qualification takes the already-computed `bases_divert_setattro` and excludes those classes — pinned.
