### PR TITLE
README as the PyPI landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,68 @@ Point(x=1.0, y=2.0)
 
 ```
 
+## Install
+
+```sh
+pip install salix
+```
+
+Wheels are published for every supported CPython — including the
+free-threaded builds — on every platform PyPI carries. salix supports CPython
+3.10 through 3.15. A machine PyPI has no wheel for compiles the sdist, which
+needs setuptools and a C compiler. PyPy and GraalPy satisfy the version floor
+but cannot compile the C source, and have no wheels.
+
+## What salix is and is not
+
+A struct's fields are the annotated names of its class body, and the
+constructor takes them in that order. Instances are frozen by default: reads,
+value equality, hashing, and a repr come with the class; writes do not.
+Inheritance extends the plan — a subclass adds its fields after its base's —
+and the metadata reads back: `_struct_fields_`, `_struct_defaults_`,
+`_struct_annotations_`, and `_struct_metadata_`, with `__`-prefixed spellings
+of the same four names answering the same values.
+
+The keywords select out of the default. `frozen=False` opens the record for
+writes. `eq=False` drops the value equality and hashing, leaving identity.
+`order=True` adds the field-order comparisons and requires `eq=True`.
+`repr=False`, `match_args`, and `weakref` stand in for the `__repr__`, the
+pattern-matching signature, and the `__weakref__` slot.
+
+salix is not the libraries that do more. `dataclasses` builds the same record
+in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
+on top. `NamedTuple` is the tuple-shaped ancestor. `msgspec` is a
+serialization library whose `Struct` validates. salix does the record and
+nothing else — no serialization, no validation, no coercion — in C, which is
+where its import and type-creation times come from. Programs that need those
+features need those libraries; salix is for the ones that only need the
+record.
+
+## Defaults
+
+An empty default of `list`, `dict`, `set`, or `bytearray` is copied per
+instance, not shared:
+
+```python
+>>> class Box(Struct):
+...     items: list = []
+
+>>> left, right = Box(), Box()
+>>> left.items.append("left")
+>>> right.items
+[]
+
+```
+
+The copy preserves the exact type or it is not a copy — a `defaultdict` copy
+would be a plain `dict` — so the rule stops at the four, and a subclass of one
+of them is shared. A non-empty default of the four is refused at class
+creation, because a copy can only be shallow and the contents would still be
+shared: default it empty and fill it in `__post_init__` with `set_field`.
+`__struct_defaults__` holds the class's own copy, severed from whatever the
+class body named: appending to the module-level object afterwards does not
+reach the class.
+
 ## ClassVar and InitVar
 
 A name annotated `ClassVar[...]` at the top level is a class variable:
@@ -91,9 +153,6 @@ from a struct base that defines `__eq__`. An `__init__` that is not
 constructor that runs `__post_init__`, so the field answer only works
 without one. The table and the caching behaviors above are pinned in
 `tests/test_classvar_paths.py`.
-
-`salix/__init__.pyi` is the API. `src/salix.c` says what this is and is
-not. `tasks.py` is what runs. `uv run camas benchmark` says what it costs.
 
 ## Working in the repo
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ Point(x=1.0, y=2.0)
 pip install salix
 ```
 
-Wheels are published for every supported CPython — including the
-free-threaded builds — on every platform PyPI carries. salix supports CPython
-3.10 through 3.15. A machine PyPI has no wheel for compiles the sdist, which
-needs setuptools and a C compiler. PyPy and GraalPy satisfy the version floor
+Wheels are published for Windows, macOS, and glibc Linux on x86_64 and
+arm64, for the supported CPythons whose ABI is frozen — a release or an rc.
+A pre-release interpreter's wheels are built and tested but held back until
+its rc. salix supports CPython 3.10 through 3.15, including the free-threaded
+builds. The full matrix is `nix/python-targets.nix`; a configuration missing
+from it has no wheel. A machine PyPI has no wheel for compiles the sdist,
+which needs setuptools and a C compiler — on every OS but Windows, where
+MSVC cannot compile this source. PyPy and GraalPy satisfy the version floor
 but cannot compile the C source, and have no wheels.
 
 ## What salix is and is not
