### PR TITLE
feat: salix.from_mapping, construction straight from a mapping

### DIFF
--- a/salix/__init__.pyi
+++ b/salix/__init__.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Final
+from collections.abc import Mapping
+from typing import Any, Final, TypeVar
 
 from typing_extensions import Self, dataclass_transform
 
@@ -25,4 +26,8 @@ class Struct:
         weakref: bool = False,
     ) -> None: ...
 
+_StructT = TypeVar("_StructT", bound=Struct)
+
+
 def set_field(instance: Struct, name: str, value: object, /) -> None: ...
+def from_mapping(cls: type[_StructT], values: Mapping[str, object], /) -> _StructT: ...

--- a/src/construct.h
+++ b/src/construct.h
@@ -14,6 +14,8 @@ PyObject * Struct_new(PyTypeObject * struct_class, PyObject * arguments, PyObjec
 
 PyObject * Struct_set_field(PyObject * module, PyObject * arguments);
 
+PyObject * Struct_from_mapping(PyObject * module, PyObject * arguments);
+
 bool struct_copies_default(PyTypeObject const * kind);
 
 PyObject * struct_default_copy(PyObject * declared);

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -1,6 +1,7 @@
 #include <Python.h>
 
 #include "construct.h"
+#include "../meta/meta.h"
 #include "../owned.h"
 #include "../result.h"
 #include "../types.h"
@@ -17,6 +18,13 @@ static enum result bind_keywords(
 	PyObject * const * arguments,
 	Py_ssize_t positional_count,
 	PyObject * keyword_names
+);
+static enum result bind_named(
+	StructType const * type,
+	PyObject * self,
+	PyObject * name,
+	PyObject * value,
+	Py_ssize_t positional_count
 );
 static enum result fill_defaults(
 	StructType const * type,
@@ -102,6 +110,133 @@ PyObject * Struct_new(
 	);
 }
 
+PyObject * Struct_from_mapping(PyObject * const module, PyObject * const arguments) {
+	PyObject * struct_class = NULL;
+	PyObject * values = NULL;
+
+	if (!PyArg_UnpackTuple(arguments, "from_mapping", 2, 2, &struct_class, &values)) {
+		return NULL;
+	}
+
+	if (!is_struct_class(struct_class)) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"from_mapping() expects a struct class, not %.200s",
+			Py_TYPE(struct_class)->tp_name
+		);
+
+		return NULL;
+	}
+
+	/* A list is PyMapping_Check-true through its subscript slot, and an
+	 * ABC-style mapping carries the sequence slots through __len__ and
+	 * __getitem__, so neither slot check alone names a mapping; items is
+	 * what the fallback path needs either way. The probe binds a method
+	 * object, so dicts, the hot path, never take it. */
+	if (!PyDict_Check(values)) {
+		int const has_items = PyObject_HasAttrString(values, "items");
+
+		if (has_items < 0) {
+			return NULL;
+		}
+
+		if (!PyMapping_Check(values) || has_items == 0) {
+			PyErr_Format(
+				PyExc_TypeError,
+				"from_mapping() values must be a mapping, not %.200s",
+				Py_TYPE(values)->tp_name
+			);
+
+			return NULL;
+		}
+	}
+
+	StructType * const type = (StructType *) struct_class;
+
+	if (defines_own_init(type)) {
+		PY_OWNED(
+			keywords,
+			PyDict_Check(values) ? Py_NewRef(values) :
+			PyObject_CallOneArg((PyObject *) &PyDict_Type, values)
+		);
+
+		if (keywords == NULL) {
+			return NULL;
+		}
+
+		PY_OWNED(no_arguments, PyTuple_New(0));
+
+		return no_arguments != NULL ? PyObject_Call(struct_class, no_arguments, keywords) : NULL;
+	}
+
+	Py_ssize_t entry_count;
+	PY_MOVABLE(items, NULL);
+
+	if (PyDict_Check(values)) {
+		entry_count = PyDict_GET_SIZE(values);
+	} else {
+		items = PyMapping_Items(values);
+
+		if (items == NULL) {
+			return NULL;
+		}
+
+		entry_count = PyList_GET_SIZE(items);
+	}
+
+	PyObject * const interned = interned_value(type, entry_count == 0);
+
+	if (interned != NULL) {
+		return interned;
+	}
+
+	PyTypeObject * const cls = &type->heap_type.ht_type;
+
+	PY_MOVABLE(built, cls->tp_alloc(cls, 0));
+
+	if (built == NULL) {
+		return NULL;
+	}
+
+	if (items == NULL) {
+		Py_ssize_t position = 0;
+		PyObject * key;
+		PyObject * value;
+
+		while (PyDict_Next(values, &position, &key, &value)) {
+			if (bind_named(type, built, key, value, 0) != RESULT_OK) {
+				return NULL;
+			}
+		}
+	} else {
+		for (Py_ssize_t i = 0; i < entry_count; ++i) {
+			PyObject * const pair = PyList_GET_ITEM(items, i);
+
+			if (
+				bind_named(
+					type,
+					built,
+					PyTuple_GET_ITEM(pair, 0),
+					PyTuple_GET_ITEM(pair, 1),
+					0
+				) !=
+				RESULT_OK
+			) {
+				return NULL;
+			}
+		}
+	}
+
+	return (
+		fill_defaults(
+			type,
+			built,
+			0
+		) == RESULT_OK && run_post_init(type, built) == RESULT_OK ? py_move(&built) :
+		NULL
+	);
+}
+
 static enum result run_post_init(StructType const * const type, PyObject * const self) {
 	if (type->struct_post_init == NULL) {
 		return RESULT_OK;
@@ -133,40 +268,62 @@ static enum result bind_keywords(
 	Py_ssize_t const keyword_count = keyword_names != NULL ? PyTuple_GET_SIZE(keyword_names) : 0;
 
 	for (Py_ssize_t i = 0; i < keyword_count; ++i) {
-		PyObject * const keyword = PyTuple_GET_ITEM(keyword_names, i);
-		struct field_lookup const found = find_field(type, keyword);
-
-		switch (found.tag) {
-			case FIELD_LOOKUP_ERROR:
-				return RESULT_ERROR;
-			case FIELD_LOOKUP_MISSING:
-				PyErr_Format(
-					PyExc_TypeError,
-					"%.200s() got an unexpected keyword argument '%U'",
-					struct_type_name(type),
-					keyword
-				);
-
-				return RESULT_ERROR;
-			case FIELD_LOOKUP_FOUND:
-				break;
+		if (
+			bind_named(
+				type,
+				self,
+				PyTuple_GET_ITEM(keyword_names, i),
+				arguments[positional_count + i],
+				positional_count
+			) !=
+			RESULT_OK
+		) {
+			return RESULT_ERROR;
 		}
+	}
 
-		PyObject * * const slot = struct_slot(type, self, found.index);
+	return RESULT_OK;
+}
 
-		if (*slot != NULL || found.index < positional_count) {
+static enum result bind_named(
+	StructType const * const type,
+	PyObject * const self,
+	PyObject * const name,
+	PyObject * const value,
+	Py_ssize_t const positional_count
+) {
+	struct field_lookup const found = find_field(type, name);
+
+	switch (found.tag) {
+		case FIELD_LOOKUP_ERROR:
+			return RESULT_ERROR;
+		case FIELD_LOOKUP_MISSING:
 			PyErr_Format(
 				PyExc_TypeError,
-				"%.200s() got multiple values for argument '%U'",
+				"%.200s() got an unexpected keyword argument '%U'",
 				struct_type_name(type),
-				keyword
+				name
 			);
 
 			return RESULT_ERROR;
-		}
-
-		*slot = Py_NewRef(arguments[positional_count + i]);
+		case FIELD_LOOKUP_FOUND:
+			break;
 	}
+
+	PyObject * * const slot = struct_slot(type, self, found.index);
+
+	if (*slot != NULL || found.index < positional_count) {
+		PyErr_Format(
+			PyExc_TypeError,
+			"%.200s() got multiple values for argument '%U'",
+			struct_type_name(type),
+			name
+		);
+
+		return RESULT_ERROR;
+	}
+
+	*slot = Py_NewRef(value);
 
 	return RESULT_OK;
 }

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -141,11 +141,7 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 	PY_MOVABLE(items, NULL);
 
 	if (dict_values == NULL) {
-		PY_MOVABLE(items_call, PyObject_GetAttrString(values, "items"));
-
-		if (items_call == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-			PyErr_Clear();
-		}
+		PY_MOVABLE(items_call, optional_attribute(values, "items"));
 
 		if (items_call == NULL && PyErr_Occurred()) {
 			return NULL;
@@ -173,8 +169,8 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 			return NULL;
 		}
 
-		for (Py_ssize_t i = 0; i < PyList_GET_SIZE(items); ++i) {
-			PyObject * const pair = PyList_GET_ITEM(items, i);
+		for (Py_ssize_t i = 0; i < PySequence_Fast_GET_SIZE(items); ++i) {
+			PyObject * const pair = PySequence_Fast_GET_ITEM(items, i);
 
 			if (!PyTuple_Check(pair) || PyTuple_GET_SIZE(pair) != 2) {
 				PyErr_Format(
@@ -205,17 +201,27 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 				return NULL;
 			}
 
-			for (Py_ssize_t i = 0; i < PyList_GET_SIZE(items); ++i) {
-				PyObject * const pair = PyList_GET_ITEM(items, i);
+			for (Py_ssize_t i = 0; i < PySequence_Fast_GET_SIZE(items); ++i) {
+				PyObject * const pair = PySequence_Fast_GET_ITEM(items, i);
+				PyObject * const name = PyTuple_GET_ITEM(pair, 0);
+				int const present = PyDict_Contains(keywords, name);
 
-				if (
-					PyDict_SetItem(
-						keywords,
-						PyTuple_GET_ITEM(pair, 0),
-						PyTuple_GET_ITEM(pair, 1)
-					) <
-					0
-				) {
+				if (present < 0) {
+					return NULL;
+				}
+
+				if (present == 1) {
+					PyErr_Format(
+						PyExc_TypeError,
+						"%.200s() got multiple values for argument '%U'",
+						struct_type_name(type),
+						name
+					);
+
+					return NULL;
+				}
+
+				if (PyDict_SetItem(keywords, name, PyTuple_GET_ITEM(pair, 1)) < 0) {
 					return NULL;
 				}
 			}
@@ -228,7 +234,7 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 
 	Py_ssize_t const entry_count = (
 		dict_values != NULL ? PyDict_GET_SIZE(dict_values) :
-		PyList_GET_SIZE(items)
+		PySequence_Fast_GET_SIZE(items)
 	);
 
 	PyObject * const interned = interned_value(type, entry_count == 0);
@@ -238,6 +244,20 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 	}
 
 	PyTypeObject * const cls = &type->heap_type.ht_type;
+
+	if (dict_values != NULL) {
+		Py_ssize_t position = 0;
+		PyObject * key;
+		PyObject * value;
+
+		while (PyDict_Next(dict_values, &position, &key, &value)) {
+			if (!PyUnicode_Check(key)) {
+				PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+
+				return NULL;
+			}
+		}
+	}
 
 	PY_MOVABLE(built, cls->tp_alloc(cls, 0));
 
@@ -251,19 +271,13 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 		PyObject * value;
 
 		while (PyDict_Next(dict_values, &position, &key, &value)) {
-			if (!PyUnicode_Check(key)) {
-				PyErr_SetString(PyExc_TypeError, "keywords must be strings");
-
-				return NULL;
-			}
-
 			if (bind_named(type, built, key, value, 0) != RESULT_OK) {
 				return NULL;
 			}
 		}
 	} else {
 		for (Py_ssize_t i = 0; i < entry_count; ++i) {
-			PyObject * const pair = PyList_GET_ITEM(items, i);
+			PyObject * const pair = PySequence_Fast_GET_ITEM(items, i);
 
 			if (
 				bind_named(

--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -128,19 +128,30 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 		return NULL;
 	}
 
-	/* A list is PyMapping_Check-true through its subscript slot, and an
-	 * ABC-style mapping carries the sequence slots through __len__ and
-	 * __getitem__, so neither slot check alone names a mapping; items is
-	 * what the fallback path needs either way. The probe binds a method
-	 * object, so dicts, the hot path, never take it. */
-	if (!PyDict_Check(values)) {
-		int const has_items = PyObject_HasAttrString(values, "items");
+	StructType * const type = (StructType *) struct_class;
 
-		if (has_items < 0) {
+	/* The fallback acquires items once and validates every pair at the
+	 * boundary, so the bind loop, the own-init kwargs and the pair-shape
+	 * error all read the same list. A list is PyMapping_Check-true through
+	 * its subscript slot and an ABC-style mapping carries the sequence
+	 * slots through __len__ and __getitem__, so the items probe names a
+	 * mapping where neither slot check does; dicts, the hot path, never
+	 * take it. */
+	PyObject * const dict_values = PyDict_Check(values) ? values : NULL;
+	PY_MOVABLE(items, NULL);
+
+	if (dict_values == NULL) {
+		PY_MOVABLE(items_call, PyObject_GetAttrString(values, "items"));
+
+		if (items_call == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+			PyErr_Clear();
+		}
+
+		if (items_call == NULL && PyErr_Occurred()) {
 			return NULL;
 		}
 
-		if (!PyMapping_Check(values) || has_items == 0) {
+		if (items_call == NULL || !PyMapping_Check(values)) {
 			PyErr_Format(
 				PyExc_TypeError,
 				"from_mapping() values must be a mapping, not %.200s",
@@ -149,19 +160,65 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 
 			return NULL;
 		}
+
+		PY_MOVABLE(items_result, PyObject_CallNoArgs(items_call));
+
+		if (items_result == NULL) {
+			return NULL;
+		}
+
+		items = PySequence_Fast(items_result, "from_mapping() items() must return a sequence");
+
+		if (items == NULL) {
+			return NULL;
+		}
+
+		for (Py_ssize_t i = 0; i < PyList_GET_SIZE(items); ++i) {
+			PyObject * const pair = PyList_GET_ITEM(items, i);
+
+			if (!PyTuple_Check(pair) || PyTuple_GET_SIZE(pair) != 2) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"from_mapping() items() must yield (str, value) pairs"
+				);
+
+				return NULL;
+			}
+
+			if (!PyUnicode_Check(PyTuple_GET_ITEM(pair, 0))) {
+				PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+
+				return NULL;
+			}
+		}
 	}
 
-	StructType * const type = (StructType *) struct_class;
-
 	if (defines_own_init(type)) {
-		PY_OWNED(
-			keywords,
-			PyDict_Check(values) ? Py_NewRef(values) :
-			PyObject_CallOneArg((PyObject *) &PyDict_Type, values)
-		);
+		PY_MOVABLE(keywords, NULL);
 
-		if (keywords == NULL) {
-			return NULL;
+		if (dict_values != NULL) {
+			keywords = Py_NewRef(dict_values);
+		} else {
+			keywords = PyDict_New();
+
+			if (keywords == NULL) {
+				return NULL;
+			}
+
+			for (Py_ssize_t i = 0; i < PyList_GET_SIZE(items); ++i) {
+				PyObject * const pair = PyList_GET_ITEM(items, i);
+
+				if (
+					PyDict_SetItem(
+						keywords,
+						PyTuple_GET_ITEM(pair, 0),
+						PyTuple_GET_ITEM(pair, 1)
+					) <
+					0
+				) {
+					return NULL;
+				}
+			}
 		}
 
 		PY_OWNED(no_arguments, PyTuple_New(0));
@@ -169,20 +226,10 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 		return no_arguments != NULL ? PyObject_Call(struct_class, no_arguments, keywords) : NULL;
 	}
 
-	Py_ssize_t entry_count;
-	PY_MOVABLE(items, NULL);
-
-	if (PyDict_Check(values)) {
-		entry_count = PyDict_GET_SIZE(values);
-	} else {
-		items = PyMapping_Items(values);
-
-		if (items == NULL) {
-			return NULL;
-		}
-
-		entry_count = PyList_GET_SIZE(items);
-	}
+	Py_ssize_t const entry_count = (
+		dict_values != NULL ? PyDict_GET_SIZE(dict_values) :
+		PyList_GET_SIZE(items)
+	);
 
 	PyObject * const interned = interned_value(type, entry_count == 0);
 
@@ -198,12 +245,18 @@ PyObject * Struct_from_mapping(PyObject * const module, PyObject * const argumen
 		return NULL;
 	}
 
-	if (items == NULL) {
+	if (dict_values != NULL) {
 		Py_ssize_t position = 0;
 		PyObject * key;
 		PyObject * value;
 
-		while (PyDict_Next(values, &position, &key, &value)) {
+		while (PyDict_Next(dict_values, &position, &key, &value)) {
+			if (!PyUnicode_Check(key)) {
+				PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+
+				return NULL;
+			}
+
 			if (bind_named(type, built, key, value, 0) != RESULT_OK) {
 				return NULL;
 			}

--- a/src/salix.c
+++ b/src/salix.c
@@ -37,6 +37,12 @@ static PyMethodDef struct_functions[] = {
 		.ml_flags = METH_VARARGS,
 		.ml_doc = "set_field(instance, name, value) -- assign a field the class declared.",
 	},
+	{
+		.ml_name = "from_mapping",
+		.ml_meth = Struct_from_mapping,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "from_mapping(cls, values) -- construct a struct from a mapping of field values.",
+	},
 	{.ml_name = NULL},
 };
 

--- a/tests/test_from_mapping.py
+++ b/tests/test_from_mapping.py
@@ -179,3 +179,64 @@ def test_a_body_init_receives_a_non_dict_mapping_through_its_items():
     built = from_mapping(WithInit, PlainMapping({"x": 3}))
 
     assert built.x == 6
+
+
+def test_an_items_result_that_is_a_tuple_works():
+    class TupleItems(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self):
+            return iter(())
+
+        def __len__(self) -> int:
+            return 2
+
+        def items(self):
+            return (("x", 1), ("y", "two"))
+
+    built = from_mapping(Point, TupleItems())
+
+    assert built == Point(1, "two")
+
+
+def test_duplicate_items_keys_are_refused_like_the_constructor():
+    class DuplicateItems(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self):
+            return iter(())
+
+        def __len__(self) -> int:
+            return 2
+
+        def items(self):
+            return [("x", 1), ("x", 2)]
+
+    with pytest.raises(TypeError, match="multiple values for argument 'x'"):
+        from_mapping(Point, DuplicateItems())
+
+
+def test_a_dict_mixing_non_string_and_unknown_keys_raises_strings_first():
+    with pytest.raises(TypeError, match="keywords must be strings"):
+        from_mapping(Point, {"z": 1, 2: "two"})  # type: ignore[arg-type]
+
+
+def test_the_field_bind_path_bypasses_a_metaclass_call():
+    calls = []
+
+    class CountingMeta(type(Struct)):
+        def __call__(cls, *args: object, **kwargs: object) -> object:
+            calls.append(1)
+            return super().__call__(*args, **kwargs)
+
+    class Counted(Struct, metaclass=CountingMeta):
+        x: int
+
+    Counted(1)
+    assert len(calls) == 1
+
+    from_mapping(Counted, {"x": 2})
+
+    assert len(calls) == 1

--- a/tests/test_from_mapping.py
+++ b/tests/test_from_mapping.py
@@ -1,0 +1,121 @@
+from collections.abc import Mapping
+
+import pytest
+
+from salix import Struct, from_mapping
+
+
+class Point(Struct):
+    x: int
+    y: str = "seven"
+
+
+class Empty(Struct):
+    pass
+
+
+class Mutable(Struct, frozen=False):
+    x: int
+
+
+class WithInit(Struct, frozen=False):
+    x: int
+
+    def __init__(self, x: int) -> None:
+        self.x = x * 2
+
+
+class PlainMapping(Mapping[str, object]):
+    def __init__(self, pairs: dict[str, object]) -> None:
+        self._pairs = pairs
+
+    def __getitem__(self, key: str) -> object:
+        return self._pairs[key]
+
+    def __iter__(self):
+        return iter(self._pairs)
+
+    def __len__(self) -> int:
+        return len(self._pairs)
+
+
+def test_keys_in_any_order_land_in_field_order():
+    built = from_mapping(Point, {"y": "two", "x": 1})
+
+    assert built == Point(1, "two")
+
+
+def test_absent_keys_take_their_defaults():
+    built = from_mapping(Point, {"x": 1})
+
+    assert built == Point(1, "seven")
+
+
+def test_an_absent_mutable_default_is_copied_per_instance():
+    class Holder(Struct):
+        required: int
+        xs: list = []  # noqa: RUF012 -- the copy is what is being pinned
+
+    (stored,) = Holder._struct_defaults_
+    built = from_mapping(Holder, {"required": 1})
+
+    assert built.xs == []
+    assert built.xs is not stored
+
+
+def test_an_unknown_key_is_refused_like_the_constructor():
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'z'"):
+        from_mapping(Point, {"x": 1, "z": 2})
+
+
+def test_a_missing_required_field_is_refused_like_the_constructor():
+    with pytest.raises(TypeError, match="missing required argument 'x'"):
+        from_mapping(Point, {})
+
+
+def test_a_non_dict_mapping_works():
+    built = from_mapping(Point, PlainMapping({"x": 1, "y": "two"}))
+
+    assert built == Point(1, "two")
+
+
+def test_a_non_mapping_is_refused():
+    with pytest.raises(TypeError, match="values must be a mapping, not list"):
+        from_mapping(Point, [("x", 1)])  # type: ignore[arg-type]
+
+
+def test_a_non_struct_class_is_refused():
+    with pytest.raises(TypeError, match="expects a struct class, not int"):
+        from_mapping(5, {})  # type: ignore[arg-type]
+
+
+def test_the_singleton_survives_an_empty_mapping():
+    assert from_mapping(Empty, {}) is Empty()
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        from_mapping(Empty, {"x": 1})
+
+
+def test_a_mutable_zero_field_struct_stays_allocated():
+    assert from_mapping(Mutable, {"x": 1}) is not from_mapping(Mutable, {"x": 1})
+
+
+def test_post_init_runs():
+    calls = []
+
+    class Counted(Struct):
+        x: int
+
+        def __post_init__(self) -> None:
+            calls.append(self.x)
+
+    built = from_mapping(Counted, {"x": 3})
+
+    assert calls == [3]
+    assert built == Counted(3)
+
+
+def test_a_body_init_is_the_construction_path():
+    built = from_mapping(WithInit, {"x": 3})
+
+    assert built.x == 6

--- a/tests/test_from_mapping.py
+++ b/tests/test_from_mapping.py
@@ -119,3 +119,63 @@ def test_a_body_init_is_the_construction_path():
     built = from_mapping(WithInit, {"x": 3})
 
     assert built.x == 6
+
+
+class LyingItems(Mapping[str, object]):
+    def __init__(self, items_result: object) -> None:
+        self._items_result = items_result
+
+    def __getitem__(self, key: str) -> object:
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self) -> int:
+        return 1
+
+    def items(self):
+        return self._items_result
+
+
+def test_an_items_pair_that_is_not_a_two_tuple_is_refused():
+    with pytest.raises(TypeError, match="items\\(\\) must yield \\(str, value\\) pairs"):
+        from_mapping(Point, LyingItems([("x", 1, "extra"), 42]))
+
+
+def test_an_items_result_that_is_not_a_sequence_is_refused():
+    with pytest.raises(TypeError, match="items\\(\\) must return a sequence"):
+        from_mapping(Point, LyingItems(5))
+
+
+def test_an_items_exception_propagates():
+    class RaisingItems(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self):
+            return iter(())
+
+        def __len__(self) -> int:
+            return 0
+
+        @property
+        def items(self) -> object:
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        from_mapping(Point, RaisingItems())
+
+
+def test_a_non_string_key_is_refused_like_the_constructor():
+    with pytest.raises(TypeError, match="keywords must be strings"):
+        from_mapping(Point, {1: "one"})  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="keywords must be strings"):
+        from_mapping(Point, LyingItems([(1, "one")]))
+
+
+def test_a_body_init_receives_a_non_dict_mapping_through_its_items():
+    built = from_mapping(WithInit, PlainMapping({"x": 3}))
+
+    assert built.x == 6

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -5,7 +5,7 @@ import sysconfig
 
 import pytest
 
-from salix import Struct, set_field
+from salix import Struct, from_mapping, set_field
 
 pytestmark = pytest.mark.skipif(
     bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
@@ -447,3 +447,19 @@ def test_a_deferred_co_base_deepcopy_does_not_leak_the_method():
         copy.deepcopy(Real(1))
 
     assert sys.getrefcount(method) == before
+
+
+def test_from_mapping_takes_one_reference_per_field_and_releases_them_with_the_instance():
+    """The mapping values land in fresh slots with fresh references: a
+    constructor that borrowed the mapping's references would leave the
+    sentinel's count unmoved."""
+
+    sentinel = Sentinel()
+    before = sys.getrefcount(sentinel)
+    pair = from_mapping(Pair, {"first": sentinel, "second": sentinel})
+
+    assert sys.getrefcount(sentinel) == before + 2
+
+    del pair
+
+    assert sys.getrefcount(sentinel) == before

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from typing_extensions import assert_type
 
-from salix import Struct, set_field
+from salix import Struct, from_mapping, set_field
 
 
 class Point(Struct):
@@ -95,6 +95,11 @@ def the_options_a_checker_cannot_see_are_still_accepted() -> None:
 def set_field_takes_a_struct_a_name_and_any_value() -> None:
     assert_type(set_field(Point(1, "two"), "x", 9), None)
     set_field(Point(1, "two"), "y", object())
+
+
+def from_mapping_returns_the_concrete_struct_type() -> None:
+    assert_type(from_mapping(Point, {"x": 1, "y": "two"}), Point)
+    from_mapping(Point, {"x": object()})
 
 
 def __copy___returns_the_concrete_struct_type() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to work through issue #62 (mapping construction) and drive the PR through the review loop.

## Summary

Closes #62, the issue's option 1: `salix.from_mapping(cls, values)` raises the keyword path's exact `TypeError`s. Values fill the named slots directly — no kwargs expansion, no names tuple, no values array — defaults apply for absent keys, and `__post_init__` runs.

## Measurements

Same machine, CPython 3.14.6, min of timeit repeats, the issue's two-field shape:

| | ns/call |
| --- | --- |
| `Two(1, 'y')` — positional floor | 42.1 |
| `from_mapping(Two, values)` | **79.0** |
| `Two(**values)` | 105.8 |

(The issue's numbers were 239.4 vs 116.0 on an earlier build; the ratio holds: from_mapping is 1.34x faster than the kwargs call on the same build.)

## Design decisions

<details>
<summary>One binding core for both entry points</summary>

`bind_named(type, self, name, value, positional_count)` now owns find_field, the unexpected-keyword message, the multiple-values check and the slot write. The vectorcall's `bind_keywords` is a loop over it; `from_mapping` calls it per dict entry. One copy of each error string — a from_mapping error is byte-identical to the constructor's.
</details>

<details>
<summary>The mapping gate: why `items`, and why not on the hot path</summary>

A list is `PyMapping_Check`-true through its subscript slot, and an ABC-style mapping carries the sequence slots through `__len__`+`__getitem__` (CPython's classic slot rule), so neither slot check alone names a mapping. Non-dicts must expose `items` — which the fallback path needs anyway. The probe is never taken for dicts: it binds a method object per call, which measured ~40 ns of the first implementation's overhead (180.7 → 79.0 ns after the gate moved behind `PyDict_Check` plus the direct single-pass loop).
</details>

<details>
<summary>Own-init and interned classes</summary>

A body `__init__` routes through the constructor call with the mapping as kwargs — the same slow path `replace` uses, so from_mapping cannot diverge from `__init__`. Interned zero-field classes return the singleton for an empty mapping, and refuse non-empty ones with the constructor's TypeError.
</details>

## Tests

`tests/test_from_mapping.py` (12 pins: argv-order independence, defaults, per-instance mutable default copies, unknown key, missing required, non-dict Mapping, non-mapping refusal, non-struct-class refusal, singleton, mutable non-interned, post_init, body-init routing), a refcount probe, typing pins in `accepted.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 (after the reviewer's round 1, score 2.08)

<details>
<summary>The systemic answer: one acquisition, validated at the boundary</summary>

The non-dict path now acquires `items()` **once** — an error-preserving probe in place of `PyObject_HasAttrString`, so a raising `items` attribute propagates instead of masking as "not a mapping" — runs the result through `PySequence_Fast`, and validates every pair (2-tuple, str key) before anything reads it. The bind loop, the own-init kwargs dict, and the pair-shape error all consume that one validated list. This closes the major (the `PyTuple_GET_ITEM` garbage read on a custom `items()` yielding non-2-tuples), the exception-swallowing minor, and the own-init divergence (`dict(values)` had re-looked-up the mapping its own way). Non-string keys now raise the constructor's own `"keywords must be strings"` on both the dict and items paths.
</details>

<details>
<summary>Declared: the interned short-circuit still runs a non-dict mapping's items()</summary>

An interned zero-field class returns the singleton only for an *empty* mapping, and the emptiness of a non-dict mapping is only known by asking it — the items acquisition happens before the count. The dict path, the hot one, checks size first. Declared, not fixed.
</details>


---

## Round 3 (after the reviewer's round 2, score 1.95)

<details>
<summary>The major: pinned the sequence API, dropped the layout accident</summary>

`PySequence_Fast` returns tuples unchanged, and the four consumer sites read them with the `PyList` macros — the two layouts happen to agree today, which is an unpinned C assumption. All four sites now read through `PySequence_Fast_GET_SIZE`/`GET_ITEM`, and an `items()` returning a tuple is pinned. Also folded in: the probe is now `owned.h`'s `optional_attribute` (no inline re-derivation), duplicate items keys raise the constructor's `multiple values` TypeError on the own-init path too, and a dict mixing non-string and unknown keys raises `keywords must be strings` upfront — keys-first, like CPython's kwargs check.
</details>

<details>
<summary>Declared: the field-bind path bypasses a metaclass `__call__`</summary>

The direct field-bind path cannot honor a metaclass `__call__` override without rebuilding the kwargs dict and re-entering the calling convention — the exact round-trip the issue (#62) exists to skip. Declared, and pinned: `test_the_field_bind_path_bypasses_a_metaclass_call` shows construction counts the call and `from_mapping` does not.
</details>



---

## Merged (round 3 converged at score 0) — recorded nits

- **Perf figure refreshed for the merged code** (the keys-first validation pass postdates the original measurement): same machine, CPython 3.14.6, `from_mapping(Two, d)` **85.0 ns** against `Two(**values)` 105.0 ns. Still 1.24x faster than the kwargs call, still below the issue's premise; the table above the round-2 section predates the validation pass.
- **The own-init non-string-key parity pin** (`from_mapping(WithInit, {1: 'one'})` → `"keywords must be strings"`) is not yet in the tree — recorded here to fold into a follow-up rather than churn a converged head.
