### PR TITLE
fix: the recorded convergence follow-ups

### DIFF
--- a/src/construct/construct.c
+++ b/src/construct/construct.c
@@ -210,7 +210,7 @@ PyObject * Struct_replace(
 			return NULL;
 		}
 
-		if (Py_TYPE(replaced) != cls) {
+		if (!PyObject_TypeCheck(replaced, cls)) {
 			PyErr_SetString(
 				PyExc_SystemError,
 				"salix internal error: the replace construction returned a different type"

--- a/tests/test_from_mapping.py
+++ b/tests/test_from_mapping.py
@@ -240,3 +240,8 @@ def test_the_field_bind_path_bypasses_a_metaclass_call():
     from_mapping(Counted, {"x": 2})
 
     assert len(calls) == 1
+
+
+def test_an_own_init_class_refuses_a_non_string_key_like_the_constructor():
+    with pytest.raises(TypeError, match="keywords must be strings"):
+        from_mapping(WithInit, {1: "one"})  # type: ignore[arg-type]

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -317,3 +317,30 @@ def test_a_metaclass_call_returning_a_foreign_struct_is_refused():
 
     with pytest.raises(SystemError, match="returned a different type"):
         replace(disguised, x=2)
+
+
+def test_a_metaclass_call_returning_a_subclass_instance_is_accepted():
+    class RogueMeta(type(Struct)):
+        def __call__(cls, *args: object, **kwargs: object) -> object:
+            if cls is Base:
+                return subclass
+            return super().__call__(*args, **kwargs)
+
+    class Base(Struct, metaclass=RogueMeta, frozen=False):
+        x: int = 0
+
+        def __init__(self, x: int = 0) -> None:
+            self.x = x
+
+    class Sub(Base, frozen=False):
+        pass
+
+    subclass = type.__call__(Sub)
+    base = type.__call__(Base)
+
+    assert type(base) is Base
+
+    replaced = replace(base, x=2)
+
+    assert type(replaced) is Sub
+    assert replaced.x == 0


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked that the convergence-recorded follow-ups from the merged replace/from_mapping PRs be folded into a follow-up rather than churn their certified heads.

## Summary

- **The constructor-call guard relaxes to `PyObject_TypeCheck`** — a metaclass `__call__` that legally returns a subclass instance (construction accepts it) is now accepted by replace; the foreign-sibling case still raises the SystemError, pinned in both directions.
- **The changed-dict presize was measured and rejected** — the API the note named does not exist publicly on any supported version, and `PyDict_Presize` exists on none. The slow path is a constructor call; the dict resizes itself.
- **The from_mapping parity pin** — an own-init class receives the constructor's own `keywords must be strings` for a non-string mapping key (CPython's kwdict processing), now pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)