@@ -40,8 +44,9 @@ of the same four names answering the same values.
 The keywords select out of the default. `frozen=False` opens the record for
 writes. `eq=False` drops the value equality and hashing, leaving identity.
 `order=True` adds the field-order comparisons and requires `eq=True`.
-`repr=False`, `match_args`, and `weakref` stand in for the `__repr__`, the
-pattern-matching signature, and the `__weakref__` slot.
+`repr`, `match_args`, and `weakref` default to `True`, `True`, and `False`
+and stand in for the `__repr__`, the pattern-matching signature, and the
+`__weakref__` slot.
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
@@ -50,7 +55,7 @@ serialization library whose `Struct` validates. salix does the record and
 nothing else — no serialization, no validation, no coercion — in C, which is
 where its import and type-creation times come from. Programs that need those
 features need those libraries; salix is for the ones that only need the
-record.
+record. `salix/__init__.pyi` is the whole of the API.
 
 ## Defaults
 
@@ -70,12 +75,14 @@ instance, not shared:
 
 The copy preserves the exact type or it is not a copy — a `defaultdict` copy
 would be a plain `dict` — so the rule stops at the four, and a subclass of one
-of them is shared. A non-empty default of the four is refused at class
-creation, because a copy can only be shallow and the contents would still be
-shared: default it empty and fill it in `__post_init__` with `set_field`.
-`__struct_defaults__` holds the class's own copy, severed from whatever the
-class body named: appending to the module-level object afterwards does not
-reach the class.
+of them is stored as the class body's object itself, shared. A non-empty
+default of the four is refused at class creation, because a copy can only be
+shallow and the contents would still be shared: default it empty and fill it
+in `__post_init__` with `set_field`. For the four, `__struct_defaults__`
+holds the class's own copy, severed from whatever the class body named:
+appending to the module-level object afterwards does not reach the class.
+The getters hand the stored objects out, not copies: do not mutate what
+`__struct_defaults__` returns.
 
 ## ClassVar and InitVar
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,16 @@ Point(x=1.0, y=2.0)
 pip install salix
 ```
 
-Wheels are published for Windows, macOS, and glibc Linux on x86_64 and
-arm64, for the supported CPythons whose ABI is frozen — a release or an rc.
-A pre-release interpreter's wheels are built and tested but held back until
-its rc. salix supports CPython 3.10 through 3.15, including the free-threaded
-builds. The full matrix is `nix/python-targets.nix`; a configuration missing
-from it has no wheel. On a machine PyPI has no wheel for, pip compiles the
-sdist — which needs setuptools and a C compiler — except on Windows, where
-MSVC cannot compile this source. PyPy and GraalPy satisfy the version floor
-and have no wheels, and whether the sdist builds there is untested.
+`nix/python-targets.nix` is the wheel matrix, and wheels are published for
+its cells — Windows, macOS, and glibc Linux on x86_64 and arm64, for the
+supported CPythons whose ABI is frozen. A pre-release interpreter's wheels
+are built and tested but held back until its rc, and a configuration missing
+from the matrix has no wheel. salix supports CPython 3.10 through 3.15,
+including the free-threaded builds. On a machine PyPI has no wheel for, pip
+compiles the sdist — which needs setuptools and a C compiler — except on
+Windows, where MSVC cannot compile this source. PyPy and GraalPy satisfy the
+version floor and have no wheels, and whether the sdist builds there is
+untested.
 
 ## What salix is and is not
 
@@ -38,20 +39,20 @@ constructor takes them in that order. Instances are frozen by default: reads,
 value equality, hashing, and a repr come with the class; writes do not.
 A body-written `__init__` — inherited or not — replaces the field
 constructor, and on a frozen struct the body fills fields with `set_field`
-(the Caching section shows the pattern), since assignment raises. Inheritance
-extends the field list — a subclass adds its fields after its base's — and
-the metadata reads back: `_struct_fields_`,
+(see Caching a computed value — the example there runs in `__post_init__`),
+since assignment raises. Inheritance extends the field list — a subclass adds
+its fields after its base's — and the metadata reads back: `_struct_fields_`,
 `_struct_defaults_`, `_struct_annotations_`, and `_struct_metadata_`, with
 `__`-prefixed spellings of the same four names answering the same values.
 
 The keywords opt out of the defaults. `frozen=False` opens the record for
 writes and drops the hashing — under the default `eq=True` a writable struct
 is unhashable, and a body `__hash__` still stands. `eq=False` drops the value
-equality and hashing, leaving identity — unless the body defines its own
-`__eq__` without a `__hash__`, which makes the struct unhashable. `order=True`
-adds the field-order comparisons and requires `eq=True`. `repr`, `match_args`,
-and `weakref` default to `True`, `True`, and `False` and stand in for the
-`__repr__`, the pattern-matching signature, and the `__weakref__` slot.
+equality and hashing, leaving identity — the exceptions are named in Caching
+a computed value. `order=True` adds the field-order comparisons and requires
+`eq=True`. `repr`, `match_args`, and `weakref` default to `True`, `True`, and
+`False` and stand in for the `__repr__`, the pattern-matching signature, and
+the `__weakref__` slot.
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
@@ -87,10 +88,11 @@ in `__post_init__` with `set_field` — unless the body writes its own
 `__init__`, which replaces the constructor that runs `__post_init__` (see
 What salix is and is not). A default whose type hashes but whose value cannot
 is refused the same way — `x: tuple = (1, [])` dies at class creation —
-because every instance would share it while its hash raises; a type outside
-the four that declares `__hash__ = None` is left alone and shared. A field
-without a default cannot follow one that has it: append defaulted fields, or
-default the new field too. For the four, `__struct_defaults__` holds the
+because every instance would share it while its hash raises; a hash that
+fails by recursing slips through and is shared, and so does a type outside
+the four that declares `__hash__ = None`. A field without a default cannot
+follow one that has it: append defaulted fields, or default the new field
+too. For the four, `__struct_defaults__` holds the
 class's own copy, severed from whatever the class body named: appending to
 the module-level object afterwards does not reach the class. The getters hand
 the stored objects out, not copies: do not mutate what `__struct_defaults__`

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Point(x=1.0, y=2.0)
 pip install salix
 ```
 
