### PR TITLE
Pin the ClassVar protocol shape, static and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ it is refused, because a class variable is a constant. An inherited
 field name stays a field: the inheritance rule outranks the ClassVar
 annotation, so re-annotating one re-declares the field. `InitVar[...]`
 is refused, and so is a `ClassVar` nested inside another annotation.
+A protocol is satisfied structurally, never inherited: a struct may not
+list a Protocol among its bases, because the two metaclasses conflict.
 The check walks the annotation's forms when it arrives as an object;
 when it arrives as source text — a quoted string, or a
 future-annotations string — the check is a spelling match, and the two

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,3 +1,5 @@
+from typing import ClassVar, Protocol
+
 import pytest
 
 from salix import Struct, set_field
@@ -119,3 +121,26 @@ def test_instances_carry_no_dict_or_weakref_slot():
         import weakref
 
         weakref.ref(point)
+
+
+class Command(Protocol):
+    COMMAND: ClassVar[bytes]
+
+
+class PayloadCommand(Struct):
+    COMMAND: ClassVar[bytes] = b"launch"
+    payload: int
+
+
+def test_a_struct_satisfies_a_classvar_protocol_structurally():
+    def read(command: Command) -> bytes:
+        return command.COMMAND
+
+    assert read(PayloadCommand(1)) == b"launch"
+    assert PayloadCommand.COMMAND == b"launch"
+    assert PayloadCommand._struct_fields_ == ("payload",)
+
+
+def test_a_struct_class_cannot_inherit_a_protocol():
+    with pytest.raises(TypeError, match="metaclass conflict"):
+        type(Struct)("Inheriting", (Struct, Command), {"__annotations__": {"payload": int}})

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -142,5 +142,5 @@ def test_a_struct_satisfies_a_classvar_protocol_structurally():
 
 
 def test_a_struct_class_cannot_inherit_a_protocol():
-    with pytest.raises(TypeError, match="metaclass conflict"):
+    with pytest.raises(TypeError):
         type(Struct)("Inheriting", (Struct, Command), {"__annotations__": {"payload": int}})

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -147,8 +147,8 @@ class CarriesCommand(Struct):
     payload: int
 
 
-def a_struct_satisfies_a_classvar_protocol_structurally(command: CommandProtocol) -> bytes:
-    return command.COMMAND
+def a_struct_satisfies_a_classvar_protocol_structurally() -> None:
+    def reads(command: CommandProtocol) -> bytes:
+        return command.COMMAND
 
-
-a_struct_satisfies_a_classvar_protocol_structurally(CarriesCommand(1))
+    assert_type(reads(CarriesCommand(1)), bytes)

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Generic, Literal, TypeVar
+from typing import Any, ClassVar, Generic, Literal, Protocol, TypeVar
 
 from typing_extensions import assert_type
 
@@ -136,3 +136,19 @@ def __copy___returns_the_concrete_struct_type() -> None:
 
 def __deepcopy___returns_the_concrete_struct_type() -> None:
     assert_type(Point(1, "two").__deepcopy__({}), Point)
+
+
+class CommandProtocol(Protocol):
+    COMMAND: ClassVar[bytes]
+
+
+class CarriesCommand(Struct):
+    COMMAND: ClassVar[bytes] = b"carried"
+    payload: int
+
+
+def a_struct_satisfies_a_classvar_protocol_structurally(command: CommandProtocol) -> bytes:
+    return command.COMMAND
+
+
+a_struct_satisfies_a_classvar_protocol_structurally(CarriesCommand(1))


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She re-opened #148 asking for static typing and runtime test coverage of the protocol shape the issue asked about, with the addition closing the issue.

Pins both halves of the measured answer to #148: a struct satisfies a `ClassVar`-member protocol **structurally**, and cannot inherit the protocol itself.

<details>
<summary><b>What is pinned where</b></summary>

- `tests/typing/accepted.py` — the working shape runs through all three type checkers: the protocol declares `COMMAND: ClassVar[bytes]`, the struct implements it as a top-level `ClassVar` with a value, and a reader typed against the protocol accepts a struct instance.
- `tests/test_protocols.py` — the runtime shape: `COMMAND` stays out of the field plan, the class and instance reads answer, and `type(Struct)(...)` with the protocol in the bases raises the metaclass conflict, so the protocol stays out of the bases for good.
</details>

<details>
<summary><b>Verification</b></summary>

Full camas gate green scoped to the two files — the whole pytest suite plus mypy --strict, pyright, and ty on tests/typing.
</details>

Closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary><b>Round 1 disposition (full review, 8742585)</b></summary>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins, following the code-review bot's round-1 findings (0.41, converged) on this PR.

The static-refusal gap is addressed in prose: measured first that declaring the metaclass in the stub makes none of the three checkers flag `class X(Struct, Protocol)` — the diagnostic is un-expressible statically — so the ClassVar section now states the rule (satisfied structurally, never inherited). The conformance pin moved into a function in the file's established style, and the runtime refusal pin no longer asserts CPython's incidental message text. The duplicated shape across the two suites stands: each file pins the same fixture for a different toolchain, and nothing runs both against one copy. Note: this branch adds one README sentence while #154 reworks the same file; #155 will rebase onto main after #154 merges.
</details>


<details>
<summary><b>Round 2 (0.00, converged) — merging with three below-floor nits recorded</b></summary>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins, recording the code-review bot's round-2 disposition on this PR.

Recorded for the residue queue, not fixed (all below the visibility floor, m ≤ 0.07, and the round verified every disposition from round 1):
- **test-name-overclaims-conformance** — the runtime test name claims structural conformance, which only the static checkers can observe; the runtime pin guards the ClassVar mechanics (excluded from the field plan, readable through class and instance). The suggested rename is the shape for a future pass.
- **namespace-dict-misreading** — the `type(Struct)(...)` refusal pin's namespace dict invites misreading; harmless as written.
- **protocol-rule-buried** — the structural-not-inherited sentence lives in the ClassVar section, away from its pinning file; acceptable while the README sections are organized by feature.
</details>
