### PR TITLE
chore(tasks): structured gate diagnostics for the fixer ladder

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -56,10 +56,11 @@ STRICT_BUILD = {"SALIX_STRICT": "1"}
 NIX_INPUTS = ("src/", "nix/", "tools/", "tests/", "flake.nix", "flake.lock", "pyproject.toml")
 
 build = Sequential(make_env, Task(BUILD, mutates=True, env=STRICT_BUILD))
+JUNIT_FORMAT = AgentFormat("--junitxml {report}", "junit", limit=1_000_000)
 pytest = Task(
     PYTEST,
     env=ENVIRONMENT_PER_INTERPRETER,
-    agent_format=AgentFormat("--junitxml {report}", "junit"),
+    agent_format=JUNIT_FORMAT,
 )
 # --no-sync: analyze reaches this from ci, and CI never installs the project.
 compile_flags = Task("uv run --no-sync python tools/compile_flags.py", mutates=True)
@@ -118,16 +119,17 @@ type_check = Parallel(mypy, pyright, ty, tooling)
 
 # Lint, not format: the style here is the style already in the files, so ruff
 # runs as a checker and never as a formatter. The rule set is in pyproject.
+LINT_FORMAT = AgentFormat("--output-format rdjson", "rdjson", limit=64_000)
 lint = Parallel(
     Task(
         "uv run --no-project --with ruff ruff check .",
-        agent_format=AgentFormat("--output-format rdjson", "rdjson"),
+        agent_format=LINT_FORMAT,
     ),
     Task(
         "uv run --no-project --with ruff ruff check --target-version py312"
         " tests/test_generics_pep695.py",
         when=lambda changed: sys.version_info >= (3, 12),
-        agent_format=AgentFormat("--output-format rdjson", "rdjson"),
+        agent_format=LINT_FORMAT,
     ),
 )
 