-`nix/python-targets.nix` is the wheel matrix, and wheels are published for
-its cells — Windows, macOS, and glibc Linux on x86_64 and arm64, for the
-supported CPythons whose ABI is frozen. A pre-release interpreter's wheels
-are built and tested but held back until its rc, and a configuration missing
-from the matrix has no wheel. salix supports CPython 3.10 through 3.15,
-including the free-threaded builds. On a machine PyPI has no wheel for, pip
-compiles the sdist — which needs setuptools and a C compiler — except on
-Windows, where MSVC cannot compile this source. PyPy and GraalPy satisfy the
-version floor and have no wheels, and whether the sdist builds there is
-untested.
+`nix/python-targets.nix` is the wheel matrix — Windows, macOS, and glibc
+Linux on x86_64 and arm64, across the supported CPythons — and wheels are
+published for its cells once the interpreter's ABI is frozen. A pre-release
+interpreter's wheels are built and tested but held back until its rc, and a
+configuration missing from the matrix has no wheel. salix supports CPython
+3.10 through 3.15, including the free-threaded builds. On a machine PyPI has
+no wheel for, pip compiles the sdist — which needs setuptools and a C
+compiler — except on Windows, where MSVC cannot compile this source. PyPy
+and GraalPy satisfy the version floor and have no wheels, and whether the
+sdist builds there is untested.
 
 ## What salix is and is not
 
@@ -38,10 +38,12 @@ A struct's fields are the annotated names of its class body, and the
 constructor takes them in that order. Instances are frozen by default: reads,
 value equality, hashing, and a repr come with the class; writes do not.
 A body-written `__init__` — inherited or not — replaces the field
