### PR TITLE
fix: bootstrap the free-threaded venv so main's CI is green again

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -146,8 +146,13 @@ FREE_THREADED = "3.14t"
 # one is installed -- any patch, even with the default variant also installed --
 # so this one is kept in a root of its own where it cannot rebind the matrix.
 FREE_THREADED_ROOT = {"UV_PYTHON_INSTALL_DIR": ".free-threaded-python"}
-free_threaded_build = Task(
-    BUILD.format(PY=FREE_THREADED), mutates=True, env=FREE_THREADED_ROOT | STRICT_BUILD
+free_threaded_build = Sequential(
+    Task(
+        "uv venv --clear --python 3.14t --managed-python .venvs/3.14t",
+        mutates=True,
+        env=FREE_THREADED_ROOT,
+    ),
+    Task(BUILD.format(PY=FREE_THREADED), mutates=True, env=FREE_THREADED_ROOT | STRICT_BUILD),
 )
 free_threaded_pytest = Task(
     PYTEST.format(PY=FREE_THREADED),


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Main's CI went red from the interpreter-agreement change merged in #140, and she flagged the failing main — this is the hotfix.

## Summary

One hunk: the free-threaded build leg gains its own venv bootstrap leaf (`uv venv --clear --python 3.14t --managed-python .venvs/3.14t` under `FREE_THREADED_ROOT`, the same measured-immune resolution the matrix legs use) before compiling against that venv's exact interpreter. The failure was "No interpreter found at path .venvs/3.14t/bin/python" — the pinned BUILD template pointed at a venv nothing created. Verified locally (FT venv creation resolves the 3.14t interpreter in `.free-threaded-python`) and green on #139's CI leg after the same fix.

This is the fix #139 carries; merging it here unblocks main without waiting on #139's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Merged (converged at 0.46) — recorded nits

- `hardcoded-version-drift`: the FT bootstrap literals should derive from `FREE_THREADED` — fold into the next tasks.py touch.
- `clean-excludes-venvs`: the clean task's exemptions should also cover `.venvs` and `.free-threaded-python` — fold likewise.