@@ -179,7 +181,7 @@ free_threaded_build = Sequential(
 free_threaded_pytest = Task(
     PYTEST.format(PY=FREE_THREADED),
     env=FREE_THREADED_ROOT | {"UV_PROJECT_ENVIRONMENT": ".venvs/" + FREE_THREADED},
-    agent_format=AgentFormat("--junitxml {report}", "junit"),
+    agent_format=JUNIT_FORMAT,
 )
 free_threaded = Sequential(free_threaded_build, free_threaded_pytest)
 benchmark = Sequential(

--- a/tasks.py
+++ b/tasks.py
@@ -124,12 +124,12 @@ HUNDREDS_OF_DIAGNOSTICS = 64_000
 LINT_FORMAT = AgentFormat("--output-format rdjson", "rdjson", limit=HUNDREDS_OF_DIAGNOSTICS)
 lint = Parallel(
     Task(
-        RUFF_CHECK + " . --exclude tests/test_generics_pep695.py",
+        RUFF_CHECK + " . --extend-exclude tests/test_generics_pep695.py",
         agent_format=LINT_FORMAT,
     ),
     Task(
         RUFF_CHECK + " --target-version py312 tests/test_generics_pep695.py",
-        when=("tests/test_generics_pep695.py",),
+        when=("tests/test_generics_pep695.py", "pyproject.toml"),
         agent_format=LINT_FORMAT,
     ),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 from camas import (
@@ -56,7 +55,8 @@ STRICT_BUILD = {"SALIX_STRICT": "1"}
 NIX_INPUTS = ("src/", "nix/", "tools/", "tests/", "flake.nix", "flake.lock", "pyproject.toml")
 
 build = Sequential(make_env, Task(BUILD, mutates=True, env=STRICT_BUILD))
-JUNIT_FORMAT = AgentFormat("--junitxml {report}", "junit", limit=1_000_000)
+FULL_SUITE_JUNIT = 1_000_000
+JUNIT_FORMAT = AgentFormat("--junitxml {report}", "junit", limit=FULL_SUITE_JUNIT)
 pytest = Task(
     PYTEST,
     env=ENVIRONMENT_PER_INTERPRETER,
@@ -119,16 +119,17 @@ type_check = Parallel(mypy, pyright, ty, tooling)
 
 # Lint, not format: the style here is the style already in the files, so ruff
 # runs as a checker and never as a formatter. The rule set is in pyproject.
-LINT_FORMAT = AgentFormat("--output-format rdjson", "rdjson", limit=64_000)
+RUFF_CHECK = "uv run --no-project --with ruff ruff check"
+HUNDREDS_OF_DIAGNOSTICS = 64_000
+LINT_FORMAT = AgentFormat("--output-format rdjson", "rdjson", limit=HUNDREDS_OF_DIAGNOSTICS)
 lint = Parallel(
     Task(
-        "uv run --no-project --with ruff ruff check .",
+        RUFF_CHECK + " . --exclude tests/test_generics_pep695.py",
         agent_format=LINT_FORMAT,
     ),
     Task(
-        "uv run --no-project --with ruff ruff check --target-version py312"
-        " tests/test_generics_pep695.py",
-        when=lambda changed: sys.version_info >= (3, 12),
+        RUFF_CHECK + " --target-version py312 tests/test_generics_pep695.py",
+        when=("tests/test_generics_pep695.py",),
         agent_format=LINT_FORMAT,
     ),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,15 @@
 from pathlib import Path
 
-from camas import Claude, Config, Parallel, Project, Sequential, Task, by_suffix
+from camas import (
+    AgentFormat,
+    Claude,
+    Config,
+    Parallel,
+    Project,
+    Sequential,
+    Task,
+    by_suffix,
+)
 
 C_SOURCES = by_suffix((".c", ".h"), default=tuple(sorted(str(p) for p in Path("src").rglob("*.[ch]"))))
 
@@ -50,7 +59,11 @@ STRICT_BUILD = {"SALIX_STRICT": "1"}
 NIX_INPUTS = ("src/", "nix/", "tools/", "tests/", "flake.nix", "flake.lock", "pyproject.toml")
 
 build = Sequential(make_env, Task(BUILD, mutates=True, env=STRICT_BUILD))
-pytest = Task(PYTEST, env=ENVIRONMENT_PER_INTERPRETER)
+pytest = Task(
+    PYTEST,
+    env=ENVIRONMENT_PER_INTERPRETER,
+    agent_format=AgentFormat("--junitxml {report}", "junit"),
+)
 # --no-sync: analyze reaches this from ci, and CI never installs the project.
 compile_flags = Task("uv run --no-sync python tools/compile_flags.py", mutates=True)
 
@@ -108,7 +121,10 @@ type_check = Parallel(mypy, pyright, ty, tooling)
 
 # Lint, not format: the style here is the style already in the files, so ruff
 # runs as a checker and never as a formatter. The rule set is in pyproject.
-lint = Task("uv run --no-project --with ruff ruff check .")
+lint = Task(
+    "uv run --no-project --with ruff ruff check .",
+    agent_format=AgentFormat("--output-format rdjson", "rdjson"),
+)
 
 bench = Project("bench")
 
@@ -157,6 +173,7 @@ free_threaded_build = Sequential(
 free_threaded_pytest = Task(
     PYTEST.format(PY=FREE_THREADED),
     env=FREE_THREADED_ROOT | {"UV_PROJECT_ENVIRONMENT": ".venvs/" + FREE_THREADED},
+    agent_format=AgentFormat("--junitxml {report}", "junit"),
 )
 free_threaded = Sequential(free_threaded_build, free_threaded_pytest)
 benchmark = Sequential(


### PR DESCRIPTION
The checking leaves now declare `agent_format`, so a failing gate hands the camas fixer subagents machine-readable diagnostics instead of tailed text:

- **lint** emits ruff rdjson — the gate's diagnostic payload carries each finding's rule, exact range, and suggestion, which is what the lint-fixer ladder reads.
- **pytest** (the six matrix legs and the free-threaded leg) write junit through `{report}` path mode — the test-fixer tier gets per-test results instead of a traceback tail.

The flags are appended only on gate runs; human and CI runs keep the commands as they were. Verified live before committing: a scoped gate on this very diff failed the lint leaf and returned `output_kind: rdjson` with the full ruff payload including the import-fix suggestion; after applying it the same gate is green with all junit leaves running clean.

## Rounds 1–3 disposition

**Streak-3 findings, deferred to camas (JPH's ruling: no camas changes):** `structured-payload-stderr-merged`, `path-mode-report-empty-on-crash`, `structured-kind-mislabeled-errored-leaf`, systemic `structured-diagnostics-camas-side-deferred`. These describe camas gate behavior (stderr mixing, the path-mode fallback on a crashed leg, the output-kind label on the fallback), not salix configuration. The salix-side mitigations are in: the raised limits mean the pointer fallback fires only past a full suite's junit or a hundred-plus-diagnostic rdjson, which is exactly the case where the payload must survive anyway.

**Fixed in the rounds:** the limits (round 1/2: junit 1_000_000, rdjson 64_000, named constants — `FULL_SUITE_JUNIT`, `HUNDREDS_OF_DIAGNOSTICS` — rather than comments, per the repo's no-comments rule); the hoisted `RUFF_CHECK` fragment and the pep695 leaf's file-keyed `when=` guard with the whole-repo leaf's exclude (round 3), so a scoped gate lints the file once and a full run targets it once at py312.

**Declined with reason:** pinning the ruff version (round 1's stderr-mitigation suggestion) — pinning a linter version is a project policy change, out of scope for this PR; recorded here instead.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was JPH's correction that the camas agent-facing options (agent_format and Config.agent) are capabilities to USE in the salix workflow; this PR wires the two diagnostic-rich leaves into them, learned from camas_docs and the installed fixer-agent definitions, and the rounds-1–3 disposition follows the review protocol.