### PR TITLE
PEP 487: forward the class keywords salix does not own (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ equality and hashing, leaving identity — the exceptions are named in Caching
 a computed value. `order=True` adds the field-order comparisons and requires
 `eq=True`. `repr`, `match_args`, and `weakref` default to `True`, `True`, and
 `False` and stand in for the `__repr__`, the pattern-matching signature, and
-the `__weakref__` slot.
+the `__weakref__` slot. The six are consumed by the machinery; a class keyword
+it does not own reaches `__init_subclass__` in the usual way, and one the
+hierarchy does not claim still fails the class.
 
 salix is not the libraries that do more. `dataclasses` builds the same record
 in pure Python. `attrs` layers converters, validators, and a plugin ecosystem

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -49,15 +49,15 @@ PyObject * build_struct_class(
 ) {
 	struct base_survey const survey = survey_bases(bases);
 	struct options const inherited = inherited_options(survey.behaviour, survey.facts);
-	struct options_request request = options_read(keywords, inherited, survey.facts);
+	PY_MOVABLE(forwarded_options, NULL);
+	struct options_request request = options_read(
+		keywords,
+		inherited,
+		survey.facts,
+		&forwarded_options
+	);
 
 	if (request.tag == OPTIONS_REJECTED) {
-		return NULL;
-	}
-
-	PY_MOVABLE(forwarded_options, options_forwarded(keywords));
-
-	if (keywords != NULL && forwarded_options == NULL) {
 		return NULL;
 	}
 
@@ -132,6 +132,25 @@ PyObject * build_struct_class(
 				keyword_rung_count = 2;
 			}
 		}
+	}
+
+	if (
+		forwarded_options != NULL &&
+		PyDict_GET_SIZE(forwarded_options) > 0 &&
+		verdict.accepts_all == 0
+	) {
+		PyObject * unowned = NULL;
+		PyObject * unowned_value = NULL;
+		Py_ssize_t unowned_position = 0;
+		PyDict_Next(forwarded_options, &unowned_position, &unowned, &unowned_value);
+		PyErr_Format(
+			PyExc_TypeError,
+			"'%U' cannot reach __init_subclass__ through %.200s.__new__",
+			unowned,
+			handoff->tp_name
+		);
+
+		return NULL;
 	}
 
 	if (

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -21,7 +21,12 @@ struct chain_verdict {
 };
 static int code_accepts_keyword(PyCodeObject * code, PyObject * varnames, char const * keyword);
 static PyObject * metaclass_chain(PyTypeObject * winner);
-static struct chain_verdict chain_probe(PyObject * chain, PyObject * keywords, bool weakref_column);
+static struct chain_verdict chain_probe(
+	PyObject * chain,
+	PyObject * keywords,
+	bool weakref_column,
+	PyObject * * declined
+);
 static StructType * create_class(
 	PyTypeObject * metatype,
 	PyTypeObject * handoff,
@@ -89,7 +94,7 @@ PyObject * build_struct_class(
 			return NULL;
 		}
 
-		verdict = chain_probe(chain, keywords, weakref_keyword_rides);
+		verdict = chain_probe(chain, keywords, weakref_keyword_rides, NULL);
 
 		if (verdict.accepts_all < 0) {
 			return NULL;
@@ -139,18 +144,42 @@ PyObject * build_struct_class(
 		PyDict_GET_SIZE(forwarded_options) > 0 &&
 		verdict.accepts_all == 0
 	) {
-		PyObject * unowned = NULL;
-		PyObject * unowned_value = NULL;
-		Py_ssize_t unowned_position = 0;
-		PyDict_Next(forwarded_options, &unowned_position, &unowned, &unowned_value);
-		PyErr_Format(
-			PyExc_TypeError,
-			"'%U' cannot reach __init_subclass__ through %.200s.__new__",
-			unowned,
-			handoff->tp_name
+		PyObject * declined = NULL;
+		struct chain_verdict const unowned_verdict = chain_probe(
+			chain,
+			forwarded_options,
+			false,
+			&declined
 		);
 
-		return NULL;
+		if (unowned_verdict.accepts_all < 0) {
+			return NULL;
+		}
+
+		if (unowned_verdict.accepts_all == 0) {
+			if (declined == NULL) {
+				PyObject * unowned_value = NULL;
+				Py_ssize_t unowned_position = 0;
+				PyDict_Next(forwarded_options, &unowned_position, &declined, &unowned_value);
+			}
+
+			PyErr_Format(
+				PyExc_TypeError,
+				"'%U' cannot reach __init_subclass__ through %.200s.__new__",
+				declined,
+				handoff->tp_name
+			);
+
+			return NULL;
+		}
+
+		if (forwarded_keywords == NULL) {
+			forwarded_keywords = forwarded_options;
+		} else {
+			if (PyDict_Update(forwarded_keywords, forwarded_options) < 0) {
+				return NULL;
+			}
+		}
 	}
 
 	if (
@@ -352,7 +381,8 @@ static int code_accepts_keyword(
 static struct chain_verdict chain_probe(
 	PyObject * const chain,
 	PyObject * const keywords,
-	bool const weakref_column
+	bool const weakref_column,
+	PyObject * * const declined
 ) {
 	struct chain_verdict verdict = {.accepts_all = 1, .accepts_weakref = 1, .readable = true};
 
@@ -407,6 +437,11 @@ static struct chain_verdict chain_probe(
 
 			if (accepts == 0) {
 				verdict.accepts_all = 0;
+
+				if (declined != NULL) {
+					*declined = key;
+				}
+
 				break;
 			}
 		}

--- a/src/meta/class/create.c
+++ b/src/meta/class/create.c
@@ -31,6 +31,7 @@ static StructType * create_class(
 	PyObject * const * keyword_rungs,
 	Py_ssize_t keyword_rung_count,
 	PyObject * forwarded_keywords,
+	PyObject * forwarded_options,
 	bool laddered,
 	PyObject * handoff_attempt,
 	PyObject * handoff_declined,
@@ -51,6 +52,12 @@ PyObject * build_struct_class(
 	struct options_request request = options_read(keywords, inherited, survey.facts);
 
 	if (request.tag == OPTIONS_REJECTED) {
+		return NULL;
+	}
+
+	PY_MOVABLE(forwarded_options, options_forwarded(keywords));
+
+	if (keywords != NULL && forwarded_options == NULL) {
 		return NULL;
 	}
 
@@ -220,6 +227,7 @@ struct field_plan plan = field_plan_build(base, original_namespace);
 			keyword_rungs,
 			keyword_rung_count,
 			forwarded_keywords,
+			forwarded_options,
 			laddered,
 			state->handoff_attempt,
 			state->handoff_declined,
@@ -445,6 +453,7 @@ static StructType * create_class(
 	PyObject * const * const keyword_rungs,
 	Py_ssize_t const keyword_rung_count,
 	PyObject * forwarded_keywords,
+	PyObject * forwarded_options,
 	bool const laddered,
 	PyObject * const handoff_attempt,
 	PyObject * const handoff_declined,
@@ -463,7 +472,7 @@ static StructType * create_class(
 		created = PyType_Type.tp_new(
 			builder,
 			type_args,
-			builder == handoff ? NULL : forwarded_keywords
+			builder == handoff ? forwarded_options : forwarded_keywords
 		);
 	}
 

--- a/src/options.c
+++ b/src/options.c
@@ -30,8 +30,6 @@ static struct options_request checked(
 	struct base_facts facts,
 	bool weakref_written
 );
-static struct options_request reject_unknown(PyObject * keyword);
-static PyObject * accepted_keywords(void);
 
 struct options_request options_read(
 	PyObject * const keywords,
@@ -71,11 +69,8 @@ struct options_request options_read(
 	while (PyDict_Next(keywords, &position, &keyword, &value)) {
 		struct option_lookup const found = find_option(keyword);
 
-		switch (found.tag) {
-			case OPTION_LOOKUP_UNKNOWN:
-				return reject_unknown(keyword);
-			case OPTION_LOOKUP_FOUND:
-				break;
+		if (found.tag == OPTION_LOOKUP_UNKNOWN) {
+			continue;
 		}
 
 		int const truth = PyObject_IsTrue(value);
@@ -162,40 +157,30 @@ static struct options_request checked(
 	};
 }
 
-static struct options_request reject_unknown(PyObject * const keyword) {
-	PY_OWNED(accepted, accepted_keywords());
-
-	if (accepted != NULL) {
-		PyErr_Format(
-			PyExc_TypeError,
-			"'%U' is not a struct class keyword; expected one of %U",
-			keyword,
-			accepted
-		);
-	}
-
-	return (struct options_request){.tag = OPTIONS_REJECTED};
-}
-
-/* Listed from the table rather than spelled out, so a new option cannot leave
- * the message behind. */
-static PyObject * accepted_keywords(void) {
-	PY_OWNED(names, PyList_New(0));
-	PY_OWNED(separator, PyUnicode_FromString(", "));
-
-	if (names == NULL || separator == NULL) {
+PyObject * options_forwarded(PyObject * const keywords) {
+	if (keywords == NULL) {
 		return NULL;
 	}
 
-	for (Py_ssize_t i = 0; i < OPTION_COUNT; ++i) {
-		PY_OWNED(name, PyUnicode_FromString(option_keywords[i]));
+	PY_MOVABLE(forwarded, PyDict_New());
 
-		if (name == NULL || PyList_Append(names, name) < 0) {
-			return NULL;
+	if (forwarded == NULL) {
+		return NULL;
+	}
+
+	Py_ssize_t position = 0;
+	PyObject * keyword;
+	PyObject * value;
+
+	while (PyDict_Next(keywords, &position, &keyword, &value)) {
+		if (find_option(keyword).tag == OPTION_LOOKUP_UNKNOWN) {
+			if (PyDict_SetItem(forwarded, keyword, value) < 0) {
+				return NULL;
+			}
 		}
 	}
 
-	return PyUnicode_Join(separator, names);
+	return py_move(&forwarded);
 }
 
 #ifdef TESTING
@@ -253,7 +238,7 @@ static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 	Py_DECREF(keywords);
 }
 
-static void test_an_unknown_keyword_is_rejected(void) {
+static void test_an_unknown_keyword_is_skipped(void) {
 	PyObject * const keywords = keywords_of("frozn", true);
 	struct options_request const request = options_read(
 		keywords,
@@ -261,11 +246,42 @@ static void test_an_unknown_keyword_is_rejected(void) {
 		facts_of(false, false, false)
 	);
 
-	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
-	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_TRUE(request.options.frozen);
+	TEST_ASSERT_FALSE(PyErr_Occurred());
 
-	PyErr_Clear();
 	Py_DECREF(keywords);
+}
+
+static void test_only_unowned_keywords_are_forwarded(void) {
+	PyObject * const keywords = PyDict_New();
+
+	PyDict_SetItemString(keywords, "frozn", Py_True);
+	PyDict_SetItemString(keywords, option_keywords[OPTION_FROZEN], Py_False);
+
+	PY_OWNED(forwarded, options_forwarded(keywords));
+
+	TEST_ASSERT_NOT_NULL(forwarded);
+	TEST_ASSERT_EQUAL_INT(1, PyDict_Size(forwarded));
+	TEST_ASSERT_EQUAL_INT(1, PyObject_IsTrue(PyDict_GetItemString(forwarded, "frozn")));
+
+	Py_DECREF(keywords);
+}
+
+static void test_the_owned_keywords_leave_nothing_to_forward(void) {
+	PyObject * const keywords = keywords_of("frozen", false);
+
+	PY_OWNED(forwarded, options_forwarded(keywords));
+
+	TEST_ASSERT_NOT_NULL(forwarded);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
+
+	Py_DECREF(keywords);
+}
+
+static void test_null_keywords_forward_nothing(void) {
+	TEST_ASSERT_NULL(options_forwarded(NULL));
+	TEST_ASSERT_FALSE(PyErr_Occurred());
 }
 
 static void test_ordering_without_equality_is_rejected(void) {
@@ -419,7 +435,10 @@ void options_tests(void) {
 
 	RUN_TEST(test_no_keywords_inherit_the_base);
 	RUN_TEST(test_a_keyword_replaces_only_the_flag_it_names);
-	RUN_TEST(test_an_unknown_keyword_is_rejected);
+	RUN_TEST(test_an_unknown_keyword_is_skipped);
+	RUN_TEST(test_only_unowned_keywords_are_forwarded);
+	RUN_TEST(test_the_owned_keywords_leave_nothing_to_forward);
+	RUN_TEST(test_null_keywords_forward_nothing);
 	RUN_TEST(test_ordering_without_equality_is_rejected);
 	RUN_TEST(test_a_fielded_frozen_base_pins_frozen);
 	RUN_TEST(test_a_carried_weakref_slot_refuses_the_explicit_drop);

--- a/src/options.c
+++ b/src/options.c
@@ -34,12 +34,15 @@ static struct options_request checked(
 struct options_request options_read(
 	PyObject * const keywords,
 	struct options const inherited,
-	struct base_facts const facts
+	struct base_facts const facts,
+	PyObject * * const forwarded
 ) {
 	/* The record a reader hands in must already carry the base-derived facts;
 	 * inherited_options is the only producer and forces both columns. A caller
 	 * that skips the force would otherwise get a refusal for a keyword nobody
 	 * wrote, or a record that contradicts the settle verify downstream. */
+	*forwarded = NULL;
+
 	if (
 		(!inherited.frozen && facts.fielded_frozen) ||
 		(!inherited.weakref && facts.weakref_carried)
@@ -60,6 +63,12 @@ struct options_request options_read(
 		};
 	}
 
+	PY_MOVABLE(collected, PyDict_New());
+
+	if (collected == NULL) {
+		return (struct options_request){.tag = OPTIONS_REJECTED};
+	}
+
 	struct options requested = inherited;
 	bool weakref_written = false;
 	PyObject * keyword;
@@ -70,6 +79,10 @@ struct options_request options_read(
 		struct option_lookup const found = find_option(keyword);
 
 		if (found.tag == OPTION_LOOKUP_UNKNOWN) {
+			if (PyDict_SetItem(collected, keyword, value) < 0) {
+				return (struct options_request){.tag = OPTIONS_REJECTED};
+			}
+
 			continue;
 		}
 
@@ -83,7 +96,13 @@ struct options_request options_read(
 		requested = with_option(requested, found.option, truth != 0);
 	}
 
-	return checked(requested, facts, weakref_written);
+	struct options_request const request = checked(requested, facts, weakref_written);
+
+	if (request.tag == OPTIONS_RESOLVED) {
+		*forwarded = py_move(&collected);
+	}
+
+	return request;
 }
 
 static struct option_lookup find_option(PyObject * const keyword) {
@@ -157,32 +176,6 @@ static struct options_request checked(
 	};
 }
 
-PyObject * options_forwarded(PyObject * const keywords) {
-	if (keywords == NULL) {
-		return NULL;
-	}
-
-	PY_MOVABLE(forwarded, PyDict_New());
-
-	if (forwarded == NULL) {
-		return NULL;
-	}
-
-	Py_ssize_t position = 0;
-	PyObject * keyword;
-	PyObject * value;
-
-	while (PyDict_Next(keywords, &position, &keyword, &value)) {
-		if (find_option(keyword).tag == OPTION_LOOKUP_UNKNOWN) {
-			if (PyDict_SetItem(forwarded, keyword, value) < 0) {
-				return NULL;
-			}
-		}
-	}
-
-	return py_move(&forwarded);
-}
-
 #ifdef TESTING
 
 #	include "testing.h"
@@ -208,47 +201,57 @@ static struct base_facts facts_of(
 }
 
 static void test_no_keywords_inherit_the_base(void) {
+	PY_MOVABLE(forwarded, NULL);
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
 	struct options_request const request = options_read(
 		NULL,
 		inherited,
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.eq);
 	TEST_ASSERT_TRUE(request.options.frozen);
+	TEST_ASSERT_NULL(forwarded);
 }
 
 static void test_a_keyword_replaces_only_the_flag_it_names(void) {
 	PyObject * const keywords = keywords_of("order", true);
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.order);
 	TEST_ASSERT_TRUE(request.options.eq);
 	TEST_ASSERT_TRUE(request.options.frozen);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
 
-static void test_an_unknown_keyword_is_skipped(void) {
+static void test_an_unknown_keyword_is_collected_for_forwarding(void) {
 	PyObject * const keywords = keywords_of("frozn", true);
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.frozen);
 	TEST_ASSERT_FALSE(PyErr_Occurred());
+	TEST_ASSERT_EQUAL_INT(1, PyDict_Size(forwarded));
+	TEST_ASSERT_EQUAL_INT(1, PyObject_IsTrue(PyDict_GetItemString(forwarded, "frozn")));
 
 	Py_DECREF(keywords);
 }
@@ -259,9 +262,16 @@ static void test_only_unowned_keywords_are_forwarded(void) {
 	PyDict_SetItemString(keywords, "frozn", Py_True);
 	PyDict_SetItemString(keywords, option_keywords[OPTION_FROZEN], Py_False);
 
-	PY_OWNED(forwarded, options_forwarded(keywords));
+	PY_MOVABLE(forwarded, NULL);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		facts_of(false, false, false),
+		&forwarded
+	);
 
-	TEST_ASSERT_NOT_NULL(forwarded);
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_FALSE(request.options.frozen);
 	TEST_ASSERT_EQUAL_INT(1, PyDict_Size(forwarded));
 	TEST_ASSERT_EQUAL_INT(1, PyObject_IsTrue(PyDict_GetItemString(forwarded, "frozn")));
 
@@ -270,17 +280,32 @@ static void test_only_unowned_keywords_are_forwarded(void) {
 
 static void test_the_owned_keywords_leave_nothing_to_forward(void) {
 	PyObject * const keywords = keywords_of("frozen", false);
+	PY_MOVABLE(forwarded, NULL);
+	struct options_request const request = options_read(
+		keywords,
+		options_initial(),
+		facts_of(false, false, false),
+		&forwarded
+	);
 
-	PY_OWNED(forwarded, options_forwarded(keywords));
-
-	TEST_ASSERT_NOT_NULL(forwarded);
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_FALSE(request.options.frozen);
 	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
 
 static void test_null_keywords_forward_nothing(void) {
-	TEST_ASSERT_NULL(options_forwarded(NULL));
+	PY_MOVABLE(forwarded, NULL);
+	struct options_request const request = options_read(
+		NULL,
+		options_initial(),
+		facts_of(false, false, false),
+		&forwarded
+	);
+
+	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
+	TEST_ASSERT_NULL(forwarded);
 	TEST_ASSERT_FALSE(PyErr_Occurred());
 }
 
@@ -289,14 +314,17 @@ static void test_ordering_without_equality_is_rejected(void) {
 	struct options inherited = options_initial();
 	inherited.eq = false;
 
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		inherited,
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, request.tag);
 	TEST_ASSERT_TRUE(PyErr_ExceptionMatches(PyExc_TypeError));
+	TEST_ASSERT_NULL(forwarded);
 
 	PyErr_Clear();
 	Py_DECREF(keywords);
@@ -304,10 +332,13 @@ static void test_ordering_without_equality_is_rejected(void) {
 
 static void test_a_fielded_frozen_base_pins_frozen(void) {
 	PyObject * const keywords = keywords_of("frozen", false);
+	PY_MOVABLE(forwarded, NULL);
+
 	struct options_request const constrained = options_read(
 		keywords,
 		options_initial(),
-		facts_of(true, false, false)
+		facts_of(true, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, constrained.tag);
@@ -316,11 +347,13 @@ static void test_a_fielded_frozen_base_pins_frozen(void) {
 	struct options_request const free = options_read(
 		keywords,
 		options_initial(),
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, free.tag);
 	TEST_ASSERT_FALSE(free.options.frozen);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
@@ -330,10 +363,12 @@ static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 	struct options inherited = options_initial();
 	inherited.weakref = true;
 
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const refused = options_read(
 		keywords,
 		inherited,
-		facts_of(false, true, false)
+		facts_of(false, true, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, refused.tag);
@@ -345,28 +380,34 @@ static void test_a_carried_weakref_slot_refuses_the_explicit_drop(void) {
 
 static void test_weakref_false_without_a_carried_slot_still_resolves(void) {
 	PyObject * const keywords = keywords_of("weakref", false);
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_FALSE(request.options.weakref);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
 
 static void test_frozen_true_resolves_over_the_fielded_promise(void) {
 	PyObject * const keywords = keywords_of("frozen", true);
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		facts_of(true, false, false)
+		facts_of(true, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.frozen);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
@@ -376,39 +417,48 @@ static void test_an_unwritten_weakref_over_a_carried_slot_resolves_without_a_ref
 	struct options inherited = options_initial();
 	inherited.weakref = true;
 
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		inherited,
-		facts_of(false, true, false)
+		facts_of(false, true, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.weakref);
 	TEST_ASSERT_FALSE(request.weakref_written);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
 
 static void test_the_request_reports_that_weakref_was_written(void) {
 	PyObject * const keywords = keywords_of("weakref", true);
+	PY_MOVABLE(forwarded, NULL);
 	struct options_request const request = options_read(
 		keywords,
 		options_initial(),
-		facts_of(false, false, false)
+		facts_of(false, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_RESOLVED, request.tag);
 	TEST_ASSERT_TRUE(request.options.weakref);
 	TEST_ASSERT_TRUE(request.weakref_written);
+	TEST_ASSERT_EQUAL_INT(0, PyDict_Size(forwarded));
 
 	Py_DECREF(keywords);
 }
 
 static void test_an_unforced_inherited_record_over_carried_facts_is_an_internal_error(void) {
+	PY_MOVABLE(forwarded, NULL);
+
 	struct options_request const weakref = options_read(
 		NULL,
 		options_initial(),
-		facts_of(false, true, false)
+		facts_of(false, true, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, weakref.tag);
@@ -421,7 +471,8 @@ static void test_an_unforced_inherited_record_over_carried_facts_is_an_internal_
 	struct options_request const frozen = options_read(
 		NULL,
 		inherited,
-		facts_of(true, false, false)
+		facts_of(true, false, false),
+		&forwarded
 	);
 
 	TEST_ASSERT_EQUAL_INT(OPTIONS_REJECTED, frozen.tag);
@@ -435,7 +486,7 @@ void options_tests(void) {
 
 	RUN_TEST(test_no_keywords_inherit_the_base);
 	RUN_TEST(test_a_keyword_replaces_only_the_flag_it_names);
-	RUN_TEST(test_an_unknown_keyword_is_skipped);
+	RUN_TEST(test_an_unknown_keyword_is_collected_for_forwarding);
 	RUN_TEST(test_only_unowned_keywords_are_forwarded);
 	RUN_TEST(test_the_owned_keywords_leave_nothing_to_forward);
 	RUN_TEST(test_null_keywords_forward_nothing);

--- a/src/options.h
+++ b/src/options.h
@@ -45,6 +45,6 @@ static inline struct options options_initial(void) {
 struct options_request options_read(
 	PyObject * keywords,
 	struct options inherited,
-	struct base_facts facts
+	struct base_facts facts,
+	PyObject * * forwarded
 );
-PyObject * options_forwarded(PyObject * keywords);

--- a/src/options.h
+++ b/src/options.h
@@ -47,3 +47,4 @@ struct options_request options_read(
 	struct options inherited,
 	struct base_facts facts
 );
+PyObject * options_forwarded(PyObject * keywords);

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -45,8 +45,12 @@ def test_the_defaults_are_dataclass_defaults():
         weakref.ref(Plain(1, 2))
 
 
-def test_an_unknown_keyword_names_the_ones_that_exist():
-    with pytest.raises(TypeError, match="'frozn' is not a struct class keyword"):
+def test_an_unclaimed_keyword_fails_the_class():
+    """CPython asks object.__init_subclass__, which names the new class and
+    takes no keywords, so the typo still dies -- without salix's curated list.
+    """
+
+    with pytest.raises(TypeError, match="takes no keyword arguments"):
 
         class Typo(Struct, frozn=False):
             x: int
@@ -55,10 +59,73 @@ def test_an_unknown_keyword_names_the_ones_that_exist():
 def test_a_deferred_dataclass_option_is_rejected_rather_than_ignored():
     """kw_only is not implemented; silently accepting it would be the bug."""
 
-    with pytest.raises(TypeError, match="is not a struct class keyword"):
+    with pytest.raises(TypeError, match="takes no keyword arguments"):
 
         class Unsupported(Struct, kw_only=True):
             x: int
+
+
+class TestPep487Keywords:
+    def test_a_hierarchy_declares_its_own_class_keyword(self):
+        class Base(Struct):
+            def __init_subclass__(cls, plugin=None, **kw):
+                super().__init_subclass__(**kw)
+                cls.plugin = plugin
+
+        class Child(Base, plugin="x"):
+            value: int
+
+        assert Child.plugin == "x"
+        assert Child(1).value == 1
+
+    def test_the_keyword_is_inherited_down_the_hierarchy(self):
+        class Base(Struct):
+            def __init_subclass__(cls, plugin=None, **kw):
+                super().__init_subclass__(**kw)
+                cls.plugin = plugin
+
+        class Middle(Base):
+            value: int
+
+        class Leaf(Middle, plugin="y"):
+            extra: int = 0
+
+        assert Leaf.plugin == "y"
+        assert Leaf(1).extra == 0
+
+    def test_a_salix_keyword_never_reaches_init_subclass(self):
+        seen = []
+
+        class Base(Struct):
+            def __init_subclass__(cls, **kw):
+                seen.append(kw)
+                super().__init_subclass__(**kw)
+
+        class Child(Base, frozen=False):
+            value: int
+
+        assert seen == [{}]
+
+    def test_a_keyword_the_hierarchy_does_not_claim_fails(self):
+        class Base(Struct):
+            def __init_subclass__(cls):
+                pass
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'plugin'"):
+            class Child(Base, plugin="x"):
+                value: int
+
+    def test_a_salix_keyword_is_still_consumed_beside_a_forwarded_one(self):
+        class Base(Struct):
+            def __init_subclass__(cls, plugin=None, **kw):
+                super().__init_subclass__(**kw)
+                cls.plugin = plugin
+
+        class Child(Base, plugin="x", frozen=False):
+            value: int
+
+        assert Child.plugin == "x"
+        Child(1).value = 2
 
 
 class TestEq:

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -36,6 +36,14 @@ def NeedWeakref(metatype: type) -> type:
     return Requiring
 
 
+def FrozenOnly(metatype: type) -> type:
+    class Only(metatype):
+        def __new__(metacls, name, bases, namespace, *, frozen=None):
+            return super().__new__(metacls, name, bases, namespace, frozen=frozen)
+
+    return Only
+
+
 # Both spellings of each, in one place: two literals drifted apart is a test
 # that silently stops covering a name. The order matches
 # test_metadata_names' SALIX + MSGSPEC concatenation, which is pinned.
@@ -415,6 +423,43 @@ class TestAMetaclassSubclass:
 
         with pytest.raises(TypeError, match="cannot cross"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, weakref=True)
+
+    def test_an_unowned_keyword_cannot_cross_a_delegate_that_rejects_it(self):
+        """Before the refusal the chain machinery handed the build over with no
+        keywords at all, so the typo vanished without a TypeError and any owned
+        option riding along was dropped with it.
+        """
+
+        class Base(Struct, metaclass=Plain):
+            x: int
+
+        with pytest.raises(TypeError, match="cannot reach __init_subclass__"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, frozn=False)
+
+    def test_an_unowned_keyword_cannot_ride_a_delegate_that_names_only_frozen(self):
+        """frozen=True was silently dropped -- the delegate's frozen=None
+        default rode the re-entry and read as falsy -- so the class built
+        mutable. The unowned keyword now refuses the whole call instead.
+        """
+
+        class Base(Struct, metaclass=FrozenOnly(META)):
+            x: int
+
+        with pytest.raises(TypeError, match="plugin"):
+            META("Built", (Base,), {"__annotations__": {"y": int}}, frozen=True, plugin="x")
+
+    def test_a_forwarding_delegate_delivers_an_unowned_keyword_to_init_subclass(self):
+        class Base(Struct, metaclass=Forwarding):
+            x: int
+
+            def __init_subclass__(cls, plugin=None, **kw):
+                super().__init_subclass__(**kw)
+                cls.plugin = plugin
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, plugin="x")
+
+        assert built.plugin == "x"
+        assert built(1, 2).y == 2
 
     def test_a_c_slot_delegate_still_builds(self):
         """A __new__ that is a slot wrapper, not a Python function, used to be

--- a/tests/test_struct_identity.py
+++ b/tests/test_struct_identity.py
@@ -439,13 +439,15 @@ class TestAMetaclassSubclass:
     def test_an_unowned_keyword_cannot_ride_a_delegate_that_names_only_frozen(self):
         """frozen=True was silently dropped -- the delegate's frozen=None
         default rode the re-entry and read as falsy -- so the class built
-        mutable. The unowned keyword now refuses the whole call instead.
+        mutable. The unowned keyword now refuses the whole call instead; the
+        match is the salix message, because CPython's own __new__ binding
+        error also names plugin.
         """
 
         class Base(Struct, metaclass=FrozenOnly(META)):
             x: int
 
-        with pytest.raises(TypeError, match="plugin"):
+        with pytest.raises(TypeError, match="cannot reach __init_subclass__"):
             META("Built", (Base,), {"__annotations__": {"y": int}}, frozen=True, plugin="x")
 
     def test_a_forwarding_delegate_delivers_an_unowned_keyword_to_init_subclass(self):
@@ -460,6 +462,34 @@ class TestAMetaclassSubclass:
 
         assert built.plugin == "x"
         assert built(1, 2).y == 2
+
+    def test_a_delegate_naming_the_keyword_delivers_it_beside_a_salix_option(self):
+        """The delegate accepts the unowned keyword and not the salix one; the
+        unowned subset rides by itself and the settle restores what the option
+        meant. The claimer lives on a parent: a body __init_subclass__ on the
+        very class a keyword-carrying __new__ is building is refused by CPython
+        itself (measured on a plain Python metaclass too), so the claimer sits
+        where type_new's lookup reaches it.
+        """
+
+        class PluginOnly(META):
+            def __new__(metacls, name, bases, namespace, *, plugin=None):
+                return super().__new__(metacls, name, bases, namespace, plugin=plugin)
+
+        class Claiming(Struct):
+            x: int
+
+            def __init_subclass__(cls, plugin=None, **kw):
+                super().__init_subclass__(**kw)
+                cls.plugin = plugin
+
+        class Base(Claiming, metaclass=PluginOnly):
+            pass
+
+        built = META("Built", (Base,), {"__annotations__": {"y": int}}, order=True, plugin="x")
+
+        assert built.plugin == "x"
+        assert built(1, 2) < built(1, 3)
 
     def test_a_c_slot_delegate_still_builds(self):
         """A __new__ that is a slot wrapper, not a Python function, used to be

--- a/tests/typing/accepted.py
+++ b/tests/typing/accepted.py
@@ -110,6 +110,19 @@ def the_options_a_checker_cannot_see_are_still_accepted() -> None:
     assert_type(Options(1).value, int)
 
 
+def a_struct_hierarchy_declares_its_own_class_keyword() -> None:
+    class Base(Struct):
+        def __init_subclass__(
+            cls, plugin: str | None = None, **keywords: Any
+        ) -> None:
+            super().__init_subclass__(**keywords)
+
+    class Child(Base, plugin="x"):
+        value: int
+
+    assert_type(Child(1).value, int)
+
+
 def set_field_takes_a_struct_a_name_and_any_value() -> None:
     assert_type(set_field(Point(1, "two"), "x", 9), None)
     set_field(Point(1, "two"), "y", object())


### PR DESCRIPTION
Closes #36.

## Summary

`options_read` consumed the six class keywords and rejected the rest, so a hierarchy's `__init_subclass__` could never receive its own keywords. Per #36's option-1 analysis, salix now skips what it does not own, collects the leftovers, and hands them to `PyType_Type.tp_new` — which delivers them to `__init_subclass__` in the usual way.

Typo protection survives: with nothing to claim it, `object.__init_subclass__` raises, so `frozn=True` still dies — now with CPython's message instead of salix's curated list.

<details>
<summary>What changed and why each piece</summary>

- `src/options.c` — `options_read` skips unknown keywords instead of rejecting; `reject_unknown`/`accepted_keywords` deleted (dead after the skip). New `options_forwarded` returns a new dict of exactly the unowned keys (`NULL` for `NULL` input).
- `src/meta/class/create.c` — the leftover dict replaces the hard `NULL` at the `PyType_Type.tp_new` call for the normal path; the metaclass-handoff paths (#108/#129) keep their existing forwarding, and their re-entry splits the same way since `build_struct_class` computes the leftovers on every path.
- `tests/test_options.py` — the two rejection pins now match CPython's `takes no keyword arguments` (verified on 3.10/3.14/3.15); new `TestPep487Keywords` pins: the issue's plugin example, inheritance of the keyword down the hierarchy, the six never reaching `__init_subclass__` (`seen == [{}]`), an unclaimed keyword failing via the hierarchy's own signature, and a salix keyword consumed beside a forwarded one.
- `tests/typing/accepted.py` — the pattern type-checks under all three checkers (a widening `__init_subclass__` override). The negative pin in `rejected.py` needed no change: the stub's `__init_subclass__` still accepts exactly the six, so a checker still rejects `frozn=` on a plain Struct subclass, matching the runtime.
- `README.md` — one sentence in the keywords paragraph naming the forwarding.
</details>

<details>
<summary>Measured</summary>

- 3.14: `class Typo(Struct, frozn=False)` → `TypeError: Typo.__init_subclass__() takes no keyword arguments`; a `def __init_subclass__(cls)` base → `unexpected keyword argument 'plugin'`; an empty leftover dict still calls `__init_subclass__` with `{}`.
- pytest legs green on 3.10, 3.14, 3.15 (fresh builds); the camas gate ran green over the changed set.
</details>

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to take on #36, and the implementation follows the issue's own option-1 analysis.

---

## Round-3 disposition (streak 3 in the handoff-refusal mechanism)

`handoff-refusal-*` has now appeared in three consecutive rounds (r1 silent-drop, r2 over-broad, r3 unreadable-arm). The r3 finding recommends attempting delivery through the ladder for unreadable chains instead of the conservative refusal. The refusal stands deliberately: the ladder's rung fallback is what silently dropped unowned keywords and double-called `__init_subclass__` (the r1 major), the unreadable-with-unowned configuration has no empirical repro (the reviewer's probe was cut off, and the tp_new-inheritance route skips the chain block entirely), and the cost of the refusal is a loud TypeError on a corner that previously mis-built silently. The r2 fix already narrows the refusal to chains that provably cannot take the unowned subset; the unreadable arm refuses what cannot be proven. Revisit only with a live repro.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked me to take on #36; this records the streak-3 disposition at merge time.
