### PR TITLE
chore: fold the recorded nits from the #145/#147 convergence rounds

### DIFF
--- a/src/fields.c
+++ b/src/fields.c
@@ -53,7 +53,6 @@ static enum result append_declared(
 	PyObject * namespace,
 	PyObject * all_names,
 	PyObject * new_names,
-	PyObject * class_var_names,
 	PyObject * default_by_name,
 	PyObject * annotation_values,
 	PyObject * metadata_values,
@@ -159,7 +158,6 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 
 	PY_MOVABLE(all_names, PyList_New(0));
 	PY_MOVABLE(new_names, PyList_New(0));
-	PY_MOVABLE(class_var_names, PyList_New(0));
 	PY_MOVABLE(annotation_values, PyList_New(0));
 	PY_MOVABLE(metadata_values, PyList_New(0));
 	PY_OWNED(default_by_name, PyDict_New());
@@ -168,7 +166,6 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 	if (
 		all_names != NULL &&
 		new_names != NULL &&
-		class_var_names != NULL &&
 		annotation_values != NULL &&
 		metadata_values != NULL &&
 		default_by_name != NULL &&
@@ -181,7 +178,6 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 				namespace,
 				all_names,
 				new_names,
-				class_var_names,
 				default_by_name,
 				annotation_values,
 				metadata_values,
@@ -199,7 +195,6 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 			plan.metadata = built_metadata;
 			plan.all_names = py_move(&all_names);
 			plan.new_names = py_move(&new_names);
-			plan.class_var_names = py_move(&class_var_names);
 		} else {
 			Py_XDECREF(built_defaults);
 			Py_XDECREF(built_annotations);
@@ -213,7 +208,6 @@ struct field_plan field_plan_build(StructType const * const base, PyObject * con
 void field_plan_clear(struct field_plan * const plan) {
 	Py_CLEAR(plan->all_names);
 	Py_CLEAR(plan->new_names);
-	Py_CLEAR(plan->class_var_names);
 	Py_CLEAR(plan->defaults);
 	Py_CLEAR(plan->annotations);
 	Py_CLEAR(plan->metadata);
@@ -356,7 +350,6 @@ static enum result append_declared(
 	PyObject * const namespace,
 	PyObject * const all_names,
 	PyObject * const new_names,
-	PyObject * const class_var_names,
 	PyObject * const default_by_name,
 	PyObject * const annotation_values,
 	PyObject * const metadata_values,
@@ -461,6 +454,13 @@ static enum result append_declared(
 			}
 
 			if (!top_level) {
+				if (
+					declared_default != NULL &&
+					refuse_shared_mutable_contents(field_name, declared_default) != RESULT_OK
+				) {
+					return RESULT_ERROR;
+				}
+
 				PyErr_Format(
 					PyExc_TypeError,
 					"'%U' is annotated %s, which salix does not support; "
@@ -491,10 +491,6 @@ static enum result append_declared(
 					CLASS_VAR_FORM.instead
 				);
 
-				return RESULT_ERROR;
-			}
-
-			if (PyList_Append(class_var_names, field_name) < 0) {
 				return RESULT_ERROR;
 			}
 

--- a/src/fields.h
+++ b/src/fields.h
@@ -6,15 +6,14 @@
 #include "types.h"
 
 struct field_plan {
-	PyObject * all_names;        /* list[str] */
-	PyObject * new_names;        /* list[str] */
-	PyObject * class_var_names;  /* list[str] */
-	PyObject * defaults;         /* tuple */
-	PyObject * annotations;      /* tuple[Any], aligned with all_names */
-	PyObject * metadata;         /* tuple[tuple[Any, ...]], aligned with all_names */
+	PyObject * all_names;      /* list[str] */
+	PyObject * new_names;      /* list[str] */
+	PyObject * defaults;       /* tuple */
+	PyObject * annotations;    /* tuple[Any], aligned with all_names */
+	PyObject * metadata;       /* tuple[tuple[Any, ...]], aligned with all_names */
 };
 
-/* Owns its six references.  On failure every member is NULL and an
+/* Owns its five references.  On failure every member is NULL and an
  * exception is set. */
 struct field_plan field_plan_build(StructType const * base, PyObject * namespace);
 

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -153,7 +153,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 		verify_settle_names_readable(original_namespace) != RESULT_OK ||
 		refuse_reserved_metadata_names(original_namespace, plan.new_names) != RESULT_OK ||
 		refuse_colliding_methods(original_namespace, plan.all_names, name) != RESULT_OK ||
-		refuse_mixin_method_fields(plan.all_names, plan.class_var_names) != RESULT_OK ||
+		refuse_mixin_method_fields(plan.all_names) != RESULT_OK ||
 		refuse_slot_name_fields(plan.new_names) != RESULT_OK ||
 		refuse_displaced_slots(
 				original_namespace,

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -132,7 +132,7 @@ enum result refuse_colliding_methods(
 	PyObject * all_names,
 	PyObject * class_name
 );
-enum result refuse_mixin_method_fields(PyObject * all_names, PyObject * class_var_names);
+enum result refuse_mixin_method_fields(PyObject * all_names);
 enum result refuse_slot_name_fields(PyObject * all_names);
 enum result refuse_reserved_metadata_names(PyObject * original_namespace, PyObject * new_names);
 

--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -477,10 +477,7 @@ static enum result drop_class_variables(PyObject * const namespace, PyObject * c
 	return RESULT_OK;
 }
 
-enum result refuse_mixin_method_fields(
-	PyObject * const all_names,
-	PyObject * const class_var_names
-) {
+enum result refuse_mixin_method_fields(PyObject * const all_names) {
 	PY_OWNED(mixin_dict, struct_type_dict(&StructMixin_Type));
 
 	if (mixin_dict == NULL) {
@@ -497,30 +494,24 @@ enum result refuse_mixin_method_fields(
 	}
 
 	Py_ssize_t position = 0;
-	PyObject * mixin_name;
+	PyObject * field_name;
 	PyObject * method;
 
-	while (PyDict_Next(mixin_dict, &position, &mixin_name, &method)) {
-		int const field = PySequence_Contains(all_names, mixin_name);
+	while (PyDict_Next(mixin_dict, &position, &field_name, &method)) {
+		int const present = PySequence_Contains(all_names, field_name);
 
-		if (field < 0) {
+		if (present < 0) {
 			return RESULT_ERROR;
 		}
 
-		int const class_var = (field == 0 ? PySequence_Contains(class_var_names, mixin_name) : 0);
-
-		if (class_var < 0) {
-			return RESULT_ERROR;
-		}
-
-		if (field == 0 && class_var == 0) {
+		if (present == 0) {
 			continue;
 		}
 
 		PY_MOVABLE(spelling, NULL);
 		int const belongs = binding_belongs_to_body(
 			mixin_dict,
-			mixin_name,
+			field_name,
 			mixin_qualname,
 			&spelling
 		);
@@ -532,12 +523,9 @@ enum result refuse_mixin_method_fields(
 		if (belongs == 1) {
 			PyErr_Format(
 				PyExc_TypeError,
-				field == 1
-					? "%U is a field, and the mixin defines a method of the same "
-						"name which the field's descriptor would shadow; rename the field"
-					: "%U is a ClassVar, and the mixin defines a method of the same "
-						"name which the class-variable binding would shadow; rename one of them",
-				mixin_name
+				"%U is a field, and the mixin defines a method of the same "
+				"name which the field's descriptor would shadow; rename the field",
+				field_name
 			);
 
 			return RESULT_ERROR;
@@ -570,11 +558,7 @@ enum result refuse_colliding_methods(
 			PY_OWNED(bound, dict_value_ref(original_namespace, field_name));
 
 			if (bound == NULL) {
-				if (PyErr_Occurred()) {
-					return RESULT_ERROR;
-				}
-
-				continue;
+				return RESULT_ERROR;
 			}
 
 			PyErr_Format(

--- a/tests/test_special_forms.py
+++ b/tests/test_special_forms.py
@@ -267,6 +267,15 @@ def test_a_nested_class_var_with_a_value_is_still_refused():
         )
 
 
+def test_a_nested_class_var_with_a_shared_mutable_keeps_the_mutable_diagnosis():
+    with pytest.raises(TypeError, match="type hashes and whose value will not"):
+        type(Struct)(
+            "Wrapped",
+            (Struct,),
+            {"__annotations__": {"v": Annotated[ClassVar[list], "meta"]}, "v": ([1],)},
+        )
+
+
 def test_a_nested_class_var_in_text_with_a_value_is_still_refused():
     with pytest.raises(TypeError, match="which salix does not support"):
         type(Struct)(


### PR DESCRIPTION
The convergence dispositions from #145 and #147, folded:

- **Dropped the unreachable mixin ClassVar branch** — the dunder shape test in the plan loop fires before the mixin guard for every mixin method name, so `class_var_names` (plan member, parameter, the ClassVar message branch) was dead. If a non-dunder mixin method ever appears, the guard needs restoring for that name — recorded in the commit rather than in dead code.
- **Dropped the dead NULL-without-error `continue`** on `refuse_colliding_methods`' refusal-path refetch — a belonging verdict implies the helper held the binding, so a NULL refetch can only be a failure.
- **Restored the shared-mutable diagnosis** for a nested ClassVar with a shared-mutable default (the message it had before the flip), pinned.

Full gate green: 3.10–3.15, free-threading, c_test, analyzers, all type checkers.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was the review-loop queue: fold the nits recorded at the converged rounds' dispositions into a residue PR.