### PR TITLE
release: version 0.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           purge-prefixes: nix-${{ runner.os }}-
           purge-created: 0
           purge-primary-key: never
-      - run: nix develop --command uv sync --no-install-workspace --only-group ci
+      - run: nix develop --command uv sync --locked --no-install-workspace --only-group ci
       - run: nix develop --command uv run --no-sync camas ci
       - run: nix build .#default --out-link result-wheels
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -54,9 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: 0.11.32 # the flake's pkgs.uv; the wheel leg's measured precedence is this resolver's
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: wheels
           path: result-wheels
-      - run: uv sync --no-install-workspace --only-group ci
+      - run: uv sync --locked --no-install-workspace --only-group ci
       - run: uv run --no-sync camas coverage --OS ${{ matrix.OS }} --PY ${{ matrix.PY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           gc-max-store-size-linux: 5G
           save: false
 
-      - run: nix develop --command uv sync --no-install-workspace --only-group ci
+      - run: nix develop --command uv sync --locked --no-install-workspace --only-group ci
 
       - env:
           TAG: ${{ github.ref_name }}

--- a/nix/c-tests.nix
+++ b/nix/c-tests.nix
@@ -5,6 +5,7 @@
 # this is a nix derivation and not a bare camas command -- it needs libpython
 # and unity on the link line, and nix is where those paths come from.
 {
+  lib,
   stdenv,
   python3,
   unity-test,
@@ -13,7 +14,7 @@
 
 stdenv.mkDerivation {
   pname = "salix-c-tests";
-  version = "0.0.0";
+  version = (lib.importTOML (src + "/pyproject.toml")).project.version;
   inherit src;
 
   nativeBuildInputs = [ python3 ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "salix"
-version = "0.0.0"
+version = "0.1.0"
 description = "A C-backed, inheritable Struct base class for Python — fast import, fast type creation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from camas import (
@@ -25,6 +26,16 @@ NIX_SOURCES = by_suffix(
 PYTHONS = tuple(Path(".python-version").read_text().split())
 OLDEST = min(PYTHONS, key=lambda python: tuple(map(int, python.split("."))))
 NEWEST = max(PYTHONS, key=lambda python: tuple(map(int, python.split("."))))
+
+# The wheel legs pin what they test to this, so a stale local wheel fails the
+# guard instead of testing the published artifact of another version.
+_PROJECT_VERSION = re.search(
+    r'^version = "([^"]+)"',
+    Path("pyproject.toml").read_text(encoding="utf-8"),
+    re.MULTILINE,
+)
+assert _PROJECT_VERSION is not None
+VERSION = _PROJECT_VERSION.group(1)
 
 # The tests member declares pytest and hypothesis, and supplies them: a
 # per-interpreter project environment is what keeps six of them from fighting
@@ -208,21 +219,23 @@ check = Parallel(test, free_threaded, format_check, lock_check, lint, analyze, c
 # can take.
 #
 # salix must come from the local tree, and once it is published the index
-# offers the same name and version. wheel_guard resolves salix with --no-index,
-# so a leg whose local wheel is missing fails there instead of passing against
-# the published artifact; the leg then resolves with the index, where
-# --find-links wins for salix (measured: uv selects the flat-index wheel for
-# an identical name and version) and the index serves the test dependencies.
+# offers the same name. Both leaves pin the version, so the guard fails on a
+# local wheel that is missing or stale rather than passing against the
+# published artifact; the leg then resolves with the index, where the same
+# pin wins the local wheel (uv selects the flat-index wheel for an identical
+# name and version -- measured, and setup-uv pins the resolver that measured
+# it) while the index serves the test dependencies.
+WHEEL_RUN = "uv run --no-cache --no-project --managed-python --python {PY}"
 wheel_guard = Task(
-    "uv run --no-cache --no-project --managed-python --python {PY}"
-    " --no-index --find-links ../result-wheels --with salix"
+    WHEEL_RUN + " --no-index --find-links ../result-wheels"
+    f' --with "salix=={VERSION}"'
     ' python -c "import salix"',
     cwd=Path("tests"),
 )
 wheel_test = Task(
-    "uv run --no-cache --no-project --managed-python --python {PY}"
-    " --find-links ../result-wheels"
-    " --with salix --with pytest --with hypothesis python -m pytest .",
+    WHEEL_RUN + " --find-links ../result-wheels"
+    f' --with "salix=={VERSION}" --with pytest --with hypothesis'
+    " python -m pytest .",
     cwd=Path("tests"),
     env={"SALIX_REQUIRE_INSTALLED": "1"},
 )

--- a/tasks.py
+++ b/tasks.py
@@ -207,12 +207,21 @@ check = Parallel(test, free_threaded, format_check, lock_check, lint, analyze, c
 # dislodges it, and `uv cache clean` wants a lock no leaf in a parallel tree
 # can take.
 #
-# --no-index, so the leg can only ever test the locally built wheel: with
-# salix published, PyPI offers the same name and version, and --find-links
-# adds to the resolver rather than replacing it.
+# salix must come from the local tree, and once it is published the index
+# offers the same name and version. wheel_guard resolves salix with --no-index,
+# so a leg whose local wheel is missing fails there instead of passing against
+# the published artifact; the leg then resolves with the index, where
+# --find-links wins for salix (measured: uv selects the flat-index wheel for
+# an identical name and version) and the index serves the test dependencies.
+wheel_guard = Task(
+    "uv run --no-cache --no-project --managed-python --python {PY}"
+    " --no-index --find-links ../result-wheels --with salix"
+    ' python -c "import salix"',
+    cwd=Path("tests"),
+)
 wheel_test = Task(
     "uv run --no-cache --no-project --managed-python --python {PY}"
-    " --find-links ../result-wheels --no-index"
+    " --find-links ../result-wheels"
     " --with salix --with pytest --with hypothesis python -m pytest .",
     cwd=Path("tests"),
     env={"SALIX_REQUIRE_INSTALLED": "1"},
@@ -237,7 +246,7 @@ WINDOWS_ARM_PYTHON = "cpython-{}-windows-aarch64"
 # check_wheel.py and imported by nothing (#37). Both are cross-compiled by zig,
 # which is the half of the build with nobody standing behind it.
 coverage = Parallel(
-    wheel_test,
+    Sequential(wheel_guard, wheel_test),
     variants=(
         *({"OS": "ubuntu-latest", "PY": python} for python in PYTHONS),
         {"OS": "macos-latest", "PY": OLDEST},

--- a/tasks.py
+++ b/tasks.py
@@ -75,6 +75,7 @@ nix_format = Task("nixfmt {paths}", paths=NIX_SOURCES, mutates=True)
 nix_format_check = Task("nixfmt --check {paths}", paths=NIX_SOURCES)
 format = Parallel(c_format, nix_format)
 format_check = Parallel(c_format_check, nix_format_check)
+lock_check = Task("uv lock --check")
 
 # Two engines rather than one: they are independent implementations, and the
 # flags carry -Werror, so gcc also holds the build to a second compiler.
@@ -189,7 +190,7 @@ free_threaded = Sequential(free_threaded_build, free_threaded_pytest)
 benchmark = Sequential(
     Task("uv run python setup.py build_ext --inplace", mutates=True, env=STRICT_BUILD), bench
 )
-check = Parallel(test, free_threaded, format_check, lint, analyze, c_test, type_check)
+check = Parallel(test, free_threaded, format_check, lock_check, lint, analyze, c_test, type_check)
 
 # Installed, not compiled: MSVC has no __attribute__((cleanup)), so the Windows
 # leg cannot build this source at all.
@@ -200,14 +201,18 @@ check = Parallel(test, free_threaded, format_check, lint, analyze, c_test, type_
 # dependencies is the cost -- uv run takes neither a pyproject.toml for
 # --with-requirements nor a member whose sources it is told to ignore.
 #
-# --no-cache, because the version is permanently 0.0.0: uv keys its cache on
-# name and version, so a rebuilt wheel is indistinguishable from one built
-# months ago and it serves the old archive. Neither --refresh-package nor
-# --reinstall-package dislodges it, and `uv cache clean` wants a lock no leaf
-# in a parallel tree can take. A real version would retire this flag.
+# --no-cache: uv keys its cache on name and version, so a rebuilt wheel of the
+# same released version is indistinguishable from one built before and it
+# serves the old archive. Neither --refresh-package nor --reinstall-package
+# dislodges it, and `uv cache clean` wants a lock no leaf in a parallel tree
+# can take.
+#
+# --no-index, so the leg can only ever test the locally built wheel: with
+# salix published, PyPI offers the same name and version, and --find-links
+# adds to the resolver rather than replacing it.
 wheel_test = Task(
     "uv run --no-cache --no-project --managed-python --python {PY}"
-    " --find-links ../result-wheels"
+    " --find-links ../result-wheels --no-index"
     " --with salix --with pytest --with hypothesis python -m pytest .",
     cwd=Path("tests"),
     env={"SALIX_REQUIRE_INSTALLED": "1"},
@@ -246,6 +251,6 @@ coverage = Parallel(
     ),
 )
 
-ci = Parallel(flake_check, free_threaded, format_check, lint, analyze, type_check)
+ci = Parallel(flake_check, free_threaded, format_check, lock_check, lint, analyze, type_check)
 
 _ = Config(default_task=check, github_task=ci, agent=Claude(fix=format, check=check))

--- a/uv.lock
+++ b/uv.lock
@@ -1087,7 +1087,7 @@ wheels = [
 
 [[package]]
 name = "salix"
-version = "0.0.0"
+version = "0.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
First PyPI release version. `check_tag.py` requires the pushed tag to be exactly `v0.1.0`; the wheels carry it via `build_config.py`. The Trusted Publisher for the `pypi` environment is configured in the repo settings (web UI) before the tag is pushed.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. She asked to move toward the first PyPI release today.