-constructor, and on a frozen struct the body fills fields with `set_field`
-(see Caching a computed value — the example there runs in `__post_init__`),
-since assignment raises. Inheritance extends the field list — a subclass adds
-its fields after its base's — and the metadata reads back: `_struct_fields_`,
+constructor, unless the body writes `object.__init__` back, which restores
+the generated one; and on a frozen struct the body fills fields with
+`set_field` (see Caching a computed value — the example there runs in
+`__post_init__`), since assignment raises. Inheritance extends the field list
+— a subclass adds its fields after its base's — and the metadata reads back:
+`_struct_fields_`,
 `_struct_defaults_`, `_struct_annotations_`, and `_struct_metadata_`, with
 `__`-prefixed spellings of the same four names answering the same values.
 
@@ -69,6 +71,8 @@ An empty default of `list`, `dict`, `set`, or `bytearray` is copied per
 instance, not shared:
 
 ```python
+>>> from salix import Struct
+
 >>> class Box(Struct):
 ...     items: list = []
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ arm64, for the supported CPythons whose ABI is frozen — a release or an rc.
 A pre-release interpreter's wheels are built and tested but held back until
 its rc. salix supports CPython 3.10 through 3.15, including the free-threaded
 builds. The full matrix is `nix/python-targets.nix`; a configuration missing
-from it has no wheel. A machine PyPI has no wheel for compiles the sdist,
-which needs setuptools and a C compiler — on every OS but Windows, where
+from it has no wheel. On a machine PyPI has no wheel for, pip compiles the
+sdist — which needs setuptools and a C compiler — except on Windows, where
 MSVC cannot compile this source. PyPy and GraalPy satisfy the version floor
 but cannot compile the C source, and have no wheels.
 
@@ -36,12 +36,12 @@ but cannot compile the C source, and have no wheels.
 A struct's fields are the annotated names of its class body, and the
 constructor takes them in that order. Instances are frozen by default: reads,
 value equality, hashing, and a repr come with the class; writes do not.
-Inheritance extends the plan — a subclass adds its fields after its base's —
-and the metadata reads back: `_struct_fields_`, `_struct_defaults_`,
+Inheritance extends the field list — a subclass adds its fields after its
+base's — and the metadata reads back: `_struct_fields_`, `_struct_defaults_`,
 `_struct_annotations_`, and `_struct_metadata_`, with `__`-prefixed spellings
 of the same four names answering the same values.
 
-The keywords select out of the default. `frozen=False` opens the record for
+The keywords opt out of the defaults. `frozen=False` opens the record for
 writes. `eq=False` drops the value equality and hashing, leaving identity.
 `order=True` adds the field-order comparisons and requires `eq=True`.
 `repr`, `match_args`, and `weakref` default to `True`, `True`, and `False`
@@ -50,12 +50,12 @@ and stand in for the `__repr__`, the pattern-matching signature, and the
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
-on top. `NamedTuple` is the tuple-shaped ancestor. `msgspec` is a
+on top. `NamedTuple` is the tuple-shaped predecessor. `msgspec` is a
 serialization library whose `Struct` validates. salix does the record and
-nothing else — no serialization, no validation, no coercion — in C, which is
-where its import and type-creation times come from. Programs that need those
-features need those libraries; salix is for the ones that only need the
-record. `salix/__init__.pyi` is the whole of the API.
+nothing else — no serialization, no field-value validation, no coercion — in
+C, which is where its import and type-creation times come from. Programs that
+need those features need those libraries; salix is for the ones that only
+need the record. `salix/__init__.pyi` is the whole of the API.
 
 ## Defaults
 
@@ -78,11 +78,13 @@ would be a plain `dict` — so the rule stops at the four, and a subclass of one
 of them is stored as the class body's object itself, shared. A non-empty
 default of the four is refused at class creation, because a copy can only be
 shallow and the contents would still be shared: default it empty and fill it
-in `__post_init__` with `set_field`. For the four, `__struct_defaults__`
-holds the class's own copy, severed from whatever the class body named:
-appending to the module-level object afterwards does not reach the class.
-The getters hand the stored objects out, not copies: do not mutate what
-`__struct_defaults__` returns.
+in `__post_init__` with `set_field`. A default whose value cannot be hashed
+is refused the same way — `x: tuple = (1, [])` dies at class creation —
+because every instance would share it while its hash raises. For the four,
+`__struct_defaults__` holds the class's own copy, severed from whatever the
+class body named: appending to the module-level object afterwards does not
+reach the class. The getters hand the stored objects out, not copies: do not
+mutate what `__struct_defaults__` returns.
 
 ## ClassVar and InitVar
 

--- a/README.md
+++ b/README.md
@@ -29,24 +29,25 @@ builds. The full matrix is `nix/python-targets.nix`; a configuration missing
 from it has no wheel. On a machine PyPI has no wheel for, pip compiles the
 sdist — which needs setuptools and a C compiler — except on Windows, where
 MSVC cannot compile this source. PyPy and GraalPy satisfy the version floor
-but cannot compile the C source, and have no wheels.
+and have no wheels, and whether the sdist builds there is untested.
 
 ## What salix is and is not
 
 A struct's fields are the annotated names of its class body, and the
 constructor takes them in that order. Instances are frozen by default: reads,
 value equality, hashing, and a repr come with the class; writes do not.
-Inheritance extends the field list — a subclass adds its fields after its
-base's — and the metadata reads back: `_struct_fields_`, `_struct_defaults_`,
-`_struct_annotations_`, and `_struct_metadata_`, with `__`-prefixed spellings
-of the same four names answering the same values.
+A body-written `__init__` — inherited or not — replaces the field
+constructor. Inheritance extends the field list — a subclass adds its fields
+after its base's — and the metadata reads back: `_struct_fields_`,
+`_struct_defaults_`, `_struct_annotations_`, and `_struct_metadata_`, with
+`__`-prefixed spellings of the same four names answering the same values.
 
 The keywords opt out of the defaults. `frozen=False` opens the record for
-writes. `eq=False` drops the value equality and hashing, leaving identity.
-`order=True` adds the field-order comparisons and requires `eq=True`.
-`repr`, `match_args`, and `weakref` default to `True`, `True`, and `False`
-and stand in for the `__repr__`, the pattern-matching signature, and the
-`__weakref__` slot.
+writes and drops the hashing — a writable struct is unhashable. `eq=False`
+drops the value equality and hashing, leaving identity. `order=True` adds
+the field-order comparisons and requires `eq=True`. `repr`, `match_args`,
+and `weakref` default to `True`, `True`, and `False` and stand in for the
+`__repr__`, the pattern-matching signature, and the `__weakref__` slot.
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
@@ -78,9 +79,13 @@ would be a plain `dict` — so the rule stops at the four, and a subclass of one
 of them is stored as the class body's object itself, shared. A non-empty
 default of the four is refused at class creation, because a copy can only be
 shallow and the contents would still be shared: default it empty and fill it
-in `__post_init__` with `set_field`. A default whose value cannot be hashed
-is refused the same way — `x: tuple = (1, [])` dies at class creation —
-because every instance would share it while its hash raises. For the four,
+in `__post_init__` with `set_field` — unless the body writes its own
+`__init__`, which replaces the constructor that runs `__post_init__`.
+A default whose type hashes but whose value cannot is refused the same way —
+`x: tuple = (1, [])` dies at class creation — because every instance would
+share it while its hash raises; a type that declares `__hash__ = None` is
+left alone and shared. A field without a default cannot follow one that has
+it: append defaulted fields, or default the new field too. For the four,
 `__struct_defaults__` holds the class's own copy, severed from whatever the
 class body named: appending to the module-level object afterwards does not
 reach the class. The getters hand the stored objects out, not copies: do not
@@ -168,6 +173,7 @@ without one. The table and the caching behaviors above are pinned in
 ```sh
 nix develop
 uv run camas check
