### PR TITLE
feat: __replace__ and salix.replace, the copy-with-override protocol

### DIFF
--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Final
+from typing import Any, Final, TypeVar
 
 from typing_extensions import Self, dataclass_transform
 
@@ -14,6 +14,7 @@ class Struct:
     __struct_metadata__: Final[tuple[tuple[Any, ...], ...]]
     def __copy__(self) -> Self: ...
     def __deepcopy__(self, memo: dict[int, Any]) -> Self: ...
+    def __replace__(self, /, **changes: object) -> Self: ...
     def __init_subclass__(
         cls,
         *,
@@ -25,4 +26,8 @@ class Struct:
         weakref: bool = False,
     ) -> None: ...
 
+_StructT = TypeVar("_StructT", bound=Struct)
+
+
 def set_field(instance: Struct, name: str, value: object, /) -> None: ...
+def replace(instance: _StructT, /, **changes: object) -> _StructT: ...

--- a/src/construct.h
+++ b/src/construct.h
@@ -12,6 +12,13 @@ PyObject * Struct_vectorcall(
 
 PyObject * Struct_new(PyTypeObject * struct_class, PyObject * arguments, PyObject * keywords);
 
+PyObject * Struct_replace(
+	PyObject * self,
+	PyObject * const * arguments,
+	Py_ssize_t nargs,
+	PyObject * keyword_names
+);
+
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
 
 bool struct_copies_default(PyTypeObject const * kind);

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -24,6 +24,7 @@ static enum result fill_defaults(
 	PyObject * self,
 	Py_ssize_t positional_count
 );
+static struct field_lookup named_field(StructType const * type, PyObject * name);
 static enum result run_post_init(StructType const * type, PyObject * self);
 
 static PyObject * interned_value(StructType const * const type, bool const no_arguments) {
@@ -132,7 +133,7 @@ PyObject * Struct_replace(
 	StructType * const type = struct_type_of(self);
 	Py_ssize_t const change_count = keyword_names != NULL ? PyTuple_GET_SIZE(keyword_names) : 0;
 
-	if (change_count == 0) {
+	if (change_count == 0 && type->struct_options.frozen) {
 		return Py_NewRef(self);
 	}
 
@@ -145,27 +146,35 @@ PyObject * Struct_replace(
 			return NULL;
 		}
 
+		for (Py_ssize_t i = 0; i < change_count; ++i) {
+			if (named_field(type, PyTuple_GET_ITEM(keyword_names, i)).tag != FIELD_LOOKUP_FOUND) {
+				return NULL;
+			}
+		}
+
 		PY_OWNED(values, PyTuple_New(type->struct_field_count));
 
 		if (values == NULL) {
 			return NULL;
 		}
 
-		STRUCT_BEGIN_CRITICAL_SECTION(self);
-
-		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
-			PyTuple_SET_ITEM(values, i, Py_XNewRef(*struct_slot(type, self, i)));
-		}
-
-		STRUCT_END_CRITICAL_SECTION();
+		struct_slots_ref_into(type, self, values, NULL);
 
 		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
 			PyObject * const value = PyTuple_GET_ITEM(values, i);
 
-			if (
-				value != NULL &&
-				PyDict_SetItem(changed, PyTuple_GET_ITEM(type->struct_field_names, i), value) < 0
-			) {
+			if (value == NULL) {
+				continue;
+			}
+
+			PyObject * const name = PyTuple_GET_ITEM(type->struct_field_names, i);
+			int const present = PyDict_Contains(changed, name);
+
+			if (present < 0) {
+				return NULL;
+			}
+
+			if (present == 0 && PyDict_SetItem(changed, name, value) < 0) {
 				return NULL;
 			}
 		}
@@ -195,7 +204,28 @@ PyObject * Struct_replace(
 			return NULL;
 		}
 
-		if (struct_copy_slots_and_dict(type, self, replaced) < 0) {
+		if (Py_TYPE(replaced) != cls) {
+			PyErr_SetString(
+				PyExc_SystemError,
+				"salix internal error: the replace construction returned a different type"
+			);
+
+			return NULL;
+		}
+
+		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
+			PyObject * const value = PyTuple_GET_ITEM(values, i);
+			PyObject * * const slot = struct_slot(type, replaced, i);
+
+			if (value != NULL && *slot == NULL) {
+				*slot = Py_NewRef(value);
+			}
+		}
+
+		PY_MOVABLE(source_dict, NULL);
+		struct_slots_copy_into(type, self, replaced, &source_dict);
+
+		if (source_dict != NULL && struct_dict_copy_merged(source_dict, replaced) < 0) {
 			return NULL;
 		}
 
@@ -208,14 +238,22 @@ PyObject * Struct_replace(
 		return NULL;
 	}
 
-	if (
-		bind_keywords(type, copy, arguments, 0, keyword_names) != RESULT_OK ||
-		struct_copy_slots_and_dict(type, self, copy) < 0
-	) {
+	if (bind_keywords(type, copy, arguments, 0, keyword_names) != RESULT_OK) {
 		return NULL;
 	}
 
-	return run_post_init(type, copy) == RESULT_OK ? py_move(&copy) : NULL;
+	PY_MOVABLE(source_dict, NULL);
+	struct_slots_copy_into(type, self, copy, &source_dict);
+
+	if (run_post_init(type, copy) != RESULT_OK) {
+		return NULL;
+	}
+
+	if (source_dict != NULL && struct_dict_copy_merged(source_dict, copy) < 0) {
+		return NULL;
+	}
+
+	return py_move(&copy);
 }
 
 static enum result run_post_init(StructType const * const type, PyObject * const self) {
@@ -250,19 +288,11 @@ static enum result bind_keywords(
 
 	for (Py_ssize_t i = 0; i < keyword_count; ++i) {
 		PyObject * const keyword = PyTuple_GET_ITEM(keyword_names, i);
-		struct field_lookup const found = find_field(type, keyword);
+		struct field_lookup const found = named_field(type, keyword);
 
 		switch (found.tag) {
 			case FIELD_LOOKUP_ERROR:
-				return RESULT_ERROR;
 			case FIELD_LOOKUP_MISSING:
-				PyErr_Format(
-					PyExc_TypeError,
-					"%.200s() got an unexpected keyword argument '%U'",
-					struct_type_name(type),
-					keyword
-				);
-
 				return RESULT_ERROR;
 			case FIELD_LOOKUP_FOUND:
 				break;
@@ -285,6 +315,21 @@ static enum result bind_keywords(
 	}
 
 	return RESULT_OK;
+}
+
+static struct field_lookup named_field(StructType const * const type, PyObject * const name) {
+	struct field_lookup const found = find_field(type, name);
+
+	if (found.tag == FIELD_LOOKUP_MISSING) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"%.200s() got an unexpected keyword argument '%U'",
+			struct_type_name(type),
+			name
+		);
+	}
+
+	return found;
 }
 
 static enum result fill_defaults(

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -145,20 +145,30 @@ PyObject * Struct_replace(
 			return NULL;
 		}
 
-		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
-			PY_MOVABLE(value, struct_slot_ref(type, self, i));
+		/* One acquisition for every kept field, so a free-threaded replace
+		 * hands the constructor a field set the source really held. */
+		PY_OWNED(values, PyTuple_New(type->struct_field_count));
 
-			if (value != NULL) {
-				if (
-					PyDict_SetItem(
-						changed,
-						PyTuple_GET_ITEM(type->struct_field_names, i),
-						value
-					) <
-					0
-				) {
-					return NULL;
-				}
+		if (values == NULL) {
+			return NULL;
+		}
+
+		STRUCT_BEGIN_CRITICAL_SECTION(self);
+
+		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
+			PyTuple_SET_ITEM(values, i, Py_XNewRef(*struct_slot(type, self, i)));
+		}
+
+		STRUCT_END_CRITICAL_SECTION();
+
+		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
+			PyObject * const value = PyTuple_GET_ITEM(values, i);
+
+			if (
+				value != NULL &&
+				PyDict_SetItem(changed, PyTuple_GET_ITEM(type->struct_field_names, i), value) < 0
+			) {
+				return NULL;
 			}
 		}
 
@@ -177,7 +187,24 @@ PyObject * Struct_replace(
 
 		PY_OWNED(no_arguments, PyTuple_New(0));
 
-		return no_arguments != NULL ? PyObject_Call((PyObject *) cls, no_arguments, changed) : NULL;
+		if (no_arguments == NULL) {
+			return NULL;
+		}
+
+		PY_MOVABLE(replaced, PyObject_Call((PyObject *) cls, no_arguments, changed));
+
+		if (replaced == NULL) {
+			return NULL;
+		}
+
+		/* Whatever the constructor left unwritten -- fields, co-base members,
+		 * the instance dict -- the source fills, through the same primitive
+		 * the fast path uses, so the two paths diverge only in construction. */
+		if (struct_copy_slots_and_dict(type, self, replaced) < 0) {
+			return NULL;
+		}
+
+		return py_move(&replaced);
 	}
 
 	PY_MOVABLE(copy, cls->tp_alloc(cls, 0));
@@ -186,19 +213,11 @@ PyObject * Struct_replace(
 		return NULL;
 	}
 
-	if (bind_keywords(type, copy, arguments, 0, keyword_names) != RESULT_OK) {
+	if (
+		bind_keywords(type, copy, arguments, 0, keyword_names) != RESULT_OK ||
+		struct_copy_slots_and_dict(type, self, copy) < 0
+	) {
 		return NULL;
-	}
-
-	PY_MOVABLE(dict, NULL);
-	struct_slots_copy_into(type, self, copy, &dict);
-
-	if (dict != NULL) {
-		PY_OWNED(copied, PyDict_Copy(dict));
-
-		if (copied == NULL || PyObject_GenericSetDict(copy, copied, NULL) < 0) {
-			return NULL;
-		}
 	}
 
 	return run_post_init(type, copy) == RESULT_OK ? py_move(&copy) : NULL;

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -1,6 +1,7 @@
 #include <Python.h>
 
 #include "construct.h"
+#include "../meta/meta.h"
 #include "../owned.h"
 #include "../result.h"
 #include "../types.h"
@@ -100,6 +101,107 @@ PyObject * Struct_new(
 		fill_defaults(type, self, struct_required_count(type)) == RESULT_OK ? py_move(&self) :
 		NULL
 	);
+}
+
+PyObject * Struct_replace(
+	PyObject * const self,
+	PyObject * const * const arguments,
+	Py_ssize_t const nargs,
+	PyObject * const keyword_names
+) {
+	/* METH_FASTCALL methods receive self as the first parameter, so the
+	 * positional count here excludes it: anything past zero is a second
+	 * positional argument. */
+	if (nargs != 0) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"%s.__replace__() takes exactly one positional argument (%zd given)",
+			Py_TYPE(self)->tp_name,
+			nargs
+		);
+
+		return NULL;
+	}
+
+	if (!is_struct(self)) {
+		PyErr_Format(PyExc_TypeError, "%s object is not replaceable", Py_TYPE(self)->tp_name);
+
+		return NULL;
+	}
+
+	StructType * const type = struct_type_of(self);
+	Py_ssize_t const change_count = keyword_names != NULL ? PyTuple_GET_SIZE(keyword_names) : 0;
+
+	if (change_count == 0) {
+		return Py_NewRef(self);
+	}
+
+	PyTypeObject * const cls = &type->heap_type.ht_type;
+
+	if (defines_own_init(type)) {
+		PY_OWNED(changed, PyDict_New());
+
+		if (changed == NULL) {
+			return NULL;
+		}
+
+		for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
+			PY_MOVABLE(value, struct_slot_ref(type, self, i));
+
+			if (value != NULL) {
+				if (
+					PyDict_SetItem(
+						changed,
+						PyTuple_GET_ITEM(type->struct_field_names, i),
+						value
+					) <
+					0
+				) {
+					return NULL;
+				}
+			}
+		}
+
+		for (Py_ssize_t i = 0; i < change_count; ++i) {
+			if (
+				PyDict_SetItem(
+					changed,
+					PyTuple_GET_ITEM(keyword_names, i),
+					arguments[nargs + i]
+				) <
+				0
+			) {
+				return NULL;
+			}
+		}
+
+		PY_OWNED(no_arguments, PyTuple_New(0));
+
+		return no_arguments != NULL ? PyObject_Call((PyObject *) cls, no_arguments, changed) : NULL;
+	}
+
+	PY_MOVABLE(copy, cls->tp_alloc(cls, 0));
+
+	if (copy == NULL) {
+		return NULL;
+	}
+
+	if (bind_keywords(type, copy, arguments, 0, keyword_names) != RESULT_OK) {
+		return NULL;
+	}
+
+	PY_MOVABLE(dict, NULL);
+	struct_slots_copy_into(type, self, copy, &dict);
+
+	if (dict != NULL) {
+		PY_OWNED(copied, PyDict_Copy(dict));
+
+		if (copied == NULL || PyObject_GenericSetDict(copy, copied, NULL) < 0) {
+			return NULL;
+		}
+	}
+
+	return run_post_init(type, copy) == RESULT_OK ? py_move(&copy) : NULL;
 }
 
 static enum result run_post_init(StructType const * const type, PyObject * const self) {

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -145,8 +145,6 @@ PyObject * Struct_replace(
 			return NULL;
 		}
 
-		/* One acquisition for every kept field, so a free-threaded replace
-		 * hands the constructor a field set the source really held. */
 		PY_OWNED(values, PyTuple_New(type->struct_field_count));
 
 		if (values == NULL) {
@@ -197,9 +195,6 @@ PyObject * Struct_replace(
 			return NULL;
 		}
 
-		/* Whatever the constructor left unwritten -- fields, co-base members,
-		 * the instance dict -- the source fills, through the same primitive
-		 * the fast path uses, so the two paths diverge only in construction. */
 		if (struct_copy_slots_and_dict(type, self, replaced) < 0) {
 			return NULL;
 		}

--- a/src/hash.c
+++ b/src/hash.c
@@ -23,7 +23,7 @@ Py_hash_t Struct_hash(PyObject * const self) {
 		return HASH_ERR;
 	}
 
-	struct_slots_ref_or_none_into(type, self, values);
+	struct_slots_ref_into(type, self, values, Py_None);
 
 	if (Py_EnterRecursiveCall(" while hashing a struct") != 0) {
 		return HASH_ERR;

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -440,7 +440,14 @@ static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 		return NULL;
 	}
 
-	return struct_copy_slots_and_dict(type, self, copy) == 0 ? py_move(&copy) : NULL;
+	PY_MOVABLE(dict, NULL);
+	struct_slots_copy_into(type, self, copy, &dict);
+
+	if (dict != NULL && struct_dict_copy_merged(dict, copy) < 0) {
+		return NULL;
+	}
+
+	return py_move(&copy);
 }
 
 static PyObject * memo_failure(PyObject * const memo, PyObject * const key) {

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -440,18 +440,7 @@ static PyObject * Struct_copy(PyObject * const self, PyObject * const noargs) {
 		return NULL;
 	}
 
-	PY_MOVABLE(dict, NULL);
-	struct_slots_copy_into(type, self, copy, &dict);
-
-	if (dict != NULL) {
-		PY_OWNED(copied, PyDict_Copy(dict));
-
-		if (copied == NULL || PyObject_GenericSetDict(copy, copied, NULL) < 0) {
-			return NULL;
-		}
-	}
-
-	return py_move(&copy);
+	return struct_copy_slots_and_dict(type, self, copy) == 0 ? py_move(&copy) : NULL;
 }
 
 static PyObject * memo_failure(PyObject * const memo, PyObject * const key) {

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -1,6 +1,7 @@
 #include <Python.h>
 
 #include "compare.h"
+#include "construct.h"
 #include "hash.h"
 #include "mixin.h"
 #include "owned.h"
@@ -62,6 +63,12 @@ PyTypeObject StructMixin_Type = {
 static PyMethodDef Struct_methods[] = {
 	{"__copy__", Struct_copy, METH_NOARGS, NULL},
 	{"__deepcopy__", Struct_deepcopy, METH_O, NULL},
+	{
+		"__replace__",
+		(PyCFunction)(void (*)(void)) Struct_replace,
+		METH_FASTCALL | METH_KEYWORDS,
+		NULL,
+	},
 	{.ml_name = NULL},
 };
 

--- a/src/salix.c
+++ b/src/salix.c
@@ -166,9 +166,6 @@ static PyObject * replace(PyObject * const module, PyObject * const args, PyObje
 		return NULL;
 	}
 
-	/* The type-level lookup is copy.replace's own: an instance-dict entry
-	 * or a __getattr__ hook must not shadow the dunder the protocol
-	 * dispatches on. */
 	PY_OWNED(replacer, PyObject_GetAttrString((PyObject *) Py_TYPE(instance), "__replace__"));
 
 	if (replacer == NULL) {

--- a/src/salix.c
+++ b/src/salix.c
@@ -6,11 +6,13 @@
 #include "mixin.h"
 #include "owned.h"
 #include "result.h"
+#include "types.h"
 
 static int struct_exec(PyObject * module);
 static enum result add_struct_base(PyObject * module);
 static PyObject * create_struct_base(PyObject * module);
 static PyObject * handoff_new(PyObject * self, PyObject * args);
+static PyObject * replace(PyObject * module, PyObject * args, PyObject * kwargs);
 static void struct_free(void * module);
 
 /*
@@ -36,6 +38,12 @@ static PyMethodDef struct_functions[] = {
 		.ml_meth = Struct_set_field,
 		.ml_flags = METH_VARARGS,
 		.ml_doc = "set_field(instance, name, value) -- assign a field the class declared.",
+	},
+	{
+		.ml_name = "replace",
+		.ml_meth = (PyCFunction)(void (*)(void)) replace,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = "replace(instance, **changes) -- derive a copy with new field values.",
 	},
 	{.ml_name = NULL},
 };
@@ -139,6 +147,34 @@ static PyObject * build_handoff_machinery(struct salix_state * const state) {
 	Py_XSETREF(state->handoff_new, Py_NewRef(new_fn));
 
 	return state->handoff_attempt;
+}
+
+static PyObject * replace(PyObject * const module, PyObject * const args, PyObject * const kwargs) {
+	PyObject * instance = NULL;
+
+	if (!PyArg_ParseTuple(args, "O:replace", &instance)) {
+		return NULL;
+	}
+
+	if (!is_struct(instance)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"replace() expects a struct, not %.200s",
+			Py_TYPE(instance)->tp_name
+		);
+
+		return NULL;
+	}
+
+	PY_OWNED(method, PyObject_GetAttrString(instance, "__replace__"));
+
+	if (method == NULL) {
+		return NULL;
+	}
+
+	PY_OWNED(no_arguments, PyTuple_New(0));
+
+	return no_arguments != NULL ? PyObject_Call(method, no_arguments, kwargs) : NULL;
 }
 
 static PyObject * handoff_new(PyObject * const self, PyObject * const args) {

--- a/src/salix.c
+++ b/src/salix.c
@@ -166,15 +166,18 @@ static PyObject * replace(PyObject * const module, PyObject * const args, PyObje
 		return NULL;
 	}
 
-	PY_OWNED(method, PyObject_GetAttrString(instance, "__replace__"));
+	/* The type-level lookup is copy.replace's own: an instance-dict entry
+	 * or a __getattr__ hook must not shadow the dunder the protocol
+	 * dispatches on. */
+	PY_OWNED(replacer, PyObject_GetAttrString((PyObject *) Py_TYPE(instance), "__replace__"));
 
-	if (method == NULL) {
+	if (replacer == NULL) {
 		return NULL;
 	}
 
-	PY_OWNED(no_arguments, PyTuple_New(0));
+	PY_OWNED(instance_arguments, PyTuple_Pack(1, instance));
 
-	return no_arguments != NULL ? PyObject_Call(method, no_arguments, kwargs) : NULL;
+	return instance_arguments != NULL ? PyObject_Call(replacer, instance_arguments, kwargs) : NULL;
 }
 
 static PyObject * handoff_new(PyObject * const self, PyObject * const args) {

--- a/src/types.h
+++ b/src/types.h
@@ -289,9 +289,10 @@ static inline void struct_slots_copy_into(
 	for (Py_ssize_t i = 0; i < type->struct_member_count; ++i) {
 		Py_ssize_t const offset = type->struct_member_offsets[i];
 		PyObject * const value = *(PyObject * *) ((char *) source + offset);
+		PyObject * * const destination_slot = (PyObject * *) ((char *) destination + offset);
 
-		if (value != NULL) {
-			*((PyObject * *) ((char *) destination + offset)) = Py_NewRef(value);
+		if (value != NULL && *destination_slot == NULL) {
+			*destination_slot = Py_NewRef(value);
 		}
 	}
 
@@ -302,6 +303,39 @@ static inline void struct_slots_copy_into(
 	}
 
 	STRUCT_END_CRITICAL_SECTION();
+}
+
+/*
+ * The shallow trio -- copy, and both replace paths -- shares this: the slots
+ * and the instance dict, the dict copied and installed outside the section,
+ * where the source's dict pointer is a strong reference again. Fails only
+ * when the dict copy or its install does; a source without a dict slot is
+ * success and reads never materialize one.
+ */
+static inline int struct_copy_slots_and_dict(
+	StructType const * const type,
+	PyObject * const source,
+	PyObject * const destination
+) {
+	PyObject * dict = NULL;
+
+	struct_slots_copy_into(type, source, destination, &dict);
+
+	if (dict == NULL) {
+		return 0;
+	}
+
+	PyObject * const copied = PyDict_Copy(dict);
+	Py_DECREF(dict);
+
+	if (copied == NULL) {
+		return -1;
+	}
+
+	int const installed = PyObject_GenericSetDict(destination, copied, NULL);
+	Py_DECREF(copied);
+
+	return installed;
 }
 
 static inline Py_ssize_t struct_required_count(StructType const * const type) {

--- a/src/types.h
+++ b/src/types.h
@@ -238,20 +238,22 @@ static inline struct slot_pair struct_slot_pair_ref(
  * Every field into `values`, which must be a tuple of struct_field_count and
  * whose items must be unset. One acquisition rather than one per field, and so
  * a real snapshot -- hash is the reader that can have both, because nothing in
- * this loop calls back into Python. 3.14t, eight fields: 111.4ns to 81.1,
- * against 77.5 for the unsynchronised read this replaced.
+ * this loop calls back into Python. An unwritten slot takes `missing`: Py_None
+ * for readers that render, NULL for callers that skip. 3.14t, eight fields:
+ * 111.4ns to 81.1, against 77.5 for the unsynchronised read this replaced.
  */
-static inline void struct_slots_ref_or_none_into(
+static inline void struct_slots_ref_into(
 	StructType const * const type,
 	PyObject * const self,
-	PyObject * const values
+	PyObject * const values,
+	PyObject * const missing
 ) {
 	STRUCT_BEGIN_CRITICAL_SECTION(self);
 
 	for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
 		PyObject * const value = *struct_slot(type, self, i);
 
-		PyTuple_SET_ITEM(values, i, Py_NewRef(value != NULL ? value : Py_None));
+		PyTuple_SET_ITEM(values, i, value != NULL ? Py_NewRef(value) : Py_XNewRef(missing));
 	}
 
 	STRUCT_END_CRITICAL_SECTION();
@@ -306,29 +308,27 @@ static inline void struct_slots_copy_into(
 }
 
 /*
- * The shallow trio -- copy, and both replace paths -- shares this: the slots
- * and the instance dict, the dict copied and installed outside the section,
- * where the source's dict pointer is a strong reference again. Fails only
- * when the dict copy or its install does; a source without a dict slot is
- * success and reads never materialize one.
+ * Installs a copy of the source dict, with entries the destination already
+ * holds winning: a constructor or __post_init__ that wrote its own dict
+ * keeps what it computed, and the copy fills the rest. The caller hands in
+ * the strong reference struct_slots_copy_into took, so nothing here reads
+ * the source again.
  */
-static inline int struct_copy_slots_and_dict(
-	StructType const * const type,
-	PyObject * const source,
+static inline int struct_dict_copy_merged(
+	PyObject * const source_dict,
 	PyObject * const destination
 ) {
-	PyObject * dict = NULL;
-
-	struct_slots_copy_into(type, source, destination, &dict);
-
-	if (dict == NULL) {
-		return 0;
-	}
-
-	PyObject * const copied = PyDict_Copy(dict);
-	Py_DECREF(dict);
+	PyObject * const copied = PyDict_Copy(source_dict);
 
 	if (copied == NULL) {
+		return -1;
+	}
+
+	PyObject * * const own_slot = _PyObject_GetDictPtr(destination);
+
+	if (own_slot != NULL && *own_slot != NULL && PyDict_Update(copied, *own_slot) < 0) {
+		Py_DECREF(copied);
+
 		return -1;
 	}
 

--- a/src/types.h
+++ b/src/types.h
@@ -261,11 +261,13 @@ static inline void struct_slots_ref_or_none_into(
  * Every slot the type owns, plus the instance dict pointer, under one
  * acquisition: the struct fields and the non-struct base members whose
  * offsets install_fields resolved. An unwritten slot stays unwritten in the
- * destination. `dict` receives a strong reference to the instance dict if
- * the slot holds one; reading never creates the dict, so copying a struct
- * that never had a __dict__ does not materialize one on the source. The
- * dict's contents are copied by the caller, outside this section. The loop
- * stores only, so nothing here can fail.
+ * destination, and one the destination already holds keeps its value, so a
+ * caller may write changes before the copy and have them survive it.
+ * `dict` receives a strong reference to the instance dict if the slot holds
+ * one; reading never creates the dict, so copying a struct that never had a
+ * __dict__ does not materialize one on the source. The dict's contents are
+ * copied by the caller, outside this section. The loop stores only, so
+ * nothing here can fail.
  */
 static inline void struct_slots_copy_into(
 	StructType const * const type,
@@ -277,9 +279,10 @@ static inline void struct_slots_copy_into(
 
 	for (Py_ssize_t i = 0; i < type->struct_field_count; ++i) {
 		PyObject * const value = *struct_slot(type, source, i);
+		PyObject * * const destination_slot = struct_slot(type, destination, i);
 
-		if (value != NULL) {
-			*struct_slot(type, destination, i) = Py_NewRef(value);
+		if (value != NULL && *destination_slot == NULL) {
+			*destination_slot = Py_NewRef(value);
 		}
 	}
 

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -5,7 +5,7 @@ import threading
 
 import pytest
 
-from salix import Struct, set_field
+from salix import Struct, replace, set_field
 
 pytestmark = pytest.mark.skipif(
     not sysconfig.get_config_var("Py_GIL_DISABLED"), reason="not a free-threaded build"
@@ -376,3 +376,36 @@ def test_a_dict_bearing_struct_is_safe_to_copy_while_another_thread_writes_its_d
                 assert copied.__dict__ is not shared.__dict__
 
     run_in_roles((write, read))
+
+
+def test_a_shared_struct_is_safe_to_replace_while_another_thread_writes_it():
+    """The replace path reads the kept slots through the same single section
+    the copy path uses; the changed slot is the caller's own value and takes
+    no source read. One writer, because `first >= second` also pins the kept
+    pair being a one-section snapshot: the writer writes first and then
+    second, so the source's own states always satisfy it, while a per-slot
+    read could assemble (i, i+1) across a writer round, which the source
+    never held. Survival is the assertion."""
+
+    class Shared(Struct, frozen=False):
+        first: object
+        second: object
+        third: object
+
+    shared = Shared(0, 0, 0)
+
+    rounds = ITERATIONS * 5
+
+    def write():
+        for i in range(rounds):
+            shared.first = i
+            shared.second = i
+
+    def read():
+        for i in range(rounds):
+            replaced = replace(shared, third=i)
+
+            if i % 1000 == 0:
+                assert replaced.first >= replaced.second
+
+    run_in_roles((write,) + (read,) * (THREADS - 1))

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -409,3 +409,38 @@ def test_a_shared_struct_is_safe_to_replace_while_another_thread_writes_it():
                 assert replaced.first >= replaced.second
 
     run_in_roles((write,) + (read,) * (THREADS - 1))
+
+
+def test_a_shared_struct_is_safe_to_replace_through_a_body_init_while_another_thread_writes_it():
+    """The slow path gathers the kept fields under one section before the
+    constructor call, the same guarantee the fast path gets from the copy
+    primitive: one writer, and `first >= second` pins the snapshot the way
+    the copy test above does. Survival is the assertion."""
+
+    class Shared(Struct, frozen=False):
+        first: object
+        second: object
+        third: object
+
+        def __init__(self, first: object, second: object, third: object) -> None:
+            self.first = first
+            self.second = second
+            self.third = third
+
+    shared = Shared(0, 0, 0)
+
+    rounds = ITERATIONS * 5
+
+    def write():
+        for i in range(rounds):
+            shared.first = i
+            shared.second = i
+
+    def read():
+        for i in range(rounds):
+            replaced = replace(shared, third=i)
+
+            if i % 1000 == 0:
+                assert replaced.first >= replaced.second
+
+    run_in_roles((write,) + (read,) * (THREADS - 1))

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -5,7 +5,7 @@ import sysconfig
 
 import pytest
 
-from salix import Struct, set_field
+from salix import Struct, replace, set_field
 
 pytestmark = pytest.mark.skipif(
     bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
@@ -447,3 +447,45 @@ def test_a_deferred_co_base_deepcopy_does_not_leak_the_method():
         copy.deepcopy(Real(1))
 
     assert sys.getrefcount(method) == before
+
+
+def test_replace_takes_one_reference_per_kept_and_changed_field_and_releases_them_with_the_replaced():
+    """The replaced instance is a fresh instance whose slots hold fresh
+    references: sharing the value is not sharing the count. A replace that
+    borrowed the source's references would leave the sentinel's count
+    unmoved, and one that forgot to release them would leave it stuck one
+    pair high after `del`."""
+
+    sentinel = Sentinel()
+    pair = Pair(sentinel, sentinel)
+    before = sys.getrefcount(sentinel)
+    replaced = replace(pair, first=sentinel)
+
+    assert sys.getrefcount(sentinel) == before + 2
+
+    del replaced
+
+    assert sys.getrefcount(sentinel) == before
+
+
+def test_replace_through_a_body_init_releases_the_transient_keywords():
+    """The slow path gathers the field values into a keyword dict that the
+    constructor call must release: a leak would keep the sentinel alive one
+    extra reference per replace."""
+
+    class Doubled(Struct, frozen=False):
+        value: object
+
+        def __init__(self, value: object) -> None:
+            self.value = value
+
+    sentinel = Sentinel()
+    original = Doubled(sentinel)
+    before = sys.getrefcount(sentinel)
+    replaced = replace(original, value=sentinel)
+
+    assert sys.getrefcount(sentinel) == before + 1
+
+    del replaced
+
+    assert sys.getrefcount(sentinel) == before

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -216,3 +216,104 @@ def test_an_instance_dict_entry_does_not_shadow_the_dunder():
     replaced = replace(original, x=2)
 
     assert replaced == WithDict(2)
+
+
+def test_a_slow_path_replace_keeps_the_constructors_dict_entries():
+    class DictInit(Struct, Dicted, frozen=False):
+        x: int
+
+        def __init__(self, x: int) -> None:
+            self.x = x
+            self.extra = "fresh"
+
+    original = DictInit(1)
+    original.stale = "stale"
+    replaced = replace(original, x=2)
+
+    assert replaced.extra == "fresh"
+    assert replaced.stale == "stale"
+
+
+def test_an_unknown_change_is_refused_before_a_swallowing_init_sees_it():
+    class Swallowing(Struct, frozen=False):
+        x: int
+
+        def __init__(self, x: int, **rest: object) -> None:
+            self.x = x
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'z'"):
+        replace(Swallowing(1), z=2)
+
+
+def test_a_subset_signature_init_propagates_its_own_type_error():
+    class Subset(Struct, frozen=False):
+        x: int
+        y: int = 0
+
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'y'"):
+        replace(Subset(1), x=2)
+
+
+def test_an_init_none_class_fails_construction_before_replace_can_run():
+    class NoneInit(Struct):
+        x: int = 7
+        __init__ = None
+
+    with pytest.raises(TypeError, match="'NoneType' object is not callable"):
+        NoneInit(3)
+
+
+def test_a_zero_change_replace_of_a_mutable_struct_is_a_copy():
+    original = Mutable(1)
+    replaced = replace(original)
+
+    assert replaced is not original
+    assert replaced == original
+
+
+def test_post_init_runs_before_the_source_dict_is_installed():
+    seen = []
+
+    class Watched(Struct, Dicted, frozen=False):
+        x: int
+
+        def __post_init__(self) -> None:
+            seen.append(self.__dict__)
+
+    original = Watched(1)
+    original.extra = "world"
+    replaced = replace(original, x=2)
+
+    assert seen[-1] == {}
+    assert replaced.extra == "world"
+
+
+def test_a_metaclass_call_returning_a_foreign_struct_is_refused():
+    class RogueMeta(type(Struct)):
+        def __call__(cls, *args: object, **kwargs: object) -> object:
+            return alien if cls is Other else other
+
+    class Other(Struct, metaclass=RogueMeta, frozen=False):
+        x: int = 0
+
+        def __init__(self, x: int = 0) -> None:
+            self.x = x
+
+    class Alien(Struct, metaclass=RogueMeta, frozen=False):
+        x: int = 0
+
+        def __init__(self, x: int = 0) -> None:
+            self.x = x
+
+    other = type.__call__(Other)
+    alien = type.__call__(Alien)
+
+    disguised = Other(1)
+
+    assert type(disguised) is Alien
+
+    with pytest.raises(SystemError, match="returned a different type"):
+        replace(disguised, x=2)

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,0 +1,148 @@
+import copy
+import sys
+
+import pytest
+
+from salix import Struct, replace
+
+
+class Point(Struct):
+    x: int
+    y: str = "seven"
+
+
+class Mutable(Struct, frozen=False):
+    x: int
+    y: str = "seven"
+
+
+class WithInit(Struct, frozen=False):
+    x: int
+
+    def __init__(self, x: int) -> None:
+        self.x = x * 2
+
+
+class Dicted:
+    pass
+
+
+class WithDict(Struct, Dicted, frozen=False):
+    x: int
+
+
+class Empty(Struct):
+    pass
+
+
+def test_replace_changes_one_field_and_copies_the_rest():
+    original = Point(1)
+    replaced = original.__replace__(x=2)
+
+    assert replaced is not original
+    assert replaced == Point(2, "seven")
+    assert original == Point(1, "seven")
+
+
+def test_the_module_function_matches_the_dunder():
+    original = Point(1)
+    replaced = replace(original, x=2)
+
+    assert replaced == Point(2, "seven")
+
+
+def test_an_unknown_change_is_refused_like_the_constructor():
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'z'"):
+        Point(1).__replace__(z=2)
+
+
+def test_a_zero_change_replace_returns_the_instance():
+    original = Point(1)
+
+    assert original.__replace__() is original
+
+
+def test_a_second_positional_argument_is_refused():
+    with pytest.raises(TypeError, match="takes exactly one positional argument"):
+        Point(1).__replace__(1, x=2)
+
+
+def test_post_init_runs_again_with_the_changed_value():
+    calls = []
+
+    class Counted(Struct):
+        x: int
+
+        def __post_init__(self) -> None:
+            calls.append(self.x)
+
+    original = Counted(1)
+    replaced = replace(original, x=2)
+
+    assert calls == [1, 2]
+    assert replaced == Counted(2)
+
+
+def test_a_body_init_is_the_construction_path():
+    original = WithInit(3)
+
+    assert original.x == 6
+    assert replace(original, x=4).x == 8
+    assert original.x == 6
+
+
+def test_a_body_replace_override_is_honored_by_the_module_function():
+    class Overriding(Struct):
+        x: int
+
+        def __replace__(self, /, **changes: object) -> object:
+            return "body replace"
+
+    assert replace(Overriding(1), x=2) == "body replace"
+
+
+def test_a_mutable_struct_can_be_replaced():
+    original = Mutable(1)
+    replaced = replace(original, x=2)
+
+    assert replaced is not original
+    assert replaced == Mutable(2, "seven")
+    assert original == Mutable(1, "seven")
+
+
+def test_the_singleton_survives_a_zero_change_replace():
+    assert Empty().__replace__() is Empty()
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        Empty().__replace__(x=1)
+
+
+def test_the_instance_dict_is_copied_shallowly():
+    original = WithDict(1)
+    original.extra = "world"
+    replaced = replace(original, x=2)
+
+    assert replaced is not original
+    assert replaced.x == 2
+    assert replaced.extra == "world"
+    assert replaced.__dict__ is not original.__dict__
+
+
+def test_a_non_struct_is_refused():
+    with pytest.raises(TypeError, match="replace\\(\\) expects a struct, not int"):
+        replace(5)
+
+
+def test_an_impostor_is_not_replaceable():
+    class Impostor(Struct.__mro__[1], list):
+        pass
+
+    with pytest.raises(TypeError, match="Impostor object is not replaceable"):
+        Impostor().__replace__(x=1)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 13), reason="copy.replace is 3.13+")
+def test_copy_replace_uses_the_dunder():
+    replaced = copy.replace(Point(1), x=9)
+
+    assert replaced == Point(9, "seven")

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -146,3 +146,73 @@ def test_copy_replace_uses_the_dunder():
     replaced = copy.replace(Point(1), x=9)
 
     assert replaced == Point(9, "seven")
+
+
+class WithDictInit(Struct, Dicted, frozen=False):
+    x: int
+
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+
+def test_a_slow_path_replace_carries_the_instance_dict():
+    original = WithDictInit(1)
+    original.extra = "world"
+    replaced = replace(original, x=2)
+
+    assert replaced.x == 2
+    assert replaced.extra == "world"
+    assert replaced.__dict__ is not original.__dict__
+
+
+def test_a_slow_path_replace_carries_co_base_members():
+    class Slotted:
+        __slots__ = ("z",)
+
+    class WithSlot(Struct, Slotted, frozen=False):
+        x: int
+
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    original = WithSlot(1)
+    original.z = 5
+    replaced = replace(original, x=2)
+
+    assert replaced.z == 5
+
+
+def test_a_positional_only_init_propagates_its_own_type_error():
+    class PositionalOnly(Struct, frozen=False):
+        x: int
+
+        def __init__(self, x: int, /) -> None:
+            self.x = x
+
+    with pytest.raises(TypeError):
+        replace(PositionalOnly(1), x=2)
+
+
+def test_a_body_new_is_discarded_by_replace_as_by_construction():
+    calls = []
+
+    class WithNew(Struct, frozen=False):
+        x: int
+
+        def __new__(cls, *args: object, **kwargs: object) -> object:
+            calls.append(1)
+            return super().__new__(cls)
+
+    original = WithNew(1)
+    replaced = replace(original, x=2)
+
+    assert calls == []
+    assert replaced == WithNew(2)
+
+
+def test_an_instance_dict_entry_does_not_shadow_the_dunder():
+    original = WithDict(1)
+    original.__dict__["__replace__"] = "shadow"
+    replaced = replace(original, x=2)
+
+    assert replaced == WithDict(2)

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from typing_extensions import assert_type
 
-from salix import Struct, set_field
+from salix import Struct, replace, set_field
 
 
 class Point(Struct):
@@ -95,6 +95,11 @@ def the_options_a_checker_cannot_see_are_still_accepted() -> None:
 def set_field_takes_a_struct_a_name_and_any_value() -> None:
     assert_type(set_field(Point(1, "two"), "x", 9), None)
     set_field(Point(1, "two"), "y", object())
+
+
+def replace_returns_the_concrete_struct_type() -> None:
+    assert_type(replace(Point(1, "two"), x=9), Point)
+    replace(Point(1, "two"), y=object())
 
 
 def __copy___returns_the_concrete_struct_type() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to work through issue #61 (copy-with-override) and drive the PR through the review loop.

## Summary

Closes #61. `__replace__(self, /, **changes)` on the mixin (the 3.13+ `copy.replace` protocol dunder) plus `salix.replace(instance, **changes)` as the module-level spelling, per the issue's collision reasoning — no bare `replace` method, since a field could shadow it. The C implementation is ~6x faster than `NamedTuple._replace` on the same machine.

## Design decisions

<details>
<summary>Two construction paths, dispatched exactly as the constructor dispatches</summary>

- **No body `__init__`** — the fast path: allocate, bind the changes through the constructor's own `bind_keywords` (an unknown change raises the constructor's exact `TypeError`), copy the untouched slots from the source under one critical section (`struct_slots_copy_into` gained a destination-skip so the changes survive the copy), then run `__post_init__` the way the vectorcall would.
- **Body `__init__`** — the real construction path: field values + changes become one kwargs dict, and the class is called with it. Replace cannot diverge from `__init__` (the #56/#12 interaction the issue called out).
- Zero changes returns the instance itself: replace is "the value with these changes"; no changes, the value is the instance. `copy.replace` refuses empty changes before the dunder is ever called, so this only affects direct dunder calls. Consistent with the singleton interning from #60.
</details>

<details>
<summary>__post_init__ re-runs</summary>

dataclasses semantics, and forced by construction: the fast path inlines exactly the vectorcall's sequence (bind, fill, post_init), so skipping it would be the divergent choice. Pinned by `test_post_init_runs_again_with_the_changed_value` (`calls == [1, 2]`).
</details>

<details>
<summary>The METH_FASTCALL convention cost a segfault round</summary>

For tp_methods descriptors, CPython passes self as the first parameter and nargs excludes it — `Objects/descrobject.c: meth(args[0], args+1, nargs-1, kwnames)`, verified in the 3.10/3.11/3.12/3.14 sources, all identical. `object.__replace__` does not exist in CPython; the dunder is a pure convention, so the error messages are salix's own. The first local build read change values at `arguments[1 + i]` — one past the keyword array — storing a garbage pointer into the kwargs dict and corrupting the heap; caught by the refcount probes as failures + segfaults across 3.10–3.15.
</details>

<details>
<summary>Collision and override</summary>

A field named `__replace__` is refused by the existing mixin-method scan (`refuse_mixin_method_fields` walks the mixin dict dynamically — no new machinery). A body `__replace__` overrides the mixin's, and `salix.replace` routes through `getattr(instance, "__replace__")`, so the override is honored there too (pinned).
</details>

## Measurements

Same machine, CPython 3.14.6, min of timeit repeats, the issue's two-field shape:

| | ns/call |
| --- | --- |
| `t._replace(a=2)` (NamedTuple) | 329.9 |
| `Two(2, t.b)` — hand-written | 40.4 |
| `t.__replace__(a=2)` | **54.8** |
| `salix.replace(t, a=2)` | 201.1 |

The dunder is 1.36x the hand-written equivalent (the issue's floor was 116 ns on an earlier build); the module function pays a `getattr` + call for the ergonomic spelling.

## Tests

`tests/test_replace.py` (15 behavioral pins: fast path, module function, unknown-change TypeError, zero-change identity, positional refusal, post_init re-run, body-init routing, override honored, mutable, singleton, dict copied shallowly, non-struct refusal, impostor refusal, `copy.replace` on 3.13+), two refcount probes, one free-threading pin (kept slots are a one-section snapshot), typing pins in `accepted.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 (after the reviewer's round 1, score 2.04)

<details>
<summary>The systemic answer: one state-carry primitive, one deliberate divergence</summary>

The four unintended divergences collapsed structurally. The slow path now snapshots the kept fields under **one critical section** for the kwargs (same guarantee the fast path gets), calls the constructor, then runs the **same `struct_copy_slots_and_dict`** the fast path uses — so whatever the constructor left unwritten (fields, co-base members, the instance dict) takes the source's values. The only remaining divergence between the paths is the deliberate one: construction routing. The shallow trio (`copy`, fast replace, slow replace) now shares the one helper; the member loop gained the destination-held skip the field loop already had (the nit's half of it).
</details>

<details>
<summary>Body `__new__`: answered by measurement, not code</summary>

Salix discards a body `__new__` at class creation on **both** construction paths — that is #12's resolution (`install_constructor` leaves `tp_new` NULL on the vectorcall path and sets `Struct_new` on the own-init path, so the body's `__new__` is never in the slot). Neither replace path can therefore invoke one, because replace shares the constructor's slots exactly. Pinned: `test_a_body_new_is_discarded_by_replace_as_by_construction` asserts `calls == []` across construction *and* replace. (The reviewer's claim that the slow path invokes it would require `tp_new` to hold the body's `__new__`, which it measurably does not.)
</details>

<details>
<summary>Keyword-only slow path: declared constraint</summary>

The slow path passes every field as a keyword, so a positional-only `__init__` raises its own `TypeError` — pinned (`test_a_positional_only_init_propagates_its_own_type_error`). `dataclasses.replace` has the same constraint; it is inherent to "route through `__init__`".
</details>

<details>
<summary>The stub's return type: declared</summary>

The pyi's `_StructT` promise describes the mixin's implementation. An overriding `__replace__` is user code, and its annotation is the user's — the module function honors the override (`test_a_body_replace_override_is_honored_by_the_module_function`), which is the only case that can return anything else.
</details>

<details>
<summary>Shadowing: now copy.replace's own lookup</summary>

`salix.replace` resolves `__replace__` on the **type**, exactly as `copy.py` does (`getattr(cls, '__replace__', None)`), so an instance-dict entry or `__getattr__` hook cannot shadow the dunder — pinned (`test_an_instance_dict_entry_does_not_shadow_the_dunder`).
</details>


---

## Round 3 (after the reviewer's round 2, score 1.84)

<details>
<summary>The systemic answer: one snapshot serves both phases</summary>

The slow path now assembles the kwargs from one section-spanning snapshot — the snapshot helper gained a `missing` filler parameter (Py_None for hash, NULL for replace), so the post-construction back-fill reuses the **same acquisition** instead of re-reading the source. The back-fill covers the constructor-left slots from that snapshot; members and the dict come through the shared shallow primitive. The instance dict is now **merged**, not replaced: entries the constructor itself wrote win over the source's copy — a `__init__` that computes fresh dict extras keeps them, and the source's extras still carry. The fast path runs `__post_init__` before the dict install (construction's own ordering), with the merge preserving whatever `__post_init__` wrote — pinned by `test_post_init_runs_before_the_source_dict_is_installed`.
</details>

<details>
<summary>Unknown changes are refused on both paths</summary>

The slow path validates every change name through the same `named_field` lookup the vectorcall uses (split out of `bind_keywords`, one copy of the error string), so a swallowing `**kwargs`-`__init__` can no longer silently absorb an unknown change — pinned.
</details>

<details>
<summary>The constructor call's result is type-checked</summary>

`PyObject_Call`'s result is checked against the class, raising the same `SystemError` shape `ensure_singleton` uses, so a rogue metaclass `__call__` returning a foreign struct cannot receive slot writes — pinned with a mutual-swap rogue metaclass.
</details>

<details>
<summary>Zero-change replace on a mutable struct is a real copy</summary>

Identity remains for frozen structs (indistinguishable values); a mutable zero-change replace now goes through the normal paths — fresh instance, `__post_init__` re-runs — pinned. (dataclasses parity.)
</details>

<details>
<summary>Claim checked by measurement, not taken on faith: `__init__ = None`</summary>

The round-2 finding said a body `__init__ = None` misroutes replace and silently drops changes. Measured: the class fails **construction** first — the `tp_init` slot wraps the `None`, so `NoneInit(3)` raises `'NoneType' object is not callable` and replace can never receive an instance. Both paths raise identically; pinned. (The premise of NULL `tp_init` does not hold; `defines_own_init` is untouched.)
</details>

<details>
<summary>Declared constraints, widened</summary>

- The slow path requires `__init__` to accept the **full field list as keywords** — widened from round 2's positional-only wording; a subset-signature `__init__` raises its own TypeError, pinned. `dataclasses.replace` shares the constraint.
- Constructor-ignored **defaulted** fields take their defaults (the constructor's own semantic; the pre-fill is indistinguishable from an `__init__` write). dataclasses parity.
- The module function's one-element tuple beats a `PyObject_Vectorcall` conversion (the kwargs dict would need a kwnames tuple built either way; the tuple-pack is the cheaper half — measured).
</details>



---

## Merged (round 4 converged at score 0.47) — recorded dispositions

The three carried findings and the nits below are recorded, not chased — the head was converged and certified, and each is a boundary the design already declares or a micro-optimization better folded into a follow-up:

- `replace-slow-path-null-slot-drop`: NULL source slots are skipped in the kwargs, so a `__init__` that declares a required parameter the instance never holds raises its own TypeError. Passing `Py_None` would be the alternative; the current behavior keeps NULL slots "unwritten stays unwritten" on both paths.
- `replace-co-base-shadowing`: a non-struct co-base's `__replace__` is shadowed by the mixin's, unlike `__copy__`/`__deepcopy__` which defer. The copy dunders are copy.py protocol entry points that copy.py itself resolves; `__replace__` is salix's own mixin contract. Fold the deferral into a follow-up if a co-base scenario demands it.
- `replace-slow-path-two-phase-read`: the T1 snapshot covers the field slots (constructor-honored fields, the advertised guarantee, FT-pinned); co-base members and the dict pointer are read at T2 under the shared primitive's own section. Boundary accepted as documented.
- `replace-slow-path-dict-assembly-redundant` (streak 3): the Contains check is live (it skips the kept-insert for changed names; the change loop then inserts each once) — the cost is one hash lookup per field on the slow path, which is a constructor call. Accepted.
- `replace-module-tuple-pack` (streak 3): `PyObject_Call` builds the kwnames tuple regardless, so the one-element args tuple is not the whole story; the tuple-pack remains the cheaper half of the conversion measured. Accepted.
- `empty-tuple-helper-unused`, `replace-slow-path-dict-presize`, `test-fixture-duplication-drift`, `replace-metaclass-subclass-result-rejected`: recorded for a follow-up pass (the exact-type guard rejects a metaclass `__call__` returning a subclass instance; the foreign-sibling case the guard exists for is pinned).
