### PR TITLE
fix: frozen writes raise AttributeError, matching every frozen thing (#24)

### DIFF
--- a/src/mixin.c
+++ b/src/mixin.c
@@ -702,8 +702,8 @@ static int Struct_set_attribute(
 	}
 
 	PyErr_Format(
-		PyExc_TypeError,
-		"%.200s object does not support attribute %s",
+		PyExc_AttributeError,
+		"'%.200s' object does not support attribute %s",
 		Py_TYPE(self)->tp_name,
 		value == NULL ? "deletion" : "assignment"
 	);

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -160,7 +160,7 @@ def observe(cls: type) -> Behaviour:
     try:
         setattr(instance(cls), cls.__struct_fields__[0], 99)
         frozen = False
-    except (TypeError, IndexError):
+    except (AttributeError, IndexError):
         frozen = True
 
     return Behaviour(

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -209,7 +209,7 @@ def test_a_frozen_struct_with_a_body_init_cannot_write_its_fields():
         def __init__(self) -> None:
             self.x = 1
 
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         Frozen()
 
 

--- a/tests/test_metadata_names.py
+++ b/tests/test_metadata_names.py
@@ -52,7 +52,7 @@ def test_neither_spelling_may_be_assigned(name):
     with pytest.raises(AttributeError):
         setattr(Point, name, ("z",))
 
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         setattr(Point(1), name, ("z",))
 
 

--- a/tests/test_multiple_bases.py
+++ b/tests/test_multiple_bases.py
@@ -159,7 +159,7 @@ class TestWhichBaseAnswers:
         class Both(MutableFieldless, WithFields):
             c: int
 
-        with pytest.raises(TypeError, match="does not support attribute assignment"):
+        with pytest.raises(AttributeError, match="does not support attribute assignment"):
             Both(1, 2, 3).a = 99
 
         with pytest.raises(TypeError, match="mutable struct cannot inherit"):
@@ -181,7 +181,7 @@ class TestWhichBaseAnswers:
         class Strengthened(FrozenFieldless, MutableFields, frozen=True):
             c: int
 
-        with pytest.raises(TypeError, match="does not support attribute assignment"):
+        with pytest.raises(AttributeError, match="does not support attribute assignment"):
             Strengthened(1, 2).a = 99
 
     def test_a_repr_less_base_in_front_takes_the_repr_with_it(self):

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -17,10 +17,10 @@ class Mutable(Struct, frozen=False):
 
 
 def test_a_struct_is_frozen_unless_it_says_otherwise():
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         Frozen(1).x = 9
 
-    with pytest.raises(TypeError, match="does not support attribute deletion"):
+    with pytest.raises(AttributeError, match="does not support attribute deletion"):
         del Frozen(1).x
 
 
@@ -28,7 +28,7 @@ def test_frozen_true_is_accepted_and_is_the_default_anyway():
     class Explicit(Struct, frozen=True):
         x: int
 
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         Explicit(1).x = 9
 
 
@@ -112,7 +112,7 @@ def test_frozenness_is_inherited():
     class Child(Frozen):
         z: int = 3
 
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         Child(1, 2, 3).z = 9
 
 
@@ -133,7 +133,7 @@ def test_a_frozen_struct_may_strengthen_a_mutable_one():
 
     instance = Child(1)
 
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         instance.x = 9
 
     assert instance == Child(1)
@@ -155,10 +155,10 @@ def test_frozen_true_over_a_mutable_base_holds_beside_a_permissive_co_base():
         pass
 
     for Child in (Ahead, Behind):
-        with pytest.raises(TypeError, match="does not support attribute"):
+        with pytest.raises(AttributeError, match="does not support attribute"):
             Child(1).x = 9
 
-        with pytest.raises(TypeError, match="does not support attribute"):
+        with pytest.raises(AttributeError, match="does not support attribute"):
             del Child(1).x
 
 
@@ -184,10 +184,10 @@ def test_a_frozen_child_of_a_frozen_base_holds_beside_a_permissive_co_base():
     for Child in (Ahead, Behind):
         assert "__setattr__" in Child.__dict__
 
-        with pytest.raises(TypeError, match="does not support attribute"):
+        with pytest.raises(AttributeError, match="does not support attribute"):
             Child(1).x = 9
 
-        with pytest.raises(TypeError, match="does not support attribute"):
+        with pytest.raises(AttributeError, match="does not support attribute"):
             del Child(1).x
 
 
@@ -222,7 +222,7 @@ def test_a_frozen_setattr_escape_beside_a_permissive_co_base_keeps_answering():
 
             assert instance.x == 9
 
-            with pytest.raises(TypeError, match="does not support attribute"):
+            with pytest.raises(AttributeError, match="does not support attribute"):
                 del instance.x
         else:
             # The parent build refuses the escape the same way on 3.10-3.12:
@@ -231,7 +231,7 @@ def test_a_frozen_setattr_escape_beside_a_permissive_co_base_keeps_answering():
             with pytest.raises(TypeError):
                 Child(1).x = 9
 
-            with pytest.raises(TypeError):
+            with pytest.raises(AttributeError):
                 del Child(1).x
 
     class Escaping(FrozenBase):
@@ -241,7 +241,7 @@ def test_a_frozen_setattr_escape_beside_a_permissive_co_base_keeps_answering():
     class InheritedAhead(Permissive, Escaping):
         pass
 
-    with pytest.raises(TypeError, match="does not support attribute"):
+    with pytest.raises(AttributeError, match="does not support attribute"):
         InheritedAhead(1).x = 9
 
 
@@ -268,13 +268,13 @@ def test_a_frozen_delattr_escape_beside_a_permissive_co_base_keeps_answering():
         if sys.version_info >= (3, 13):
             del Child(1).x
 
-            with pytest.raises(TypeError, match="does not support attribute"):
+            with pytest.raises(AttributeError, match="does not support attribute"):
                 Child(1).x = 9
         else:
             with pytest.raises(TypeError):
                 del Child(1).x
 
-            with pytest.raises(TypeError):
+            with pytest.raises(AttributeError):
                 Child(1).x = 9
 
 
@@ -348,8 +348,12 @@ def test_a_frozen_structs_body_delattr_keeps_answering():
             deleted.append(name)
 
     for Child in (Single, Strengthened):
-        with pytest.raises(TypeError):
-            Child(1).x = 9
+        if sys.version_info >= (3, 13) or Child is Single:
+            with pytest.raises(AttributeError):
+                Child(1).x = 9
+        else:
+            with pytest.raises(TypeError):
+                Child(1).x = 9
 
         del Child(1).x
 
@@ -420,7 +424,7 @@ def test_a_child_of_a_fieldless_mutable_base_may_freeze_itself():
     class Child(Fieldless, frozen=True):
         x: int
 
-    with pytest.raises(TypeError, match="does not support attribute assignment"):
+    with pytest.raises(AttributeError, match="does not support attribute assignment"):
         Child(1).x = 9
 
     assert hash(Child(1)) == hash((1,))

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -70,9 +70,9 @@ def test_defaults():
 
 def test_immutable():
     p = Point2D(1.0, 2.0)
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         p.x = 9.0
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         del p.x
 
 

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -534,7 +534,7 @@ class TestAMetaclassSubclass:
 
         Built = META("Built", (Base,), {"__annotations__": {}}, frozen=True)
 
-        with pytest.raises(TypeError, match="does not support attribute"):
+        with pytest.raises(AttributeError, match="does not support attribute"):
             Built(1).x = 9
 
     def test_a_delegate_that_swallows_the_options_gets_the_displaced_slot_advice(self):


### PR DESCRIPTION
**#24** — writing to a frozen struct now raises `AttributeError`, matching a frozen dataclass, a read-only property, a namedtuple field, and a slotted class — the exception an `except AttributeError:` is written for. The message also quotes the type name the way CPython does everywhere else.

## Scope

- `Struct_set_attribute`'s refusal: `PyExc_TypeError` → `PyExc_AttributeError` for both assignment and deletion; message becomes `'P' object does not support attribute assignment`.
- The `__orig_class__` carve-out is untouched.
- Twenty pins flip in the suite. Where 3.10–3.12 already split the escaped-shape tests (the slot wrapper's own `can't apply this __setattr__` TypeError for the body-hook half), the split is per operation now: the half salix answers is the new `AttributeError` on every version, the slot half stays `TypeError`.
- The base-combinations classifier (`observe`) catches `AttributeError` for the frozen column.

## Noted, not this PR

`test_base_combinations.py` has a `strict=False` xfail (`test_a_single_base_asking_to_drop_an_inherited_weakref_slot_is_the_same_bug`) that xpasses — its marker says to flip it when the behavior changes; the weakref refusal is class-creation machinery this PR never touches, so it stays as-is.

Full gate green: 3.10–3.15, free-threading, c_test, analyzers, all type checkers.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was the review-loop queue: take #24 from the open-issue list, implement its table's ruling, and drive it through the loop.