+uv run camas benchmark
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,17 +37,19 @@ A struct's fields are the annotated names of its class body, and the
 constructor takes them in that order. Instances are frozen by default: reads,
 value equality, hashing, and a repr come with the class; writes do not.
 A body-written `__init__` — inherited or not — replaces the field
-constructor. Inheritance extends the field list — a subclass adds its fields
-after its base's — and the metadata reads back: `_struct_fields_`,
+constructor, and on a frozen struct the body fills fields with `set_field`,
+since assignment raises. Inheritance extends the field list — a subclass adds
+its fields after its base's — and the metadata reads back: `_struct_fields_`,
 `_struct_defaults_`, `_struct_annotations_`, and `_struct_metadata_`, with
 `__`-prefixed spellings of the same four names answering the same values.
 
 The keywords opt out of the defaults. `frozen=False` opens the record for
-writes and drops the hashing — a writable struct is unhashable. `eq=False`
-drops the value equality and hashing, leaving identity. `order=True` adds
-the field-order comparisons and requires `eq=True`. `repr`, `match_args`,
-and `weakref` default to `True`, `True`, and `False` and stand in for the
-`__repr__`, the pattern-matching signature, and the `__weakref__` slot.
+writes and drops the hashing — under the default `eq=True` a writable struct
+is unhashable, and a body `__hash__` still stands. `eq=False` drops the value
+equality and hashing, leaving identity. `order=True` adds the field-order
+comparisons and requires `eq=True`. `repr`, `match_args`, and `weakref`
+default to `True`, `True`, and `False` and stand in for the `__repr__`, the
+pattern-matching signature, and the `__weakref__` slot.
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
@@ -80,16 +82,17 @@ of them is stored as the class body's object itself, shared. A non-empty
 default of the four is refused at class creation, because a copy can only be
 shallow and the contents would still be shared: default it empty and fill it
 in `__post_init__` with `set_field` — unless the body writes its own
