### PR TITLE
feat: ClassVar-annotated class variables are kept, not refused (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,27 @@ Point(x=1.0, y=2.0)
 
 ## ClassVar and InitVar
 
-A field annotated `ClassVar[...]` or `InitVar[...]` is refused at class
-creation when the annotation reaches the check as one of those forms. The
-check walks the annotation's forms when it arrives as an object; when it
-arrives as source text — a quoted string, or a future-annotations string —
-the check is a spelling match, and the two paths differ at the edges:
+A name annotated `ClassVar[...]` at the top level is a class variable:
+with an assigned value it is kept in the class dict and excluded from
+the field plan, the constructor, and every metadata table; without one
+it is refused, because a class variable is a constant. `InitVar[...]`
+is refused, and so is a `ClassVar` nested inside another annotation.
+The check walks the annotation's forms when it arrives as an object;
+when it arrives as source text — a quoted string, or a
+future-annotations string — the check is a spelling match, and the two
+paths differ at the edges:
 
 | annotation | object path | text path |
 | --- | --- | --- |
-| an alias of `ClassVar`, `CV[int]` | refused | accepted; the field swallows a positional |
+| an alias of `ClassVar`, `CV[int]` | the form itself: kept with a value, refused without | accepted; the field swallows a positional |
 | a type of yours actually named `ClassVar` | accepted | refused |
 | `Annotated[int, ClassVar]` | accepted | refused, though the `ClassVar` there is metadata |
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 
-3.14 evaluates resolvable annotations by default, so there the alias reaches
-the object path and is refused; a name whose root cannot be resolved
-arrives as an object too, and is accepted, while any other evaluation
-error still fails the class. Every row is pinned in
+3.14 evaluates resolvable annotations by default, so there the alias
+reaches the object path and is the form; a name whose root cannot be
+resolved arrives as an object too, and is accepted, while any other
+evaluation error still fails the class. Every row is pinned in
 `tests/test_classvar_paths.py`.
 
 ## Caching a computed value

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Point(x=1.0, y=2.0)
 A name annotated `ClassVar[...]` at the top level is a class variable:
 with an assigned value it is kept in the class dict and excluded from
 the field plan, the constructor, and every metadata table; without one
-it is refused, because a class variable is a constant. `InitVar[...]`
+it is refused, because a class variable is a constant. An inherited
+field name stays a field: the inheritance rule outranks the ClassVar
+annotation, so re-annotating one re-declares the field. `InitVar[...]`
 is refused, and so is a `ClassVar` nested inside another annotation.
 The check walks the annotation's forms when it arrives as an object;
 when it arrives as source text — a quoted string, or a

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ paths differ at the edges:
 | annotation | object path | text path |
 | --- | --- | --- |
 | an alias of `ClassVar`, `CV[int]` | the form itself: kept with a value, refused without | accepted; the field swallows a positional |
-| a type of yours actually named `ClassVar` | accepted | refused |
+| a type of yours actually named `ClassVar` | accepted | kept with a value, refused without |
 | `Annotated[int, ClassVar]` | accepted | refused, though the `ClassVar` there is metadata |
 | `Optional[Annotated[ClassVar[int], "m"]]` | refused | refused |
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -53,6 +53,7 @@ static enum result append_declared(
 	PyObject * namespace,
 	PyObject * all_names,
 	PyObject * new_names,
+	PyObject * class_var_names,
 	PyObject * default_by_name,
 	PyObject * annotation_values,
 	PyObject * metadata_values,
@@ -145,6 +146,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 
 	PY_MOVABLE(all_names, PyList_New(0));
 	PY_MOVABLE(new_names, PyList_New(0));
+	PY_MOVABLE(class_var_names, PyList_New(0));
 	PY_MOVABLE(annotation_values, PyList_New(0));
 	PY_MOVABLE(metadata_values, PyList_New(0));
 	PY_OWNED(default_by_name, PyDict_New());
@@ -153,6 +155,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 	if (
 		all_names != NULL &&
 		new_names != NULL &&
+		class_var_names != NULL &&
 		annotation_values != NULL &&
 		metadata_values != NULL &&
 		default_by_name != NULL &&
@@ -165,6 +168,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 				namespace,
 				all_names,
 				new_names,
+				class_var_names,
 				default_by_name,
 				annotation_values,
 				metadata_values,
@@ -182,6 +186,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 			plan.metadata = built_metadata;
 			plan.all_names = py_move(&all_names);
 			plan.new_names = py_move(&new_names);
+			plan.class_var_names = py_move(&class_var_names);
 		} else {
 			Py_XDECREF(built_defaults);
 			Py_XDECREF(built_annotations);
@@ -195,6 +200,7 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 void field_plan_clear(struct field_plan * const plan) {
 	Py_CLEAR(plan->all_names);
 	Py_CLEAR(plan->new_names);
+	Py_CLEAR(plan->class_var_names);
 	Py_CLEAR(plan->defaults);
 	Py_CLEAR(plan->annotations);
 	Py_CLEAR(plan->metadata);
@@ -337,6 +343,7 @@ static enum result append_declared(
 	PyObject * const namespace,
 	PyObject * const all_names,
 	PyObject * const new_names,
+	PyObject * const class_var_names,
 	PyObject * const default_by_name,
 	PyObject * const annotation_values,
 	PyObject * const metadata_values,
@@ -369,10 +376,6 @@ static enum result append_declared(
 	for (Py_ssize_t at = 0; at < PyList_GET_SIZE(declared); ++at) {
 		PyObject * const field_name = PyList_GET_ITEM(declared, at);
 
-		if (refuse_reserved_name(field_name) != RESULT_OK) {
-			return RESULT_ERROR;
-		}
-
 		PY_OWNED(annotation, dict_value_ref(annotations, field_name));
 
 		if (annotation == NULL) {
@@ -395,6 +398,10 @@ static enum result append_declared(
 		if (!PyUnicode_CheckExact(field_name)) {
 			PyErr_SetString(PyExc_TypeError, "annotation keys must be strings");
 
+			return RESULT_ERROR;
+		}
+
+		if (refuse_reserved_name(field_name) != RESULT_OK) {
 			return RESULT_ERROR;
 		}
 
@@ -433,47 +440,51 @@ static enum result append_declared(
 			return RESULT_ERROR;
 		}
 
-		if (special.name != NULL) {
-			if (special.kind == SPECIAL_FORM_CLASS_VAR) {
-				bool const top_level = class_var_top_level(annotation, &probes);
+		if (special.name != NULL && special.kind == SPECIAL_FORM_CLASS_VAR) {
+			bool const top_level = class_var_top_level(annotation, &probes);
 
-				if (PyErr_Occurred()) {
-					return RESULT_ERROR;
-				}
-
-				if (!top_level) {
-					PyErr_Format(
-						PyExc_TypeError,
-						"'%U' is annotated %s, which salix does not support; "
-						"write it below the fields, without an annotation",
-						field_name,
-						special.name
-					);
-
-					return RESULT_ERROR;
-				}
-
-				if (declared_default == NULL) {
-					PyErr_Format(
-						PyExc_TypeError,
-						"'%U' is annotated ClassVar without an assigned value; %s",
-						field_name,
-						CLASS_VAR_FORM.instead
-					);
-
-					return RESULT_ERROR;
-				}
-
-				continue;
-			}
-
-			if (
-				declared_default != NULL &&
-				refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
-			) {
+			if (PyErr_Occurred()) {
 				return RESULT_ERROR;
 			}
 
+			if (!top_level) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"'%U' is annotated %s, which salix does not support; "
+					"write it below the fields, without an annotation",
+					field_name,
+					special.name
+				);
+
+				return RESULT_ERROR;
+			}
+
+			if (declared_default == NULL) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"'%U' is annotated ClassVar without an assigned value; %s",
+					field_name,
+					CLASS_VAR_FORM.instead
+				);
+
+				return RESULT_ERROR;
+			}
+
+			if (PyList_Append(class_var_names, field_name) < 0) {
+				return RESULT_ERROR;
+			}
+
+			continue;
+		}
+
+		if (
+			declared_default != NULL &&
+			refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+		) {
+			return RESULT_ERROR;
+		}
+
+		if (special.name != NULL) {
 			PyErr_Format(
 				PyExc_TypeError,
 				"'%U' is annotated %s, which salix does not support; %s",
@@ -482,13 +493,6 @@ static enum result append_declared(
 				special.instead
 			);
 
-			return RESULT_ERROR;
-		}
-
-		if (
-			declared_default != NULL &&
-			refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
-		) {
 			return RESULT_ERROR;
 		}
 
@@ -795,6 +799,11 @@ static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
 
 		if ((character == ']' || character == ')') && depth > 0) {
 			--depth;
+			continue;
+		}
+
+		if (character == '|' && depth == 0) {
+			return false;
 		}
 	}
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -128,6 +128,7 @@ static struct special_form named_special_form(PyObject * text, struct form_probe
 static bool names_form(PyObject * text, PyObject * needle);
 static bool names_form_at_top(PyObject * text, PyObject * needle);
 static bool top_level_prefix(PyObject * text, Py_ssize_t until);
+static bool top_level_suffix(PyObject * text, Py_ssize_t from);
 static bool class_var_top_level(PyObject * annotation, struct form_probes const * probes);
 static bool continues_identifier(Py_UCS4 character);
 static PyObject * module_attribute(char const * module_name, char const * attribute);
@@ -368,6 +369,10 @@ static enum result append_declared(
 	for (Py_ssize_t at = 0; at < PyList_GET_SIZE(declared); ++at) {
 		PyObject * const field_name = PyList_GET_ITEM(declared, at);
 
+		if (refuse_reserved_name(field_name) != RESULT_OK) {
+			return RESULT_ERROR;
+		}
+
 		PY_OWNED(annotation, dict_value_ref(annotations, field_name));
 
 		if (annotation == NULL) {
@@ -399,10 +404,7 @@ static enum result append_declared(
 			if (PyErr_Occurred()) {
 				return RESULT_ERROR;
 			}
-		} else if (
-			refuse_reserved_name(field_name) != RESULT_OK ||
-			PyDict_SetItem(default_by_name, field_name, declared_default) < 0
-		) {
+		} else if (PyDict_SetItem(default_by_name, field_name, declared_default) < 0) {
 			return RESULT_ERROR;
 		}
 
@@ -432,10 +434,6 @@ static enum result append_declared(
 		}
 
 		if (special.name != NULL) {
-			if (refuse_reserved_name(field_name) != RESULT_OK) {
-				return RESULT_ERROR;
-			}
-
 			if (special.kind == SPECIAL_FORM_CLASS_VAR) {
 				bool const top_level = class_var_top_level(annotation, &probes);
 
@@ -761,11 +759,21 @@ static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
 		Py_UCS4 const character = PyUnicode_ReadChar(text, at);
 
 		if (single_quoted) {
+			if (character == '\\') {
+				++at;
+				continue;
+			}
+
 			single_quoted = character != '\'';
 			continue;
 		}
 
 		if (double_quoted) {
+			if (character == '\\') {
+				++at;
+				continue;
+			}
+
 			double_quoted = character != '"';
 			continue;
 		}
@@ -793,6 +801,66 @@ static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
 	return depth == 0 && !single_quoted && !double_quoted;
 }
 
+static bool top_level_suffix(PyObject * const text, Py_ssize_t const from) {
+	Py_ssize_t const length = PyUnicode_GET_LENGTH(text);
+	int depth = 0;
+	bool single_quoted = false;
+	bool double_quoted = false;
+
+	for (Py_ssize_t at = from; at < length; ++at) {
+		Py_UCS4 const character = PyUnicode_ReadChar(text, at);
+
+		if (single_quoted) {
+			if (character == '\\') {
+				++at;
+				continue;
+			}
+
+			single_quoted = character != '\'';
+			continue;
+		}
+
+		if (double_quoted) {
+			if (character == '\\') {
+				++at;
+				continue;
+			}
+
+			double_quoted = character != '"';
+			continue;
+		}
+
+		if (character == '\'') {
+			single_quoted = true;
+			continue;
+		}
+
+		if (character == '"') {
+			double_quoted = true;
+			continue;
+		}
+
+		if (character == '[' || character == '(') {
+			++depth;
+			continue;
+		}
+
+		if (character == ']' || character == ')') {
+			if (depth > 0) {
+				--depth;
+			}
+
+			continue;
+		}
+
+		if (character == '|' && depth == 0) {
+			return false;
+		}
+	}
+
+	return depth == 0 && !single_quoted && !double_quoted;
+}
+
 static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
 	Py_ssize_t const length = PyUnicode_GET_LENGTH(text);
 	Py_ssize_t const form_length = PyUnicode_GET_LENGTH(needle);
@@ -810,7 +878,12 @@ static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
 			!continues_identifier(PyUnicode_ReadChar(text, found + form_length))
 		);
 
-		if (opens && closes && top_level_prefix(text, found)) {
+		if (
+			opens &&
+			closes &&
+			top_level_prefix(text, found) &&
+			top_level_suffix(text, found + form_length)
+		) {
 			return true;
 		}
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -78,21 +78,6 @@ static struct special_form const INIT_VAR_FORM = {
 	.instead = "take the value in a custom __init__ and write the fields with set_field",
 };
 
-static char const * const class_var_machinery_names[] = {
-	"__init__",
-	"__post_init__",
-	"__new__",
-	"__match_args__",
-	"__slots__",
-	"__weakref__",
-	"__dict__",
-	"__getstate__",
-	"__setstate__",
-	"__reduce__",
-	"__reduce_ex__",
-	NULL,
-};
-
 char const * const reserved_metadata_names[] = {
 	"_struct_fields_",
 	"_struct_defaults_",
@@ -132,18 +117,16 @@ static enum result refuse_reserved_name(PyObject * const field_name) {
 	return RESULT_ERROR;
 }
 
-static char const * class_var_machinery_name_of(PyObject * const name) {
-	for (
-		char const * const * machinery = class_var_machinery_names;
-		*machinery != NULL;
-		++machinery
-	) {
-		if (PyUnicode_CompareWithASCIIString(name, *machinery) == 0) {
-			return *machinery;
-		}
-	}
+static bool class_var_machinery_name(PyObject * const name) {
+	Py_ssize_t const length = PyUnicode_GET_LENGTH(name);
 
-	return NULL;
+	return (
+		length >= 4 &&
+		PyUnicode_ReadChar(name, 0) == '_' &&
+		PyUnicode_ReadChar(name, 1) == '_' &&
+		PyUnicode_ReadChar(name, length - 1) == '_' &&
+		PyUnicode_ReadChar(name, length - 2) == '_'
+	);
 }
 static PyObject * build_defaults(PyObject * all_names, PyObject * default_by_name);
 static enum result reject_unsafe_default(PyObject * field_name, PyObject * value);
@@ -489,23 +472,23 @@ static enum result append_declared(
 				return RESULT_ERROR;
 			}
 
+			if (class_var_machinery_name(field_name)) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"'%U' cannot be a ClassVar: a double-underscore name shadows "
+					"Python's slot and protocol lookups; rename it",
+					field_name
+				);
+
+				return RESULT_ERROR;
+			}
+
 			if (declared_default == NULL) {
 				PyErr_Format(
 					PyExc_TypeError,
 					"'%U' is annotated ClassVar without an assigned value; %s",
 					field_name,
 					CLASS_VAR_FORM.instead
-				);
-
-				return RESULT_ERROR;
-			}
-
-			if (class_var_machinery_name_of(field_name) != NULL) {
-				PyErr_Format(
-					PyExc_TypeError,
-					"'%U' cannot be a ClassVar: salix installs its own class "
-					"attribute of that name; rename it",
-					field_name
 				);
 
 				return RESULT_ERROR;
@@ -769,6 +752,8 @@ static bool continues_identifier(Py_UCS4 const character) {
 }
 
 static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
+	Py_ssize_t last_non_space = -1;
+
 	for (Py_ssize_t at = 0; at < until; ++at) {
 		Py_UCS4 const character = PyUnicode_ReadChar(text, at);
 
@@ -779,9 +764,13 @@ static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
 		) {
 			return false;
 		}
+
+		if (!Py_UNICODE_ISSPACE(character)) {
+			last_non_space = at;
+		}
 	}
 
-	return true;
+	return last_non_space == -1 || PyUnicode_ReadChar(text, last_non_space) == '.';
 }
 
 static bool top_level_suffix(PyObject * const text, Py_ssize_t const from) {
@@ -843,6 +832,10 @@ static bool top_level_suffix(PyObject * const text, Py_ssize_t const from) {
 
 					break;
 				}
+			}
+
+			if (character == ',' && depth == 1) {
+				return false;
 			}
 		}
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -61,7 +61,7 @@ static enum result append_annotation(
 
 static struct special_form const CLASS_VAR_FORM = {
 	.name = "ClassVar",
-	.instead = "write it below the fields, without an annotation",
+	.instead = "a class variable is a constant, so assign the value in the class body",
 };
 static struct special_form const INIT_VAR_FORM = {
 	.name = "InitVar",
@@ -389,8 +389,7 @@ static enum result append_declared(
 			}
 		} else if (
 			refuse_reserved_name(field_name) != RESULT_OK ||
-			PyDict_SetItem(default_by_name, field_name, declared_default) < 0 ||
-			refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+			PyDict_SetItem(default_by_name, field_name, declared_default) < 0
 		) {
 			return RESULT_ERROR;
 		}
@@ -418,6 +417,21 @@ static enum result append_declared(
 				return RESULT_ERROR;
 			}
 
+			if (special.name == CLASS_VAR_FORM.name) {
+				if (declared_default == NULL) {
+					PyErr_Format(
+						PyExc_TypeError,
+						"'%U' is annotated ClassVar without an assigned value; %s",
+						field_name,
+						CLASS_VAR_FORM.instead
+					);
+
+					return RESULT_ERROR;
+				}
+
+				continue;
+			}
+
 			PyErr_Format(
 				PyExc_TypeError,
 				"'%U' is annotated %s, which salix does not support; %s",
@@ -426,6 +440,13 @@ static enum result append_declared(
 				special.instead
 			);
 
+			return RESULT_ERROR;
+		}
+
+		if (
+			declared_default != NULL &&
+			refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+		) {
 			return RESULT_ERROR;
 		}
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -8,7 +8,14 @@
 #include "result.h"
 #include "types.h"
 
+enum special_form_kind {
+	SPECIAL_FORM_NONE,
+	SPECIAL_FORM_CLASS_VAR,
+	SPECIAL_FORM_INIT_VAR,
+};
+
 struct special_form {
+	enum special_form_kind kind;
 	char const * name;
 	char const * instead;
 };
@@ -60,10 +67,12 @@ static enum result append_annotation(
 );
 
 static struct special_form const CLASS_VAR_FORM = {
+	.kind = SPECIAL_FORM_CLASS_VAR,
 	.name = "ClassVar",
 	.instead = "a class variable is a constant, so assign the value in the class body",
 };
 static struct special_form const INIT_VAR_FORM = {
+	.kind = SPECIAL_FORM_INIT_VAR,
 	.name = "InitVar",
 	.instead = "take the value in a custom __init__ and write the fields with set_field",
 };
@@ -117,6 +126,9 @@ static struct special_form special_form_of(
 static struct special_form form_within(PyObject * annotation, struct form_probes const * probes);
 static struct special_form named_special_form(PyObject * text, struct form_probes const * probes);
 static bool names_form(PyObject * text, PyObject * needle);
+static bool names_form_at_top(PyObject * text, PyObject * needle);
+static bool top_level_prefix(PyObject * text, Py_ssize_t until);
+static bool class_var_top_level(PyObject * annotation, struct form_probes const * probes);
 static bool continues_identifier(Py_UCS4 character);
 static PyObject * module_attribute(char const * module_name, char const * attribute);
 static enum result refuse_shared_mutable_contents(PyObject * field_name, PyObject * value);
@@ -398,6 +410,13 @@ static enum result append_declared(
 			case INHERITANCE_ERROR:
 				return RESULT_ERROR;
 			case INHERITANCE_INHERITED:
+				if (
+					declared_default != NULL &&
+					refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+				) {
+					return RESULT_ERROR;
+				}
+
 				continue;
 			case INHERITANCE_NEW:
 				break;
@@ -417,7 +436,25 @@ static enum result append_declared(
 				return RESULT_ERROR;
 			}
 
-			if (special.name == CLASS_VAR_FORM.name) {
+			if (special.kind == SPECIAL_FORM_CLASS_VAR) {
+				bool const top_level = class_var_top_level(annotation, &probes);
+
+				if (PyErr_Occurred()) {
+					return RESULT_ERROR;
+				}
+
+				if (!top_level) {
+					PyErr_Format(
+						PyExc_TypeError,
+						"'%U' is annotated %s, which salix does not support; "
+						"write it below the fields, without an annotation",
+						field_name,
+						special.name
+					);
+
+					return RESULT_ERROR;
+				}
+
 				if (declared_default == NULL) {
 					PyErr_Format(
 						PyExc_TypeError,
@@ -430,6 +467,13 @@ static enum result append_declared(
 				}
 
 				continue;
+			}
+
+			if (
+				declared_default != NULL &&
+				refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+			) {
+				return RESULT_ERROR;
 			}
 
 			PyErr_Format(
@@ -531,6 +575,47 @@ static struct special_form form_named_by(
 	}
 
 	return (struct special_form){0};
+}
+
+static bool class_var_object_top_level(
+	PyObject * const annotation,
+	struct form_probes const * const probes
+) {
+	if (probes->class_var == NULL || annotation == probes->class_var) {
+		return annotation == probes->class_var;
+	}
+
+	if (PyType_Check(annotation)) {
+		return false;
+	}
+
+	PY_OWNED(origin, optional_attribute(annotation, "__origin__"));
+
+	if (origin == NULL || origin != probes->class_var) {
+		return false;
+	}
+
+	PY_OWNED(metadata, optional_attribute(annotation, "__metadata__"));
+
+	if (PyErr_Occurred()) {
+		return false;
+	}
+
+	return metadata == NULL;
+}
+
+static bool class_var_top_level(
+	PyObject * const annotation,
+	struct form_probes const * const probes
+) {
+	if (PyUnicode_Check(annotation)) {
+		return (
+			probes->class_var_name != NULL &&
+			names_form_at_top(annotation, probes->class_var_name)
+		);
+	}
+
+	return class_var_object_top_level(annotation, probes);
 }
 
 static struct special_form special_form_of(
@@ -658,6 +743,74 @@ static bool names_form(PyObject * const text, PyObject * const needle) {
 		);
 
 		if (opens && closes) {
+			return true;
+		}
+
+		at = found;
+	}
+
+	return false;
+}
+
+static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
+	int depth = 0;
+	bool single_quoted = false;
+	bool double_quoted = false;
+
+	for (Py_ssize_t at = 0; at < until; ++at) {
+		Py_UCS4 const character = PyUnicode_ReadChar(text, at);
+
+		if (single_quoted) {
+			single_quoted = character != '\'';
+			continue;
+		}
+
+		if (double_quoted) {
+			double_quoted = character != '"';
+			continue;
+		}
+
+		if (character == '\'') {
+			single_quoted = true;
+			continue;
+		}
+
+		if (character == '"') {
+			double_quoted = true;
+			continue;
+		}
+
+		if (character == '[' || character == '(') {
+			++depth;
+			continue;
+		}
+
+		if ((character == ']' || character == ')') && depth > 0) {
+			--depth;
+		}
+	}
+
+	return depth == 0 && !single_quoted && !double_quoted;
+}
+
+static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
+	Py_ssize_t const length = PyUnicode_GET_LENGTH(text);
+	Py_ssize_t const form_length = PyUnicode_GET_LENGTH(needle);
+
+	for (Py_ssize_t at = 0; at + form_length <= length; ++at) {
+		Py_ssize_t const found = PyUnicode_Find(text, needle, at, length, 1);
+
+		if (found < 0) {
+			return false;
+		}
+
+		bool const opens = found == 0 || !continues_identifier(PyUnicode_ReadChar(text, found - 1));
+		bool const closes = (
+			found + form_length == length ||
+			!continues_identifier(PyUnicode_ReadChar(text, found + form_length))
+		);
+
+		if (opens && closes && top_level_prefix(text, found)) {
 			return true;
 		}
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -78,6 +78,21 @@ static struct special_form const INIT_VAR_FORM = {
 	.instead = "take the value in a custom __init__ and write the fields with set_field",
 };
 
+static char const * const class_var_machinery_names[] = {
+	"__init__",
+	"__post_init__",
+	"__new__",
+	"__match_args__",
+	"__slots__",
+	"__weakref__",
+	"__dict__",
+	"__getstate__",
+	"__setstate__",
+	"__reduce__",
+	"__reduce_ex__",
+	NULL,
+};
+
 char const * const reserved_metadata_names[] = {
 	"_struct_fields_",
 	"_struct_defaults_",
@@ -116,6 +131,20 @@ static enum result refuse_reserved_name(PyObject * const field_name) {
 
 	return RESULT_ERROR;
 }
+
+static char const * class_var_machinery_name_of(PyObject * const name) {
+	for (
+		char const * const * machinery = class_var_machinery_names;
+		*machinery != NULL;
+		++machinery
+	) {
+		if (PyUnicode_CompareWithASCIIString(name, *machinery) == 0) {
+			return *machinery;
+		}
+	}
+
+	return NULL;
+}
 static PyObject * build_defaults(PyObject * all_names, PyObject * default_by_name);
 static enum result reject_unsafe_default(PyObject * field_name, PyObject * value);
 static PyObject * checked_annotations(PyObject * namespace);
@@ -127,6 +156,7 @@ static struct special_form special_form_of(
 static struct special_form form_within(PyObject * annotation, struct form_probes const * probes);
 static struct special_form named_special_form(PyObject * text, struct form_probes const * probes);
 static bool names_form(PyObject * text, PyObject * needle);
+static bool names_form_matching(PyObject * text, PyObject * needle, bool top_only);
 static bool names_form_at_top(PyObject * text, PyObject * needle);
 static bool top_level_prefix(PyObject * text, Py_ssize_t until);
 static bool top_level_suffix(PyObject * text, Py_ssize_t from);
@@ -470,6 +500,17 @@ static enum result append_declared(
 				return RESULT_ERROR;
 			}
 
+			if (class_var_machinery_name_of(field_name) != NULL) {
+				PyErr_Format(
+					PyExc_TypeError,
+					"'%U' cannot be a ClassVar: salix installs its own class "
+					"attribute of that name; rename it",
+					field_name
+				);
+
+				return RESULT_ERROR;
+			}
+
 			if (PyList_Append(class_var_names, field_name) < 0) {
 				return RESULT_ERROR;
 			}
@@ -727,150 +768,101 @@ static bool continues_identifier(Py_UCS4 const character) {
 	return PyUnicode_IsIdentifier(probe) == 1;
 }
 
-static bool names_form(PyObject * const text, PyObject * const needle) {
-	Py_ssize_t const length = PyUnicode_GET_LENGTH(text);
-	Py_ssize_t const form_length = PyUnicode_GET_LENGTH(needle);
-
-	for (Py_ssize_t at = 0; at + form_length <= length; ++at) {
-		Py_ssize_t const found = PyUnicode_Find(text, needle, at, length, 1);
-
-		if (found < 0) {
-			return false;
-		}
-
-		bool const opens = found == 0 || !continues_identifier(PyUnicode_ReadChar(text, found - 1));
-		bool const closes = (
-			found + form_length == length ||
-			!continues_identifier(PyUnicode_ReadChar(text, found + form_length))
-		);
-
-		if (opens && closes) {
-			return true;
-		}
-
-		at = found;
-	}
-
-	return false;
-}
-
 static bool top_level_prefix(PyObject * const text, Py_ssize_t const until) {
-	int depth = 0;
-	bool single_quoted = false;
-	bool double_quoted = false;
-
 	for (Py_ssize_t at = 0; at < until; ++at) {
 		Py_UCS4 const character = PyUnicode_ReadChar(text, at);
 
-		if (single_quoted) {
-			if (character == '\\') {
-				++at;
-				continue;
-			}
-
-			single_quoted = character != '\'';
-			continue;
-		}
-
-		if (double_quoted) {
-			if (character == '\\') {
-				++at;
-				continue;
-			}
-
-			double_quoted = character != '"';
-			continue;
-		}
-
-		if (character == '\'') {
-			single_quoted = true;
-			continue;
-		}
-
-		if (character == '"') {
-			double_quoted = true;
-			continue;
-		}
-
-		if (character == '[' || character == '(') {
-			++depth;
-			continue;
-		}
-
-		if ((character == ']' || character == ')') && depth > 0) {
-			--depth;
-			continue;
-		}
-
-		if (character == '|' && depth == 0) {
+		if (
+			character != '.' &&
+			!Py_UNICODE_ISSPACE(character) &&
+			!continues_identifier(character)
+		) {
 			return false;
 		}
 	}
 
-	return depth == 0 && !single_quoted && !double_quoted;
+	return true;
 }
 
 static bool top_level_suffix(PyObject * const text, Py_ssize_t const from) {
 	Py_ssize_t const length = PyUnicode_GET_LENGTH(text);
-	int depth = 0;
-	bool single_quoted = false;
-	bool double_quoted = false;
+	Py_ssize_t at = from;
 
-	for (Py_ssize_t at = from; at < length; ++at) {
-		Py_UCS4 const character = PyUnicode_ReadChar(text, at);
+	while (at < length && Py_UNICODE_ISSPACE(PyUnicode_ReadChar(text, at))) {
+		++at;
+	}
 
-		if (single_quoted) {
-			if (character == '\\') {
-				++at;
+	if (at < length && PyUnicode_ReadChar(text, at) == '[') {
+		int depth = 0;
+		bool single_quoted = false;
+		bool double_quoted = false;
+
+		for (; at < length; ++at) {
+			Py_UCS4 const character = PyUnicode_ReadChar(text, at);
+
+			if (single_quoted) {
+				if (character == '\\') {
+					++at;
+					continue;
+				}
+
+				single_quoted = character != '\'';
 				continue;
 			}
 
-			single_quoted = character != '\'';
-			continue;
-		}
+			if (double_quoted) {
+				if (character == '\\') {
+					++at;
+					continue;
+				}
 
-		if (double_quoted) {
-			if (character == '\\') {
-				++at;
+				double_quoted = character != '"';
 				continue;
 			}
 
-			double_quoted = character != '"';
-			continue;
-		}
+			if (character == '\'') {
+				single_quoted = true;
+				continue;
+			}
 
-		if (character == '\'') {
-			single_quoted = true;
-			continue;
-		}
+			if (character == '"') {
+				double_quoted = true;
+				continue;
+			}
 
-		if (character == '"') {
-			double_quoted = true;
-			continue;
-		}
+			if (character == '[') {
+				++depth;
+				continue;
+			}
 
-		if (character == '[' || character == '(') {
-			++depth;
-			continue;
-		}
-
-		if (character == ']' || character == ')') {
-			if (depth > 0) {
+			if (character == ']') {
 				--depth;
-			}
 
-			continue;
+				if (depth == 0) {
+					++at;
+
+					break;
+				}
+			}
 		}
 
-		if (character == '|' && depth == 0) {
+		if (depth != 0) {
 			return false;
 		}
 	}
 
-	return depth == 0 && !single_quoted && !double_quoted;
+	while (at < length && Py_UNICODE_ISSPACE(PyUnicode_ReadChar(text, at))) {
+		++at;
+	}
+
+	return at == length;
 }
 
-static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
+static bool names_form_matching(
+	PyObject * const text,
+	PyObject * const needle,
+	bool const top_only
+) {
 	Py_ssize_t const length = PyUnicode_GET_LENGTH(text);
 	Py_ssize_t const form_length = PyUnicode_GET_LENGTH(needle);
 
@@ -890,8 +882,10 @@ static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
 		if (
 			opens &&
 			closes &&
-			top_level_prefix(text, found) &&
-			top_level_suffix(text, found + form_length)
+			(
+				!top_only ||
+				(top_level_prefix(text, found) && top_level_suffix(text, found + form_length))
+			)
 		) {
 			return true;
 		}
@@ -900,6 +894,14 @@ static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
 	}
 
 	return false;
+}
+
+static bool names_form(PyObject * const text, PyObject * const needle) {
+	return names_form_matching(text, needle, false);
+}
+
+static bool names_form_at_top(PyObject * const text, PyObject * const needle) {
+	return names_form_matching(text, needle, true);
 }
 
 /*

--- a/src/fields.h
+++ b/src/fields.h
@@ -6,14 +6,15 @@
 #include "types.h"
 
 struct field_plan {
-	PyObject * all_names;     /* list[str] */
-	PyObject * new_names;     /* list[str] */
-	PyObject * defaults;      /* tuple */
-	PyObject * annotations;   /* tuple[Any], aligned with all_names */
-	PyObject * metadata;      /* tuple[tuple[Any, ...]], aligned with all_names */
+	PyObject * all_names;        /* list[str] */
+	PyObject * new_names;        /* list[str] */
+	PyObject * class_var_names;  /* list[str] */
+	PyObject * defaults;         /* tuple */
+	PyObject * annotations;      /* tuple[Any], aligned with all_names */
+	PyObject * metadata;         /* tuple[tuple[Any, ...]], aligned with all_names */
 };
 
-/* Owns its five references.  On failure every member is NULL and an
+/* Owns its six references.  On failure every member is NULL and an
  * exception is set. */
 struct field_plan field_plan_build(StructType const * base, PyObject * namespace);
 

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -153,7 +153,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 		verify_settle_names_readable(original_namespace) != RESULT_OK ||
 		refuse_reserved_metadata_names(original_namespace, plan.new_names) != RESULT_OK ||
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
-		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||
+		refuse_mixin_method_fields(plan.all_names, plan.class_var_names) != RESULT_OK ||
 		refuse_slot_name_fields(plan.new_names) != RESULT_OK ||
 		refuse_displaced_slots(
 				original_namespace,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -132,7 +132,7 @@ enum result refuse_colliding_methods(
 	PyObject * all_names,
 	PyObject * class_name
 );
-enum result refuse_mixin_method_fields(PyObject * all_names);
+enum result refuse_mixin_method_fields(PyObject * all_names, PyObject * class_var_names);
 enum result refuse_slot_name_fields(PyObject * all_names);
 enum result refuse_reserved_metadata_names(PyObject * original_namespace, PyObject * new_names);
 

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -477,7 +477,10 @@ static enum result drop_class_variables(PyObject * const namespace, PyObject * c
 	return RESULT_OK;
 }
 
-enum result refuse_mixin_method_fields(PyObject * const all_names) {
+enum result refuse_mixin_method_fields(
+	PyObject * const all_names,
+	PyObject * const class_var_names
+) {
 	PY_OWNED(mixin_dict, struct_type_dict(&StructMixin_Type));
 
 	if (mixin_dict == NULL) {
@@ -494,24 +497,30 @@ enum result refuse_mixin_method_fields(PyObject * const all_names) {
 	}
 
 	Py_ssize_t position = 0;
-	PyObject * field_name;
+	PyObject * mixin_name;
 	PyObject * method;
 
-	while (PyDict_Next(mixin_dict, &position, &field_name, &method)) {
-		int const present = PySequence_Contains(all_names, field_name);
+	while (PyDict_Next(mixin_dict, &position, &mixin_name, &method)) {
+		int const field = PySequence_Contains(all_names, mixin_name);
 
-		if (present < 0) {
+		if (field < 0) {
 			return RESULT_ERROR;
 		}
 
-		if (present == 0) {
+		int const class_var = (field == 0 ? PySequence_Contains(class_var_names, mixin_name) : 0);
+
+		if (class_var < 0) {
+			return RESULT_ERROR;
+		}
+
+		if (field == 0 && class_var == 0) {
 			continue;
 		}
 
 		PY_MOVABLE(spelling, NULL);
 		int const belongs = binding_belongs_to_body(
 			mixin_dict,
-			field_name,
+			mixin_name,
 			mixin_qualname,
 			&spelling
 		);
@@ -523,9 +532,12 @@ enum result refuse_mixin_method_fields(PyObject * const all_names) {
 		if (belongs == 1) {
 			PyErr_Format(
 				PyExc_TypeError,
-				"%U is a field, and the mixin defines a method of the same "
-				"name which the field's descriptor would shadow; rename the field",
-				field_name
+				field == 1
+					? "%U is a field, and the mixin defines a method of the same "
+						"name which the field's descriptor would shadow; rename the field"
+					: "%U is a ClassVar, and the mixin defines a method of the same "
+						"name which the class-variable binding would shadow; rename one of them",
+				mixin_name
 			);
 
 			return RESULT_ERROR;

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -302,7 +302,7 @@ def test_a_non_string_annotation_key_still_gets_the_key_error():
 
 
 def test_a_class_var_named_like_a_mixin_method_is_refused():
-    with pytest.raises(TypeError, match=r"is a ClassVar.*the mixin defines a method"):
+    with pytest.raises(TypeError, match="cannot be a ClassVar: a double-underscore name"):
 
         class Colliding(Struct):
             __copy__: ClassVar[object] = 5
@@ -330,10 +330,27 @@ def test_an_operator_around_the_form_in_text_with_a_value_is_still_refused(annot
 
 
 def test_a_class_var_named_like_salix_machinery_is_refused():
-    with pytest.raises(TypeError, match="cannot be a ClassVar: salix installs its own"):
+    with pytest.raises(TypeError, match="cannot be a ClassVar: a double-underscore name"):
 
         class Colliding(Struct):
             __match_args__: ClassVar[tuple] = ()
+
+
+def test_a_dunder_class_var_without_a_value_reports_the_machinery_refusal():
+    with pytest.raises(TypeError, match="cannot be a ClassVar"):
+
+        class Colliding(Struct):
+            __len__: ClassVar[object]
+
+
+def test_a_keyword_before_the_form_in_text_with_a_value_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "and ClassVar[int]"}, "v": 5})
+
+
+def test_a_two_argument_class_var_in_text_with_a_value_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "ClassVar[int, str]"}, "v": 5})
 
 
 def test_the_text_path_cannot_tell_the_user_s_type_apart():

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -232,7 +232,9 @@ def test_re_annotating_an_inherited_field_with_a_value_replaces_the_default():
     class Sub(Base):
         x: ClassVar[int] = 5
 
+    assert Sub._struct_fields_ == ("x",)
     assert Sub().x == 5
+    assert Sub(99).x == 99
 
 
 def test_re_annotating_an_inherited_field_with_a_mutable_keeps_the_mutable_refusal():
@@ -292,6 +294,38 @@ def test_an_init_var_with_a_shared_mutable_keeps_the_mutable_refusal():
 
         class Seeded(Struct):
             seed: InitVar[int] = ([1],)
+
+
+def test_a_non_string_annotation_key_still_gets_the_key_error():
+    with pytest.raises(TypeError, match="annotation keys must be strings"):
+        type(Struct)("Probe", (Struct,), {"__annotations__": {1: int}})
+
+
+def test_a_class_var_named_like_a_mixin_method_is_refused():
+    with pytest.raises(TypeError, match=r"is a ClassVar.*the mixin defines a method"):
+
+        class Colliding(Struct):
+            __copy__: ClassVar[object] = 5
+
+
+def test_a_class_var_operand_in_text_with_the_form_second_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "None | ClassVar[int]"}, "v": 5})
+
+
+def test_the_text_path_cannot_tell_the_user_s_type_apart():
+    """The spelling heuristic's mirror of the renamed-import hole: text naming
+    ClassVar is kept with a value whether the form or the author's own type is
+    meant, and refused without one.
+    """
+
+    Kept = type(Struct)("Kept", (Struct,), {"__annotations__": {"v": "ClassVar[int]"}, "v": 5})
+
+    assert Kept._struct_fields_ == ()
+    assert Kept.v == 5
+
+    with pytest.raises(TypeError, match="without an assigned value"):
+        type(Struct)("Refused", (Struct,), {"__annotations__": {"v": "ClassVar[int]"}})
 
 
 def test_a_renamed_import_is_not_resolved_in_the_source_text_form():

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -277,6 +277,16 @@ def test_a_quoted_class_var_in_text_with_a_value_is_still_refused():
         type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "'ClassVar[int]'"}, "v": 5})
 
 
+def test_a_class_var_operand_of_a_union_in_text_with_a_value_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "ClassVar[int] | None"}, "v": 5})
+
+
+def test_an_escaped_quote_inside_the_string_does_not_end_it():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "'a\\'b ClassVar[int]'"}, "v": 5})
+
+
 def test_an_init_var_with_a_shared_mutable_keeps_the_mutable_refusal():
     with pytest.raises(TypeError, match="type hashes and whose value will not"):
 

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -313,6 +313,29 @@ def test_a_class_var_operand_in_text_with_the_form_second_is_still_refused():
         type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "None | ClassVar[int]"}, "v": 5})
 
 
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "ClassVar[int] or None",
+        "ClassVar[int] + int",
+        "ClassVar[int] & int",
+        "(ClassVar[int])",
+        "ClassVar[int][str]",
+    ],
+    ids=["or", "plus", "ampersand", "parenthesized", "double-subscript"],
+)
+def test_an_operator_around_the_form_in_text_with_a_value_is_still_refused(annotation):
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": annotation}, "v": 5})
+
+
+def test_a_class_var_named_like_salix_machinery_is_refused():
+    with pytest.raises(TypeError, match="cannot be a ClassVar: salix installs its own"):
+
+        class Colliding(Struct):
+            __match_args__: ClassVar[tuple] = ()
+
+
 def test_the_text_path_cannot_tell_the_user_s_type_apart():
     """The spelling heuristic's mirror of the renamed-import hole: text naming
     ClassVar is kept with a value whether the form or the author's own type is

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -47,7 +47,7 @@ def test_a_class_var_holding_a_mutable_is_the_constant_it_was_written_as():
 
 
 def test_a_bare_class_var_is_refused():
-    with pytest.raises(TypeError, match="annotated ClassVar"):
+    with pytest.raises(TypeError, match="without an assigned value"):
 
         class Bare(Struct):
             marker: ClassVar
@@ -223,6 +223,65 @@ def test_re_annotating_an_inherited_field_stays_a_no_op():
 
     assert Sub._struct_fields_ == ("x",)
     assert Sub(1).x == 1
+
+
+def test_re_annotating_an_inherited_field_with_a_value_replaces_the_default():
+    class Base(Struct):
+        x: int = 3
+
+    class Sub(Base):
+        x: ClassVar[int] = 5
+
+    assert Sub().x == 5
+
+
+def test_re_annotating_an_inherited_field_with_a_mutable_keeps_the_mutable_refusal():
+    class Base(Struct):
+        x: int = 3
+
+    with pytest.raises(TypeError, match="type hashes and whose value will not"):
+
+        class Sub(Base):
+            x: ClassVar[list] = ([1],)
+
+
+def test_re_annotating_an_inherited_class_var_without_a_value_is_refused():
+    class Base(Struct):
+        limit: ClassVar[int] = 10
+        name: str
+
+    with pytest.raises(TypeError, match="without an assigned value"):
+
+        class Sub(Base):
+            limit: ClassVar[int]
+
+
+def test_a_nested_class_var_with_a_value_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)(
+            "Wrapped",
+            (Struct,),
+            {"__annotations__": {"v": Annotated[ClassVar[int], "meta"]}, "v": 5},
+        )
+
+
+def test_a_nested_class_var_in_text_with_a_value_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)(
+            "Wrapped", (Struct,), {"__annotations__": {"v": "Optional[ClassVar[int]]"}, "v": 5}
+        )
+
+
+def test_a_quoted_class_var_in_text_with_a_value_is_still_refused():
+    with pytest.raises(TypeError, match="which salix does not support"):
+        type(Struct)("Wrapped", (Struct,), {"__annotations__": {"v": "'ClassVar[int]'"}, "v": 5})
+
+
+def test_an_init_var_with_a_shared_mutable_keeps_the_mutable_refusal():
+    with pytest.raises(TypeError, match="type hashes and whose value will not"):
+
+        class Seeded(Struct):
+            seed: InitVar[int] = ([1],)
 
 
 def test_a_renamed_import_is_not_resolved_in_the_source_text_form():

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -7,16 +7,43 @@ import pytest
 from salix import Struct
 
 
-def test_a_class_var_is_refused():
-    """The shape a dataclass port arrives with, which used to fail with a
-    message about default ordering that never mentioned ClassVar.
+def test_a_class_var_is_kept_and_not_a_field():
+    """The shape a dataclass port arrives with: the annotated binding stays in
+    the class dict, and the name never enters the field plan.
     """
 
-    with pytest.raises(TypeError, match="annotated ClassVar"):
+    class Registry(Struct):
+        instances: ClassVar[list] = []
+        name: str
 
-        class Registry(Struct):
-            instances: ClassVar[list] = []
-            name: str
+    assert Registry._struct_fields_ == ("name",)
+    assert Registry.instances == []
+    assert Registry("x").instances == []
+
+
+def test_a_class_var_is_excluded_from_every_metadata_table():
+    class Tagged(Struct):
+        limit: ClassVar[int] = 10
+        name: str
+
+    assert Tagged._struct_fields_ == ("name",)
+    assert Tagged._struct_defaults_ == ()
+    assert Tagged._struct_annotations_ == (str,)
+    assert Tagged.__match_args__ == ("name",)
+    assert Tagged.limit == 10
+    assert Tagged("x").limit == 10
+
+
+def test_a_class_var_holding_a_mutable_is_the_constant_it_was_written_as():
+    """The shared-mutable refusal is a field rule; a ClassVar declares the
+    sharing, so the unannotated path's semantics apply.
+    """
+
+    class Registry(Struct):
+        instances: ClassVar[list] = [1]
+
+    assert Registry._struct_fields_ == ()
+    assert Registry.instances == [1]
 
 
 def test_a_bare_class_var_is_refused():
@@ -34,7 +61,7 @@ def test_an_init_var_is_refused():
 
 
 def test_each_says_what_to_do_instead():
-    with pytest.raises(TypeError, match="without an annotation"):
+    with pytest.raises(TypeError, match="without an assigned value"):
         type(Struct)("A", (Struct,), {"__annotations__": {"v": ClassVar[int]}})
 
     with pytest.raises(TypeError, match="set_field"):
@@ -223,28 +250,45 @@ def test_a_plain_annotated_is_still_a_field():
     assert Tagged(1, []).v == 1
 
 
-@pytest.mark.parametrize("FORM", [ClassVar, InitVar], ids=["ClassVar", "InitVar"])
-def test_a_real_future_annotations_module_takes_the_text_path(tmp_path, FORM):
+def test_a_real_future_annotations_module_keeps_the_class_var(tmp_path):
     """Every other text-path case here hands salix a string it built itself.
     This one makes the compiler produce the annotations, which is the only way
-    to know the path is reachable the way a user reaches it -- and both forms
-    go through it, because what the compiler stores is the source text and the
-    two forms are different text.
+    to know the path is reachable the way a user reaches it.
     """
 
     module = tmp_path / "future_struct.py"
     module.write_text(
         "from __future__ import annotations\n"
-        f"from {FORM.__module__} import {FORM.__name__}\n"
+        "from typing import ClassVar\n"
         "from salix import Struct\n"
         "\n"
         "class Registry(Struct):\n"
-        f"    instances: {FORM.__name__}[list] = []\n"
+        "    instances: ClassVar[list] = []\n"
+        "    name: str\n"
+    )
+    namespace: dict[str, object] = {"__name__": "future_struct"}
+
+    exec(compile(module.read_text(), str(module), "exec"), namespace)
+    Registry = namespace["Registry"]
+
+    assert Registry._struct_fields_ == ("name",)  # type: ignore[attr-defined]
+    assert Registry.instances == []  # type: ignore[attr-defined]
+
+
+def test_a_real_future_annotations_module_takes_the_text_path_for_init_var(tmp_path):
+    module = tmp_path / "future_init_var.py"
+    module.write_text(
+        "from __future__ import annotations\n"
+        "from dataclasses import InitVar\n"
+        "from salix import Struct\n"
+        "\n"
+        "class Seeded(Struct):\n"
+        "    seed: InitVar[int] = 0\n"
         "    name: str\n"
     )
 
-    with pytest.raises(TypeError, match=f"annotated {FORM.__name__}"):
-        exec(compile(module.read_text(), str(module), "exec"), {"__name__": "future_struct"})
+    with pytest.raises(TypeError, match="annotated InitVar"):
+        exec(compile(module.read_text(), str(module), "exec"), {"__name__": "future_init_var"})
 
 
 def test_a_real_future_annotations_module_still_builds_ordinary_fields():

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TypeVar
 
 from typing_extensions import assert_type
 
@@ -13,6 +13,11 @@ class Point(Struct):
 class Defaulted(Struct):
     a: int
     b: str = "b"
+
+
+class Constants(Struct):
+    limit: ClassVar[int] = 10
+    name: str
 
 
 class Mutable(Struct, frozen=False):
@@ -47,6 +52,12 @@ def the_constructor_is_synthesised_from_the_annotations() -> None:
 def a_default_makes_its_argument_optional() -> None:
     assert_type(Defaulted(1).b, str)
     assert_type(Defaulted(1, "other").b, str)
+
+
+def a_class_var_is_a_class_attribute_and_not_a_constructor_argument() -> None:
+    assert_type(Constants.limit, int)
+    assert_type(Constants("x").limit, int)
+    assert_type(Constants("x").name, str)
 
 
 def a_mutable_struct_accepts_a_write() -> None:


### PR DESCRIPTION
**#134** — `x: ClassVar[int] = 5` becomes the typed equivalent of the unannotated class-body assignment, per JPH's ruling on the issue (no default → refused: a class variable is a constant).

## What changed

The probe's answer flips: wherever `special_form_of` answers ClassVar (object path or text path), the name is **excluded from the field plan instead of refused** — the binding stays in the class dict, and the constructor, slots, `__match_args__`, and every metadata table exclude it. The shared-mutable refusal no longer applies to it: that check is a field rule, and the ClassVar annotation declares the sharing.

## Decisions, and where they come from

<details><summary>Rulings and semantics table</summary>

| shape | before | after |
| --- | --- | --- |
| `x: ClassVar[T] = value` | refused | kept, not a field |
| `x: ClassVar` / no value | refused (unsupported) | refused: "without an assigned value; a class variable is a constant, so assign the value in the class body" |
| `x: ClassVar[list] = [1]` (shared mutable) | refused (shared-mutable) | kept — the unannotated path's semantics |
| reserved metadata name as ClassVar | reserved refusal | reserved refusal (outranks) |
| subclass re-annotating an inherited field | no-op | no-op (inheritance check runs first) |
| `InitVar` | refused | refused (unchanged) |
| ClassVar nested in another annotation | refused | **excluded-and-kept** — the issue's "the probe's answer becomes exclude and keep" applied literally, not top-level-only. The with-default nested shape is unpinned either way. |

</details>

## Verified

- Live probe: fields/defaults/annotations/`__match_args__` all exclude the name; class and instance attribute reads agree; the no-default and reserved-outrank refusals fire with the expected messages.
- Full gate green: pytest 3.10–3.15 + free-threaded, c_test, analyzers, ruff, and mypy/pyright/ty — no stub change needed: PEP 681's `dataclass_transform` already teaches all three checkers that a ClassVar-annotated name is not a field; `accepted.py` pins it.
- All existing refusal pins survive the flip: every nested/bare shape in `test_special_forms.py` and `test_classvar_paths.py` still refuses, via the no-default rule.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was JPH's "what are the chances of taking this on" for #134; the scope assessment (high — the machinery already implements the target semantics) led to this implementation.

closes #134 