### PR TITLE
chore: fold the nits flagged by the #150/#151 dispositions

### DIFF
--- a/src/meta/namespace.c
+++ b/src/meta/namespace.c
@@ -558,7 +558,11 @@ enum result refuse_colliding_methods(
 			PY_OWNED(bound, dict_value_ref(original_namespace, field_name));
 
 			if (bound == NULL) {
-				return RESULT_ERROR;
+				if (PyErr_Occurred()) {
+					return RESULT_ERROR;
+				}
+
+				continue;
 			}
 
 			PyErr_Format(

--- a/src/mixin.c
+++ b/src/mixin.c
@@ -697,7 +697,7 @@ static int Struct_set_attribute(
 		return PyObject_GenericSetAttr(self, name, value);
 	}
 
-	if (PyUnicode_CompareWithASCIIString(name, "__orig_class__") == 0) {
+	if (PyUnicode_Check(name) && PyUnicode_CompareWithASCIIString(name, "__orig_class__") == 0) {
 		return 0;
 	}
 

--- a/tests/test_base_combinations.py
+++ b/tests/test_base_combinations.py
@@ -160,7 +160,7 @@ def observe(cls: type) -> Behaviour:
     try:
         setattr(instance(cls), cls.__struct_fields__[0], 99)
         frozen = False
-    except (AttributeError, IndexError):
+    except (TypeError, AttributeError, IndexError):
         frozen = True
 
     return Behaviour(


### PR DESCRIPTION
The three nits the #150 and #151 convergence dispositions flagged for folding:

- The base-combination classifier's write probe catches `TypeError` again beside `AttributeError`/`IndexError`, mirroring `deletes()`, so a future combination reaching the 3.10–3.12 slot wrapper cannot misclassify frozen as mutable. (The why lives in the commit message; the repo's no-new-comments rule keeps it out of the code.)
- The `__orig_class__` carve-out guards its name with `PyUnicode_Check`, removing the unchecked-path risk: in release builds `PyUnicode_CompareWithASCIIString` reads a non-str as a unicode. The 3.13-only `PyUnicode_EqualToUTF8` the reviewer named was measured unavailable on 3.10–3.12 and not used.
- `refuse_colliding_methods` restores the separated error discipline on its refusal-path refetch.

Full gate green: 3.10–3.15, free-threading, c_test, analyzers, all type checkers.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. The prompt was the review-loop queue: fold the nits flagged in the prior converged PRs' dispositions into a residue PR.