-`__init__`, which replaces the constructor that runs `__post_init__`.
-A default whose type hashes but whose value cannot is refused the same way —
-`x: tuple = (1, [])` dies at class creation — because every instance would
-share it while its hash raises; a type that declares `__hash__ = None` is
-left alone and shared. A field without a default cannot follow one that has
-it: append defaulted fields, or default the new field too. For the four,
-`__struct_defaults__` holds the class's own copy, severed from whatever the
-class body named: appending to the module-level object afterwards does not
-reach the class. The getters hand the stored objects out, not copies: do not
-mutate what `__struct_defaults__` returns.
+`__init__`, which replaces the constructor that runs `__post_init__` (see
+What salix is and is not). A default whose type hashes but whose value cannot
+is refused the same way — `x: tuple = (1, [])` dies at class creation —
+because every instance would share it while its hash raises; a type outside
+the four that declares `__hash__ = None` is left alone and shared. A field
+without a default cannot follow one that has it: append defaulted fields, or
+default the new field too. For the four, `__struct_defaults__` holds the
+class's own copy, severed from whatever the class body named: appending to
+the module-level object afterwards does not reach the class. The getters hand
+the stored objects out, not copies: do not mutate what `__struct_defaults__`
+returns.
 
 ## ClassVar and InitVar
 
@@ -170,11 +173,8 @@ without one. The table and the caching behaviors above are pinned in
 
 ## Working in the repo
 
-```sh
-nix develop
-uv run camas check
-uv run camas benchmark
-```
+The contributor loop is `CONTRIBUTING.md`. `uv run camas benchmark` says what
+it costs.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,21 @@ A struct's fields are the annotated names of its class body, and the
 constructor takes them in that order. Instances are frozen by default: reads,
 value equality, hashing, and a repr come with the class; writes do not.
 A body-written `__init__` — inherited or not — replaces the field
-constructor, and on a frozen struct the body fills fields with `set_field`,
-since assignment raises. Inheritance extends the field list — a subclass adds
-its fields after its base's — and the metadata reads back: `_struct_fields_`,
+constructor, and on a frozen struct the body fills fields with `set_field`
+(the Caching section shows the pattern), since assignment raises. Inheritance
+extends the field list — a subclass adds its fields after its base's — and
+the metadata reads back: `_struct_fields_`,
 `_struct_defaults_`, `_struct_annotations_`, and `_struct_metadata_`, with
 `__`-prefixed spellings of the same four names answering the same values.
 
 The keywords opt out of the defaults. `frozen=False` opens the record for
 writes and drops the hashing — under the default `eq=True` a writable struct
 is unhashable, and a body `__hash__` still stands. `eq=False` drops the value
