### PR TITLE
refactor: one body-binding classifier for every refusal site (#119)

### DIFF
--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -46,9 +46,9 @@ static enum result apply_options(
 );
 static enum result rebind(PyObject * namespace, char const * const * names, bool from_mixin);
 static enum result drop_class_variables(PyObject * namespace, PyObject * all_names);
-static int defines_a_method(
-	PyObject * bound,
-	PyObject * field_name,
+static int binding_belongs_to_body(
+	PyObject * namespace,
+	PyObject * name,
 	PyObject * class_name,
 	PyObject * * spelling
 );
@@ -484,22 +484,43 @@ enum result refuse_mixin_method_fields(PyObject * const all_names) {
 		return RESULT_ERROR;
 	}
 
+	PY_OWNED(
+		mixin_qualname,
+		PyObject_GetAttrString((PyObject *) &StructMixin_Type, "__qualname__")
+	);
+
+	if (mixin_qualname == NULL) {
+		return RESULT_ERROR;
+	}
+
 	Py_ssize_t position = 0;
 	PyObject * field_name;
 	PyObject * method;
 
 	while (PyDict_Next(mixin_dict, &position, &field_name, &method)) {
-		if (!PyObject_TypeCheck(method, &PyMethodDescr_Type)) {
-			continue;
-		}
-
 		int const present = PySequence_Contains(all_names, field_name);
 
 		if (present < 0) {
 			return RESULT_ERROR;
 		}
 
-		if (present == 1) {
+		if (present == 0) {
+			continue;
+		}
+
+		PY_MOVABLE(spelling, NULL);
+		int const belongs = binding_belongs_to_body(
+			mixin_dict,
+			field_name,
+			mixin_qualname,
+			&spelling
+		);
+
+		if (belongs < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (belongs == 1) {
 			PyErr_Format(
 				PyExc_TypeError,
 				"%U is a field, and the mixin defines a method of the same "
@@ -521,24 +542,29 @@ enum result refuse_colliding_methods(
 ) {
 	for (Py_ssize_t i = 0; i < PyList_GET_SIZE(all_names); ++i) {
 		PyObject * const field_name = PyList_GET_ITEM(all_names, i);
-		PY_OWNED(bound, dict_value_ref(original_namespace, field_name));
-
-		if (bound == NULL) {
-			if (PyErr_Occurred()) {
-				return RESULT_ERROR;
-			}
-
-			continue;
-		}
-
 		PY_MOVABLE(spelling, NULL);
-		int const method = defines_a_method(bound, field_name, class_name, &spelling);
+		int const method = binding_belongs_to_body(
+			original_namespace,
+			field_name,
+			class_name,
+			&spelling
+		);
 
 		if (method < 0) {
 			return RESULT_ERROR;
 		}
 
 		if (method == 1) {
+			PY_OWNED(bound, dict_value_ref(original_namespace, field_name));
+
+			if (bound == NULL) {
+				if (PyErr_Occurred()) {
+					return RESULT_ERROR;
+				}
+
+				continue;
+			}
+
 			PyErr_Format(
 				PyExc_TypeError,
 				"'%U' is a field, and the class body binds a %.100s to that name "
@@ -605,12 +631,18 @@ static PyObject * qualname_of(PyObject * const value) {
 	return qualname_direct(func);
 }
 
-static int defines_a_method(
-	PyObject * const bound,
-	PyObject * const field_name,
+static int binding_belongs_to_body(
+	PyObject * const namespace,
+	PyObject * const name,
 	PyObject * const class_name,
 	PyObject * * const spelling
 ) {
+	PY_OWNED(bound, dict_value_ref(namespace, name));
+
+	if (bound == NULL) {
+		return PyErr_Occurred() ? -1 : 0;
+	}
+
 	if (
 		PyObject_TypeCheck(bound, &PyProperty_Type) ||
 		PyObject_TypeCheck(bound, &PyClassMethod_Type) ||
@@ -625,7 +657,7 @@ static int defines_a_method(
 		return PyErr_Occurred() ? -1 : 0;
 	}
 
-	return defined_in_this_body(qualname, field_name, class_name, spelling);
+	return defined_in_this_body(qualname, name, class_name, spelling);
 }
 
 static int defined_in_this_body(

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -859,6 +859,28 @@ class TestNameCollisions:
 
         assert Fine(21).doubled() == 42
 
+    @pytest.mark.parametrize(
+        "mixin_method",
+        (
+            "__copy__",
+            "__deepcopy__",
+            "__replace__",
+            "__repr__",
+            "__setattr__",
+            "__delattr__",
+            "__lt__",
+            "__le__",
+            "__eq__",
+            "__ne__",
+            "__gt__",
+            "__ge__",
+            "__hash__",
+        ),
+    )
+    def test_a_field_named_like_a_mixin_method_is_refused(self, mixin_method):
+        with pytest.raises(TypeError, match=r"is a field.*the mixin defines a method"):
+            type(Struct)("Collide", (Struct,), {"__annotations__": {mixin_method: int}})
+
 
 class TestDefaultsThatAreCallable:
     """The negative control for #54's refusal, and the reason it asks a


### PR DESCRIPTION
**#119** — the body-binding classification, answered once instead of four ways.

## What changed

`binding_belongs_to_body(namespace, name, class_name, spelling)` in `namespace.c` replaces two of the four answers:

- `defines_a_method` (the colliding-methods site's qualname probe) becomes the shared helper — same tri-state, same `spelling` out-param, same AttributeError discipline, now reading its binding from the namespace itself.
- The mixin site's `PyMethodDescr_Type` check becomes a call to the same helper, with the mixin's own `__qualname__` as the class name (a static `PyTypeObject` has no C field for it on any supported interpreter; the runtime attribute is what the interpreter builds the mixin's method-descriptor qualnames from).
- The reserved-metadata refusal is untouched: it refuses *names*, not bindings, which is a different question than the one the helper answers.

The payoff is the issue's: a new wrapper family added to the mixin is recognised at every site by adding one check in one place.

## Measured behavior delta

The classifier also answers for the mixin's wrapper descriptors, whose qualnames name the mixin exactly as the method descriptors' do. Probe against today's build:

<details><summary>accept → refuse (the same "field would shadow the mixin's method" refusal <code>__copy__</code> already gets)</summary>

| field name | before | after |
|---|---|---|
| `__repr__`, `__setattr__`, `__delattr__`, `__lt__`, `__le__`, `__eq__`, `__ne__`, `__gt__`, `__ge__` | accepted | refused |
| `__hash__` | CPython slots `ValueError` | salix's mixin refusal (earlier, clearer) |
| `__copy__`, `__deepcopy__`, `__replace__` | refused | refused (unchanged) |
| `__doc__`, the eight metadata names | as before | unchanged |

</details>

The shadowing the refusal describes is the same hazard under those names — a field named `__eq__` silently replaces the mixin's structural equality for attribute lookup — so the refusal now covers the whole mixin-carried set. `test_methods.py` pins the full set parametrically.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was issue #119's brief: consolidate the body-binding classification into one shared helper, measure the mixin-site delta before committing to it, pin it, and open the PR for review.