-equality and hashing, leaving identity. `order=True` adds the field-order
-comparisons and requires `eq=True`. `repr`, `match_args`, and `weakref`
-default to `True`, `True`, and `False` and stand in for the `__repr__`, the
-pattern-matching signature, and the `__weakref__` slot.
+equality and hashing, leaving identity — unless the body defines its own
+`__eq__` without a `__hash__`, which makes the struct unhashable. `order=True`
+adds the field-order comparisons and requires `eq=True`. `repr`, `match_args`,
+and `weakref` default to `True`, `True`, and `False` and stand in for the
+`__repr__`, the pattern-matching signature, and the `__weakref__` slot.
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem
@@ -173,8 +175,8 @@ without one. The table and the caching behaviors above are pinned in
 
 ## Working in the repo
 
-The contributor loop is `CONTRIBUTING.md`. `uv run camas benchmark` says what
-it costs.
+The contributor loop is documented in `CONTRIBUTING.md`. `uv run camas
+benchmark` says what it costs.
 
 ## License
 


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to drive the open-issue queue; #18 said publishing makes README.md the PyPI project page while it still reads like a repository file — install instructions absent, four dead-end references, nothing on interpreters or on what salix is not.

The README now opens the way a landing page should: `pip install salix`, the interpreter story, what salix is and is not beside `dataclasses`/`attrs`/`NamedTuple`/`msgspec`, and the defaults section #49's review routed to this issue. Closes #18.

<details>
<summary><b>What changed and the constraints it was written under</b></summary>

- **Install first** — `pip install salix`, wheels for every supported CPython including the free-threaded builds, the sdist path, and the PyPy/GraalPy truth (they satisfy the version floor, cannot compile the C source, and have no wheels).
- **Support claims stay version-shaped, never numbered** — the wheel matrix and the classifiers are the source of truth, so the page says 3.10 through 3.15 and never a wheel count that would drift.
- **What salix is and is not** — fields from the annotated class body, frozen by default, the six keywords, the metadata quartet — then the honest "not the libraries that do more" paragraph: no serialization, no validation, no coercion, in C.
- **Defaults section** — the three facts from #49's review comment: empty `list`/`dict`/`set`/`bytearray` copied per instance, non-empty refused at class creation, `__struct_defaults__` severed from the body's object — plus the exact-type boundary where the rule stops. The one code sample is a doctest that runs with the suite.
- **The four dead ends are gone** — the repository link now lives in the Project-URL metadata (#17) where PyPI renders it.
- The ClassVar/InitVar table and the caching section are carried over unchanged; their pins were verified before the pass (`tests/test_classvar_paths.py` does own the caching behaviors).
</details>

<details>
<summary><b>Verification</b></summary>

- Full camas gate green scoped to README.md — including pytest on the README's doctests (testpaths collects it) and the lint leaves.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary><b>Round 1 disposition (full review, d734c03)</b></summary>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins, following the code-review bot's round-1 findings on this PR.

All five minors fixed in d734c03 by writing the distribution claims from the release machinery instead of PyPI's tag vocabulary: the platform shape is named (Windows, macOS, glibc Linux on x86_64 and arm64), the rc gate is stated as the mechanism (pre-release interpreters build and test but are held back), the matrix file is pointed at as the cell-level truth, the Windows sdist caveat is stated, the Defaults severance claim is scoped to the four exact types with the getters' stored-object behavior named, and the pyi API pointer is restored.

The one hidden nit not addressed — no CI leg round-trips the sdist into a wheel — is a repository-workflow question, not landing-page prose; it stands on its own as a follow-up issue.
</details>


<details>
<summary><b>Round 8 (0.00, converged) — merging with one below-floor nit recorded</b></summary>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins, recording the code-review bot's round-8 disposition on this PR.

Recorded for the residue queue, not fixed (below the visibility floor, m = 0.10, and this round verified every other claim): the What-section escape clause is act-scoped ("unless the body writes `object.__init__` back") where the code and the Caching section state the rule on the value (`not object.__init__`). The natural anaphora resolves the sentence correctly, so only a strict act-scoped reading of "the body" mispredicts the two-generation edge (a subclass inheriting the write-back). The value-based rephrasing the reviewer offers is the shape to take in a future residue pass.
</details>
